### PR TITLE
✨ Ensure messages throughput per min is initially equal to processed count

### DIFF
--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -742,9 +742,9 @@ defmodule Sequin.Consumers do
     Health.update(consumer, :acknowledge, :healthy)
     Metrics.incr_consumer_messages_processed_count(consumer, count)
 
-    Enum.each(0..count, fn _ ->
-      Metrics.incr_consumer_messages_processed_throughput(consumer)
-    end)
+    if count > 0 do
+      Enum.each(1..count, fn _ -> Metrics.incr_consumer_messages_processed_throughput(consumer) end)
+    end
 
     :ok
   end
@@ -768,9 +768,11 @@ defmodule Sequin.Consumers do
 
     Metrics.incr_consumer_messages_processed_count(consumer, count_deleted + count_updated)
 
-    Enum.each(0..(count_deleted + count_updated), fn _ ->
-      Metrics.incr_consumer_messages_processed_throughput(consumer)
-    end)
+    count = count_deleted + count_updated
+
+    if count > 0 do
+      Enum.each(1..count, fn _ -> Metrics.incr_consumer_messages_processed_throughput(consumer) end)
+    end
 
     :ok
   end

--- a/lib/sequin/metrics/store.ex
+++ b/lib/sequin/metrics/store.ex
@@ -92,6 +92,10 @@ defmodule Sequin.Metrics.Store do
 
         # Nanoseconds to seconds
         time_diff_seconds = time_diff / 1_000_000_000
+
+        # Require at least 60 seconds to avoid spikes
+        time_diff_seconds = max(time_diff_seconds, 60)
+
         {:ok, count / time_diff_seconds}
 
       error ->

--- a/test/sequin/metrics/store_test.exs
+++ b/test/sequin/metrics/store_test.exs
@@ -41,18 +41,18 @@ defmodule Sequin.Metrics.StoreTest do
       assert Store.incr_throughput(ctx.key) == :ok
       assert Store.incr_throughput(ctx.key) == :ok
 
-      Process.sleep(500)
+      # We have a 60 second minimum window so 5 requests in 60 seconds is 0.0833 requests per second
+      assert {:ok, throughput} = Store.get_throughput(ctx.key)
+      assert Float.round(throughput, 3) == 0.083
+
+      assert Store.incr_throughput(ctx.key) == :ok
+      assert Store.incr_throughput(ctx.key) == :ok
+      assert Store.incr_throughput(ctx.key) == :ok
+      assert Store.incr_throughput(ctx.key) == :ok
+      assert Store.incr_throughput(ctx.key) == :ok
 
       assert {:ok, throughput} = Store.get_throughput(ctx.key)
-      assert throughput > 5.0
-      assert throughput < 10.0
-
-      # Sleep for 2 seconds to let the throughput decrease
-      Process.sleep(2000)
-
-      assert {:ok, throughput} = Store.get_throughput(ctx.key)
-      assert throughput < 5.0
-      assert throughput > 0.0
+      assert Float.round(throughput, 3) == 0.167
     end
   end
 end


### PR DESCRIPTION
count