### PR TITLE
Add ability to set a row consumer to a specific location

### DIFF
--- a/assets/svelte/consumers/HttpPullForm.svelte
+++ b/assets/svelte/consumers/HttpPullForm.svelte
@@ -45,6 +45,10 @@
     maxAckPending: consumer.max_ack_pending || 10000,
     maxWaiting: consumer.max_waiting || 20,
     sortColumnAttnum: consumer.sort_column_attnum || null,
+    recordConsumerState: consumer.record_consumer_state || {
+      producer: "table_and_wal",
+      initialMinSortCol: null,
+    },
   };
 
   let form = { ...initialForm };
@@ -243,6 +247,7 @@
 
     <SortAndFilterCard
       messageKind={form.messageKind}
+      showStartPositionForm={!isEditMode}
       {selectedTable}
       bind:form
       {errors}

--- a/assets/svelte/consumers/HttpPushForm.svelte
+++ b/assets/svelte/consumers/HttpPushForm.svelte
@@ -57,6 +57,9 @@
       encryptedHeaders: {},
     },
     sortColumnAttnum: consumer.sort_column_attnum || null,
+    recordConsumerState: consumer.record_consumer_state || {
+      initialMinSortCol: null,
+    },
   };
   let isSubmitting = false;
 
@@ -295,6 +298,7 @@
 
     <SortAndFilterCard
       messageKind={form.messageKind}
+      showStartPositionForm={!isEditMode}
       {selectedTable}
       bind:form
       {errors}

--- a/assets/svelte/consumers/Wizard.svelte
+++ b/assets/svelte/consumers/Wizard.svelte
@@ -70,6 +70,10 @@
     };
     httpEndpointPath: string;
     sortColumnAttnum: number | null;
+    recordConsumerState: {
+      producer: "table_and_wal";
+      initialMinSortCol: number | null | Date;
+    };
   } = {
     postgresDatabaseId: null,
     tableOid: null,
@@ -90,6 +94,10 @@
     },
     httpEndpointPath: "",
     sortColumnAttnum: null,
+    recordConsumerState: {
+      producer: "table_and_wal",
+      initialMinSortCol: null,
+    },
   };
 
   export let databases: Array<{
@@ -250,20 +258,6 @@
           (table) => table.oid === form.tableOid
         );
       }
-    }
-  }
-
-  let tableRefreshState: "idle" | "refreshing" | "done" = "idle";
-
-  function refreshTables(databaseId: string) {
-    if (databaseId) {
-      tableRefreshState = "refreshing";
-      pushEvent("refresh_tables", { database_id: databaseId }, () => {
-        tableRefreshState = "done";
-        setTimeout(() => {
-          tableRefreshState = "idle";
-        }, 2000);
-      });
     }
   }
 
@@ -750,6 +744,7 @@
         </div>
         <div class="p-8 max-w-5xl mx-auto">
           <SortAndFilterCard
+            showCardTitle={false}
             showTableInfo
             messageKind={form.messageKind}
             {selectedTable}

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -15,7 +15,7 @@ defmodule Sequin.Consumers do
   alias Sequin.ConsumersRuntime.Supervisor, as: ConsumersSupervisor
   alias Sequin.Databases
   alias Sequin.Databases.PostgresDatabase
-  alias Sequin.DatabasesRuntime.Supervisor
+  alias Sequin.DatabasesRuntime.Supervisor, as: DatabasesRuntimeSupervisor
   alias Sequin.Error
   alias Sequin.Health
   alias Sequin.Metrics
@@ -1130,8 +1130,8 @@ defmodule Sequin.Consumers do
   end
 
   defp notify_consumer_create(consumer) do
-    if consumer.message_kind == :record and env() != :test do
-      Enum.each(consumer.source_tables, &Supervisor.start_table_producer({consumer, &1.oid}))
+    if consumer.message_kind == :record and consumer.record_consumer_state.producer == :table_and_wal and env() != :test do
+      Enum.each(consumer.source_tables, &DatabasesRuntimeSupervisor.start_table_producer({consumer, &1.oid}))
     end
   end
 
