### PR TITLE
[row consumer] Add `fetch_first_row`

### DIFF
--- a/lib/sequin/consumers/record_consumer_state.ex
+++ b/lib/sequin/consumers/record_consumer_state.ex
@@ -7,11 +7,12 @@ defmodule Sequin.Consumers.RecordConsumerState do
   @primary_key false
   embedded_schema do
     field :producer, Ecto.Enum, values: [:table_and_wal, :wal]
+    field :initial_min_cursor, Sequin.Ecto.IntegerKeyMap
   end
 
   def changeset(config, attrs) do
     config
-    |> cast(attrs, [:producer])
+    |> cast(attrs, [:producer, :initial_min_cursor])
     |> validate_required([:producer])
   end
 end

--- a/lib/sequin/ecto/integer_key_map.ex
+++ b/lib/sequin/ecto/integer_key_map.ex
@@ -1,0 +1,33 @@
+defmodule Sequin.Ecto.IntegerKeyMap do
+  @moduledoc false
+  use Ecto.Type
+
+  def type, do: :map
+
+  def cast(data) when is_map(data) do
+    {:ok, Map.new(data, fn {k, v} -> {to_integer_key(k), v} end)}
+  end
+
+  def cast(_), do: :error
+
+  def load(data) when is_map(data) do
+    {:ok, Map.new(data, fn {k, v} -> {to_integer_key(k), v} end)}
+  end
+
+  def load(_), do: :error
+
+  def dump(data) when is_map(data) do
+    {:ok, Map.new(data, fn {k, v} -> {to_string(k), v} end)}
+  end
+
+  def dump(_), do: :error
+
+  defp to_integer_key(key) when is_binary(key) do
+    case Integer.parse(key) do
+      {int_key, ""} -> int_key
+      _ -> key
+    end
+  end
+
+  defp to_integer_key(key), do: key
+end

--- a/test/sequin/table_producer_server_test.exs
+++ b/test/sequin/table_producer_server_test.exs
@@ -15,12 +15,9 @@ defmodule Sequin.DatabasesRuntime.TableProducerServerTest do
   alias Sequin.Repo
   alias Sequin.Test.Support.Models.Character
 
-  @moduletag :uses_characters
-
   setup do
     # Set up the database and consumer
