### PR TITLE
🐛 Prevent concurrent receives from delivering same message

### DIFF
--- a/examples/bash_cpu_metrics/load_consumer.sh
+++ b/examples/bash_cpu_metrics/load_consumer.sh
@@ -62,7 +62,7 @@ while true; do
             
             # Acknowledge the message
             ack_response=$(sequin consumer ack "$STREAM_NAME" "$CONSUMER_NAME" "$ack_id" 2>&1)
-            if echo "$ack_response" | grep -q '"success":true'; then
+            if [[ $ack_response == *"Message acknowledged with Ack ID"* ]]; then
                 echo "Successfully acknowledged message with ack_id: $ack_id"
             else
                 echo "Failed to acknowledge message with ack_id: $ack_id"

--- a/server/lib/sequin_web/channels/observe_channel.ex
+++ b/server/lib/sequin_web/channels/observe_channel.ex
@@ -33,10 +33,18 @@ defmodule SequinWeb.ObserveChannel do
       {:ok, consumer} = Streams.get_consumer(consumer_id)
 
       pending_messages =
-        Streams.list_consumer_messages_for_consumer(consumer.stream_id, consumer_id, is_deliverable: false, limit: limit)
+        Streams.list_consumer_messages_for_consumer(consumer.stream_id, consumer_id,
+          is_deliverable: false,
+          limit: limit,
+          order_by: :message_seq
+        )
 
       upcoming_messages =
-        Streams.list_consumer_messages_for_consumer(consumer.stream_id, consumer_id, is_deliverable: true, limit: limit)
+        Streams.list_consumer_messages_for_consumer(consumer.stream_id, consumer_id,
+          is_deliverable: true,
+          limit: limit,
+          order_by: :message_seq
+        )
 
       new_messages = %{
         pending_messages: pending_messages,


### PR DESCRIPTION
* Sort observe consumer messages by seq
* Fix ack success parsing in examples/bash_cpu_metrics/load_consumer.sh