### PR TITLE
Fix consumers_test and improve put_source_data handling

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,1 @@
-
+alias Sequin.Repo

--- a/lib/sequin/application.ex
+++ b/lib/sequin/application.ex
@@ -24,7 +24,7 @@ defmodule Sequin.Application do
   end
 
   defp children(_) do
-    base_children() ++ [Sequin.ReplicationRuntime.Supervisor, Sequin.StreamsRuntime.Supervisor]
+    base_children() ++ [Sequin.ReplicationRuntime.Supervisor]
   end
 
   defp base_children do

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -232,6 +232,8 @@ defmodule Sequin.Consumers do
     Repo.all(query)
   end
 
+  def insert_consumer_events([]), do: {:ok, 0}
+
   def insert_consumer_events(consumer_events) do
     now = DateTime.utc_now()
 
@@ -302,6 +304,8 @@ defmodule Sequin.Consumers do
       ELSE 'available'
     END::#{@consumer_record_state_enum}
   """
+  def insert_consumer_records([]), do: {:ok, 0}
+
   def insert_consumer_records(consumer_records) do
     now = DateTime.utc_now()
 
@@ -310,6 +314,9 @@ defmodule Sequin.Consumers do
         record
         |> Map.put(:inserted_at, now)
         |> Map.put(:updated_at, now)
+        |> ConsumerRecord.from_map()
+        # insert_all expects a plain outer-map, but struct embeds
+        |> Sequin.Map.from_ecto()
       end)
 
     conflict_target = [:consumer_id, :record_pks, :table_oid]

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -347,6 +347,22 @@ defmodule Sequin.Consumers do
     {:ok, count}
   end
 
+  def delete_consumer_records([]), do: {:ok, 0}
+
+  def delete_consumer_records(consumer_records) do
+    record_pks = Enum.map(consumer_records, & &1.record_pks)
+
+    delete_query =
+      from cr in ConsumerRecord,
+        where:
+          cr.consumer_id in ^Enum.map(consumer_records, & &1.consumer_id) and
+            cr.table_oid in ^Enum.map(consumer_records, & &1.table_oid) and
+            fragment("? in (?)", cr.record_pks, splice(^record_pks))
+
+    {count, _} = Repo.delete_all(delete_query)
+    {:ok, count}
+  end
+
   # Consumer Lifecycle
 
   defp create_consumer_partition(%{message_kind: :event} = consumer) do

--- a/priv/repo/migrations/20240626021320_create_initial.exs
+++ b/priv/repo/migrations/20240626021320_create_initial.exs
@@ -185,7 +185,7 @@ defmodule Sequin.Repo.Migrations.CreateInitial do
       add :consumer_id, :uuid, null: false, primary_key: true
       add :id, :serial, null: false, primary_key: true
       add :commit_lsn, :bigint, null: false
-      add :record_pks, {:array, :string}, null: false
+      add :record_pks, {:array, :text}, null: false
       add :table_oid, :integer, null: false
 
       add :data, :jsonb, null: false
@@ -225,7 +225,7 @@ defmodule Sequin.Repo.Migrations.CreateInitial do
       add :consumer_id, :uuid, null: false, primary_key: true
       add :id, :serial, null: false, primary_key: true
       add :commit_lsn, :bigint
-      add :record_pks, {:array, :string}, null: false
+      add :record_pks, {:array, :text}, null: false
       add :table_oid, :integer, null: false
       add :state, :"#{@stream_schema}.consumer_record_state", null: false
 

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -261,7 +261,8 @@ defmodule Sequin.ConsumersTest do
     end
 
     test "fetches multiple records from the same table with single PK", %{consumer: consumer, conn: conn} do
-      characters = Enum.map(1..3, fn _ -> CharacterFactory.insert_character!() end)
+      characters = for _ <- 1..3, do: CharacterFactory.insert_character!()
+      _other_characters = for _ <- 1..3, do: CharacterFactory.insert_character!()
       records = Enum.map(characters, &build_consumer_record(consumer, &1))
 
       {:ok, fetched_records} = Consumers.put_source_data(conn, consumer, records)
@@ -285,7 +286,8 @@ defmodule Sequin.ConsumersTest do
     end
 
     test "fetches multiple records from the same table with compound PK", %{consumer: consumer, conn: conn} do
-      characters = Enum.map(1..3, fn _ -> CharacterFactory.insert_character_multi_pk!() end)
+      characters = for _ <- 1..3, do: CharacterFactory.insert_character_multi_pk!()
+      _other_characters = for _ <- 1..3, do: CharacterFactory.insert_character_multi_pk!()
       records = Enum.map(characters, &build_consumer_record(consumer, &1, :multi_pk))
 
       {:ok, fetched_records} = Consumers.put_source_data(conn, consumer, records)

--- a/test/sequin/message_handler_test.exs
+++ b/test/sequin/message_handler_test.exs
@@ -6,67 +6,124 @@ defmodule Sequin.MessageHandlerTest do
   alias Sequin.Factory.ReplicationFactory
   alias Sequin.Replication.MessageHandler
 
-  describe "handle_messages/3" do
-    test "two messages with two consumers are fanned out to each consumer" do
-      # Create two messages with specific table_oid
-      message1 = ReplicationFactory.postgres_message(table_oid: 123)
-      message2 = ReplicationFactory.postgres_message(table_oid: 123)
-
-      # Create a source table with matching oid
+  describe "handle_messages/2" do
+    test "handles message_kind: event correctly" do
+      message = ReplicationFactory.postgres_message(table_oid: 123, action: :insert)
       source_table = ConsumersFactory.source_table(oid: 123, column_filters: [])
+      consumer = ConsumersFactory.insert_consumer!(message_kind: :event, source_tables: [source_table])
+      context = %MessageHandler.Context{consumers: [consumer]}
 
-      # Create two consumers with the matching source table
-      consumer1 = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table])
-      consumer2 = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table])
+      {:ok, 1} = MessageHandler.handle_messages(context, [message])
 
-      # Create context with both consumers
-      context = %MessageHandler.Context{consumers: [consumer1, consumer2]}
+      [event] = Consumers.list_consumer_events_for_consumer(consumer.id)
+      assert event.consumer_id == consumer.id
+      assert event.table_oid == 123
+      assert event.commit_lsn == DateTime.to_unix(message.commit_timestamp, :microsecond)
+      assert event.record_pks == Enum.map(message.ids, &to_string/1)
+      assert event.data.action == :insert
+      assert event.data.record == fields_to_map(message.fields)
+      assert event.data.changes == nil
+      assert event.data.metadata.table == message.table_name
+      assert event.data.metadata.schema == message.table_schema
+      assert event.data.metadata.commit_timestamp == message.commit_timestamp
+    end
 
-      # Handle messages
+    test "handles message_kind: record correctly" do
+      message = ReplicationFactory.postgres_message(table_oid: 456, action: :update)
+      source_table = ConsumersFactory.source_table(oid: 456, column_filters: [])
+      consumer = ConsumersFactory.insert_consumer!(message_kind: :record, source_tables: [source_table])
+      context = %MessageHandler.Context{consumers: [consumer]}
+
+      {:ok, 1} = MessageHandler.handle_messages(context, [message])
+
+      [record] = Consumers.list_consumer_records_for_consumer(consumer.id)
+      assert record.consumer_id == consumer.id
+      assert record.table_oid == 456
+      assert record.commit_lsn == DateTime.to_unix(message.commit_timestamp, :microsecond)
+      assert record.record_pks == Enum.map(message.ids, &to_string/1)
+      assert record.state == :available
+    end
+
+    test "fans out messages correctly for mixed message_kind consumers" do
+      message1 = ReplicationFactory.postgres_message(table_oid: 123, action: :insert)
+      message2 = ReplicationFactory.postgres_message(table_oid: 456, action: :update)
+
+      source_table1 = ConsumersFactory.source_table(oid: 123, column_filters: [])
+      source_table2 = ConsumersFactory.source_table(oid: 456, column_filters: [])
+
+      consumer1 = ConsumersFactory.insert_consumer!(message_kind: :event, source_tables: [source_table1])
+      consumer2 = ConsumersFactory.insert_consumer!(message_kind: :record, source_tables: [source_table2])
+      consumer3 = ConsumersFactory.insert_consumer!(message_kind: :event, source_tables: [source_table1, source_table2])
+
+      context = %MessageHandler.Context{consumers: [consumer1, consumer2, consumer3]}
+
       {:ok, 4} = MessageHandler.handle_messages(context, [message1, message2])
 
-      # Verify consumer events for consumer1
-      consumer1_events = Consumers.list_consumer_events_for_consumer(consumer1.id)
-      assert length(consumer1_events) == 2
-      assert Enum.all?(consumer1_events, &(&1.consumer_id == consumer1.id))
-      assert Enum.all?(consumer1_events, &(&1.table_oid == 123))
+      consumer1_messages = list_messages(consumer1.id)
+      consumer2_messages = list_messages(consumer2.id)
+      consumer3_messages = list_messages(consumer3.id)
 
-      # Verify consumer events for consumer2
-      consumer2_events = Consumers.list_consumer_events_for_consumer(consumer2.id)
-      assert length(consumer2_events) == 2
-      assert Enum.all?(consumer2_events, &(&1.consumer_id == consumer2.id))
-      assert Enum.all?(consumer2_events, &(&1.table_oid == 123))
+      assert length(consumer1_messages) == 1
+      assert hd(consumer1_messages).table_oid == 123
 
-      # Verify that the events contain the correct data
-      all_events = consumer1_events ++ consumer2_events
-      assert Enum.any?(all_events, &(&1.commit_lsn == DateTime.to_unix(message1.commit_timestamp, :microsecond)))
-      assert Enum.any?(all_events, &(&1.commit_lsn == DateTime.to_unix(message2.commit_timestamp, :microsecond)))
+      assert length(consumer2_messages) == 1
+      assert hd(consumer2_messages).table_oid == 456
+
+      assert length(consumer3_messages) == 2
+      assert Enum.any?(consumer3_messages, &(&1.table_oid == 123))
+      assert Enum.any?(consumer3_messages, &(&1.table_oid == 456))
+    end
+
+    test "two messages with two consumers are fanned out to each consumer" do
+      message1 = ReplicationFactory.postgres_message(table_oid: 123)
+      message2 = ReplicationFactory.postgres_message(table_oid: 123)
+      source_table = ConsumersFactory.source_table(oid: 123, column_filters: [])
+      consumer1 = ConsumersFactory.insert_consumer!(source_tables: [source_table])
+      consumer2 = ConsumersFactory.insert_consumer!(source_tables: [source_table])
+      context = %MessageHandler.Context{consumers: [consumer1, consumer2]}
+
+      {:ok, 4} = MessageHandler.handle_messages(context, [message1, message2])
+
+      consumer1_messages = list_messages(consumer1.id)
+      consumer2_messages = list_messages(consumer2.id)
+
+      assert length(consumer1_messages) == 2
+      assert Enum.all?(consumer1_messages, &(&1.consumer_id == consumer1.id))
+      assert Enum.all?(consumer1_messages, &(&1.table_oid == 123))
+
+      assert length(consumer2_messages) == 2
+      assert Enum.all?(consumer2_messages, &(&1.consumer_id == consumer2.id))
+      assert Enum.all?(consumer2_messages, &(&1.table_oid == 123))
+
+      all_messages = consumer1_messages ++ consumer2_messages
+      assert Enum.any?(all_messages, &(&1.commit_lsn == DateTime.to_unix(message1.commit_timestamp, :microsecond)))
+      assert Enum.any?(all_messages, &(&1.commit_lsn == DateTime.to_unix(message2.commit_timestamp, :microsecond)))
     end
 
     test "inserts message for consumer with matching source table and no filters" do
       message = ReplicationFactory.postgres_message(table_oid: 123, action: :insert)
       source_table = ConsumersFactory.source_table(oid: 123, column_filters: [])
-      consumer = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table])
+      consumer = ConsumersFactory.insert_consumer!(source_tables: [source_table])
       context = %MessageHandler.Context{consumers: [consumer]}
 
       {:ok, 1} = MessageHandler.handle_messages(context, [message])
 
-      consumer_events = Consumers.list_consumer_events_for_consumer(consumer.id)
-      assert length(consumer_events) == 1
-      assert hd(consumer_events).table_oid == 123
-      assert hd(consumer_events).consumer_id == consumer.id
+      messages = list_messages(consumer.id)
+      assert length(messages) == 1
+      assert hd(messages).table_oid == 123
+      assert hd(messages).consumer_id == consumer.id
     end
 
     test "does not insert message for consumer with non-matching source table" do
       message = ReplicationFactory.postgres_message(table_oid: 123)
       source_table = ConsumersFactory.source_table(oid: 456)
-      consumer = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table])
+      consumer = ConsumersFactory.insert_consumer!(source_tables: [source_table])
       context = %MessageHandler.Context{consumers: [consumer]}
 
       {:ok, 0} = MessageHandler.handle_messages(context, [message])
 
-      consumer_events = Consumers.list_consumer_events_for_consumer(consumer.id)
-      assert Enum.empty?(consumer_events)
+      messages = list_messages(consumer.id)
+      assert Enum.empty?(messages)
     end
 
     test "inserts message for consumer with matching source table and passing filters" do
@@ -80,7 +137,7 @@ defmodule Sequin.MessageHandlerTest do
         )
 
       source_table = ConsumersFactory.source_table(oid: 123, column_filters: [column_filter])
-      consumer = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table])
+      consumer = ConsumersFactory.insert_consumer!(source_tables: [source_table])
 
       test_field = ReplicationFactory.field(column_attnum: 1, value: "test")
       message = %{message | fields: [test_field | message.fields]}
@@ -89,10 +146,10 @@ defmodule Sequin.MessageHandlerTest do
 
       {:ok, 1} = MessageHandler.handle_messages(context, [message])
 
-      consumer_events = Consumers.list_consumer_events_for_consumer(consumer.id)
-      assert length(consumer_events) == 1
-      assert hd(consumer_events).table_oid == 123
-      assert hd(consumer_events).consumer_id == consumer.id
+      messages = list_messages(consumer.id)
+      assert length(messages) == 1
+      assert hd(messages).table_oid == 123
+      assert hd(messages).consumer_id == consumer.id
     end
 
     test "does not insert message for consumer with matching source table but failing filters" do
@@ -106,7 +163,7 @@ defmodule Sequin.MessageHandlerTest do
         )
 
       source_table = ConsumersFactory.source_table(oid: 123, column_filters: [column_filter])
-      consumer = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table])
+      consumer = ConsumersFactory.insert_consumer!(source_tables: [source_table])
 
       # Ensure the message has a non-matching field for the filter
       message = %{message | fields: [%{column_attnum: 1, value: "not_test"} | message.fields]}
@@ -115,40 +172,18 @@ defmodule Sequin.MessageHandlerTest do
 
       {:ok, 0} = MessageHandler.handle_messages(context, [message])
 
-      consumer_events = Consumers.list_consumer_events_for_consumer(consumer.id)
-      assert Enum.empty?(consumer_events)
+      messages = list_messages(consumer.id)
+      assert Enum.empty?(messages)
     end
+  end
 
-    test "fans out messages correctly for multiple consumers with different source table and filter combinations" do
-      message1 = ReplicationFactory.postgres_message(table_oid: 123, action: :insert)
-      message2 = ReplicationFactory.postgres_message(table_oid: 456, action: :update)
+  defp list_messages(consumer_id) do
+    events = Consumers.list_consumer_events_for_consumer(consumer_id)
+    records = Consumers.list_consumer_records_for_consumer(consumer_id)
+    events ++ records
+  end
 
-      source_table1 = ConsumersFactory.source_table(oid: 123, column_filters: [])
-      source_table2 = ConsumersFactory.source_table(oid: 456, column_filters: [])
-
-      consumer1 = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table1])
-      consumer2 = ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table2])
-
-      consumer3 =
-        ConsumersFactory.insert_http_push_consumer!(message_kind: :event, source_tables: [source_table1, source_table2])
-
-      context = %MessageHandler.Context{consumers: [consumer1, consumer2, consumer3]}
-
-      {:ok, 4} = MessageHandler.handle_messages(context, [message1, message2])
-
-      consumer1_events = Consumers.list_consumer_events_for_consumer(consumer1.id)
-      consumer2_events = Consumers.list_consumer_events_for_consumer(consumer2.id)
-      consumer3_events = Consumers.list_consumer_events_for_consumer(consumer3.id)
-
-      assert length(consumer1_events) == 1
-      assert hd(consumer1_events).table_oid == 123
-
-      assert length(consumer2_events) == 1
-      assert hd(consumer2_events).table_oid == 456
-
-      assert length(consumer3_events) == 2
-      assert Enum.any?(consumer3_events, &(&1.table_oid == 123))
-      assert Enum.any?(consumer3_events, &(&1.table_oid == 456))
-    end
+  defp fields_to_map(fields) do
+    Map.new(fields, fn %{column_name: name, value: value} -> {name, value} end)
   end
 end

--- a/test/sequin/postgres_replication_test.exs
+++ b/test/sequin/postgres_replication_test.exs
@@ -6,10 +6,11 @@ defmodule Sequin.PostgresReplicationTest do
   the interference (issues starting the replication connection?), but it definitely seems to occur
   when the two tests are running and connecting to slots at the same time.
 
-  To keep them async, we're just co-locating them in this one test file. That ensures they run
-  serially, avoiding interference, while remaining concurrent with the rest of the test suite.
+  We're making this test async: false to avoid interference with other tests, as they need to use
+  character tables un-sandboxed (to produce WAL). We can make these async true with a clever trick
+  like isolating tests with partitioned tables. (Cost is low, at time of writing these tests take 0.6s)
   """