-    database =
-      DatabasesFactory.insert_configured_postgres_database!()
+    database = DatabasesFactory.insert_configured_postgres_database!()
 
     replication =
       ReplicationFactory.insert_postgres_replication!(
@@ -31,6 +28,8 @@ defmodule Sequin.DatabasesRuntime.TableProducerServerTest do
     {:ok, database} = Databases.update_tables(database)
 
     table_oid = Character.table_oid()
+    table = Sequin.Enum.find!(database.tables, &(&1.oid == table_oid))
+    table = %{table | sort_column_attnum: Character.column_attnum("updated_at")}
 
     source_table =
       ConsumersFactory.source_table(
@@ -39,32 +38,33 @@ defmodule Sequin.DatabasesRuntime.TableProducerServerTest do
         column_filters: []
       )
 
+    # Insert initial 8 records
+    characters =
+      1..8
+      |> Enum.map(fn _ -> CharacterFactory.insert_character!() end)
+      |> Enum.sort_by(& &1.updated_at, NaiveDateTime)
+
+    ConnectionCache.cache_connection(database, Repo)
+
     consumer =
       ConsumersFactory.insert_consumer!(
         replication_slot_id: replication.id,
         message_kind: :record,
-        record_consumer_state: ConsumersFactory.record_consumer_state_attrs(),
+        record_consumer_state: ConsumersFactory.record_consumer_state_attrs(initial_min_cursor: nil),
         source_tables: [source_table],
         account_id: database.account_id
       )
 
-    ConnectionCache.cache_connection(database, Repo)
-
-    {:ok, consumer: consumer, table_oid: table_oid}
+    {:ok, consumer: consumer, table: table, table_oid: table_oid, database: database, characters: characters}
   end
 
   describe "TableProducerServer" do
     test "initializes, fetches, and paginates records correctly", %{
       consumer: consumer,
-      table_oid: table_oid
+      table_oid: table_oid,
+      characters: characters
     } do
       page_size = 3
-
-      # Insert initial 8 records
-      characters =
-        1..8
-        |> Enum.map(fn _ -> CharacterFactory.insert_character!() end)
-        |> Enum.sort_by(& &1.updated_at, NaiveDateTime)
 
       pid =
         start_supervised!(
@@ -98,6 +98,65 @@ defmodule Sequin.DatabasesRuntime.TableProducerServerTest do
       end
 
       # Assert that the consumer's cursor has been updated
+      cursor = TableProducer.fetch_cursors(consumer.id)
+      # Cursor should be nil after completion
+      assert cursor == :error
+
+      # Verify that the consumer's producer state has been updated
+      consumer = Repo.reload(consumer)
+      assert consumer.record_consumer_state.producer == :wal
+      # Assert that the initial_min_cursor gets set
+      assert consumer.record_consumer_state.initial_min_cursor
+    end
+
+    test "processes only characters after initial_min_cursor", %{
+      consumer: consumer,
+      table_oid: table_oid,
+      characters: characters
+    } do
+      page_size = 3
+
+      # Use the 4th character as the initial_min_cursor
+      initial_min_cursor = %{
+        Character.column_attnum("updated_at") => Enum.at(characters, 3).updated_at,
+        Character.column_attnum("id") => Enum.at(characters, 3).id
+      }
+
+      record_state = consumer.record_consumer_state
+      consumer = %{consumer | record_consumer_state: %{record_state | initial_min_cursor: initial_min_cursor}}
+
+      pid =
+        start_supervised!(
+          {TableProducerServer,
+           [
+             consumer: consumer,
+             page_size: page_size,
+             table_oid: table_oid,
+             test_pid: self()
+           ]}
+        )
+
+      Process.monitor(pid)
+
+      # Wait for the TableProducerServer to finish processing
+      assert_receive {:DOWN, _ref, :process, ^pid, :normal}, 5000
+
+      # Fetch ConsumerRecords from the database
+      consumer_records =
+        consumer.id
+        |> ConsumerRecord.where_consumer_id()
+        |> Repo.all()
+        |> Enum.sort_by(& &1.id)
+
+      # We expect only 5 records (the last 5 characters)
+      assert length(consumer_records) == 5
+
+      # Verify that the records match the last 5 inserted characters
+      for {consumer_record, character} <- Enum.zip(consumer_records, Enum.drop(characters, 3)) do
+        assert consumer_record.table_oid == table_oid
+        assert consumer_record.record_pks == [to_string(character.id)]
+      end
+
       cursor = TableProducer.fetch_cursors(consumer.id)
       # Cursor should be nil after completion
       assert cursor == :error

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -36,7 +36,7 @@ defmodule Sequin.DataCase do
   end
 
   setup tags do
-    if tags[:unboxed] || tags[:uses_characters] do
+    if tags[:unboxed] do
       UnboxedRepo.delete_all(Character)
       UnboxedRepo.delete_all(CharacterDetailed)
       UnboxedRepo.delete_all(CharacterMultiPK)

--- a/test/support/factory/consumers_factory.ex
+++ b/test/support/factory/consumers_factory.ex
@@ -196,7 +196,8 @@ defmodule Sequin.Factory.ConsumersFactory do
     attrs = Map.new(attrs)
 
     %RecordConsumerState{
-      producer: Enum.random([:table_and_wal, :wal])
+      producer: Enum.random([:table_and_wal, :wal]),
+      initial_min_cursor: %{Factory.unique_integer() => Factory.timestamp()}
     }
     |> merge_attributes(attrs)
     |> Sequin.Map.from_ecto()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,3 +2,8 @@ Sequin.Test.UnboxedRepo.start_link()
 Sequin.Test.Support.ReplicationSlots.setup_all()
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Sequin.Repo, :manual)
+
+# These can be left dirty by unboxed repo tests, namely ReplicationSlot tests
+Sequin.Test.UnboxedRepo.delete_all(Sequin.Test.Support.Models.Character)
+Sequin.Test.UnboxedRepo.delete_all(Sequin.Test.Support.Models.CharacterDetailed)
+Sequin.Test.UnboxedRepo.delete_all(Sequin.Test.Support.Models.CharacterMultiPK)


### PR DESCRIPTION
Use to init instead of situation where we have no min_cursor. Means we always need to always have an initial_min_cursor. This will allow us to start from wherever in a table.