@@ -1154,7 +1154,7 @@ defmodule Sequin.Consumers do
 
   defp maybe_disable_table_producer(%{message_kind: :record} = consumer) do
     unless env() == :test do
-      Enum.each(consumer.source_tables, &Supervisor.stop_table_producer({consumer, &1.oid}))
+      Enum.each(consumer.source_tables, &DatabasesRuntimeSupervisor.stop_table_producer({consumer, &1.oid}))
     end
   end
 

--- a/test/sequin/table_producer_server_test.exs
+++ b/test/sequin/table_producer_server_test.exs
@@ -50,7 +50,8 @@ defmodule Sequin.DatabasesRuntime.TableProducerServerTest do
       ConsumersFactory.insert_consumer!(
         replication_slot_id: replication.id,
         message_kind: :record,
-        record_consumer_state: ConsumersFactory.record_consumer_state_attrs(initial_min_cursor: nil),
+        record_consumer_state:
+          ConsumersFactory.record_consumer_state_attrs(initial_min_cursor: nil, producer: :table_and_wal),
         source_tables: [source_table],
         account_id: database.account_id
       )
@@ -59,56 +60,6 @@ defmodule Sequin.DatabasesRuntime.TableProducerServerTest do
   end
 
   describe "TableProducerServer" do
-    test "initializes, fetches, and paginates records correctly", %{
-      consumer: consumer,
-      table_oid: table_oid,
-      characters: characters
-    } do
-      page_size = 3
-
-      pid =
-        start_supervised!(
-          {TableProducerServer,
-           [
-             consumer: consumer,
-             page_size: page_size,
-             table_oid: table_oid,
-             test_pid: self()
-           ]}
-        )
-
-      Process.monitor(pid)
-
-      # Wait for the TableProducerServer to finish processing
-      assert_receive {:DOWN, _ref, :process, ^pid, :normal}, 5000
-
-      # Fetch ConsumerRecords from the database
-      consumer_records =
-        consumer.id
-        |> ConsumerRecord.where_consumer_id()
-        |> Repo.all()
-        |> Enum.sort_by(& &1.id)
-
-      assert length(consumer_records) == 8
-
-      # Verify that the records match the inserted characters
-      for {consumer_record, character} <- Enum.zip(consumer_records, characters) do
-        assert consumer_record.table_oid == table_oid
-        assert consumer_record.record_pks == [to_string(character.id)]
-      end
-
-      # Assert that the consumer's cursor has been updated
-      cursor = TableProducer.fetch_cursors(consumer.id)
-      # Cursor should be nil after completion
-      assert cursor == :error
-
-      # Verify that the consumer's producer state has been updated
-      consumer = Repo.reload(consumer)
-      assert consumer.record_consumer_state.producer == :wal
-      # Assert that the initial_min_cursor gets set
-      assert consumer.record_consumer_state.initial_min_cursor
-    end
-
     test "processes only characters after initial_min_cursor", %{
       consumer: consumer,
       table_oid: table_oid,


### PR DESCRIPTION
This pull request enhances the datetime component and improves the consumer configuration process. Here are the key changes:

1. Added an "Autofill from ISO8601" feature to the Datetime component, allowing users to input ISO8601 formatted datetime strings.

2. Updated the SortAndFilterCard component to include a new "Sort and start" section, which allows users to select a sort column and specify where the consumer should start processing records.

3. Modified the HttpPullForm and HttpPushForm components to include the new recordConsumerState field and show the start position form for new consumers.

4. Updated the Wizard component to include the recordConsumerState in the initial form state.

5. Refactored the Consumers module to handle the new recordConsumerState and adjust table producer behavior accordingly.

6. Enhanced the KeysetCursor module with new functions to generate minimum cursors based on column types.

7. Updated the TableProducerServer to handle different producer types (table_and_wal or wal) and periodically reload the consumer configuration.

8. Modified the ConsumersLive.Form module to handle the new recordConsumerState and properly encode it when creating or updating consumers.

9. Updated tests to reflect the new behavior of the TableProducerServer.

These changes provide more flexibility in configuring consumers and improve the user experience when working with datetime fields.