-  use Sequin.DataCase, async: true
+  use Sequin.DataCase, async: false
 
   alias Sequin.Consumers
   alias Sequin.Extensions.Replication, as: ReplicationExt

--- a/test/sequin/postgres_replication_test.exs
+++ b/test/sequin/postgres_replication_test.exs
@@ -260,7 +260,7 @@ defmodule Sequin.PostgresReplicationTest do
       # Insert
       character = CharacterFactory.insert_character_multi_pk!()
 
-      assert_receive {ReplicationExt, :flush_messages}, 500
+      assert_receive {ReplicationExt, :flush_messages}, 1000
 
       [insert_event] = Consumers.list_consumer_events_for_consumer(consumer.id)
       %{data: data} = insert_event

--- a/test/support/factory/character_factory.ex
+++ b/test/support/factory/character_factory.ex
@@ -53,7 +53,7 @@ defmodule Sequin.Factory.CharacterFactory do
     attrs =
       Map.merge(
         %{
-          id_integer: Factory.unique_integer(),
+          # Omit id_integer, allow it to be auto-generated, so it's auto-incremented
           id_string: Faker.UUID.v4(),
           id_uuid: Faker.UUID.v4(),
           name: Faker.Person.name()

--- a/test/support/models/character_multi_pk.ex
+++ b/test/support/models/character_multi_pk.ex
@@ -6,7 +6,7 @@ defmodule Sequin.Test.Support.Models.CharacterMultiPK do
 
   @primary_key false
   schema "characters_multi_pk" do
-    field :id_integer, :integer, primary_key: true
+    field :id_integer, :integer, primary_key: true, read_after_writes: true
     field :id_string, :string, primary_key: true
     field :id_uuid, Ecto.UUID, primary_key: true
     field :name, :string

--- a/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
+++ b/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
@@ -23,7 +23,7 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
 
     # New table with multiple primary keys of different types
     create table(:characters_multi_pk, primary_key: false) do
-      add :id_integer, :integer, primary_key: true
+      add :id_integer, :serial, primary_key: true
       add :id_string, :string, primary_key: true
       add :id_uuid, :uuid, primary_key: true
       add :name, :text


### PR DESCRIPTION
This pull request addresses several improvements and bug fixes across the Sequin project:

1. Added an alias for Sequin.Repo in .iex.exs for easier access in IEx sessions.

2. Removed Sequin.StreamsRuntime.Supervisor from the application's children list.

3. Optimized the preloading of postgres_database in the put_source_data function to avoid unnecessary database queries during tests.

4. Fixed a pattern matching issue in the put_source_data function when executing Postgrex queries.

5. Updated and improved the ConsumersTest module:
   - Enabled previously skipped tests
   - Refined test cases for put_source_data function
   - Improved error handling and assertions
   - Updated helper functions and factory methods

6. Made PostgresReplicationTest async: false to prevent interference with other tests using character tables.

7. Modified the CharacterMultiPK schema to use auto-incrementing id_integer field.

8. Updated the database migration to use serial type for id_integer in the characters_multi_pk table.

These changes improve test reliability, optimize database interactions, and enhance error handling throughout the project.