### PR TITLE
🐛 Skip replication tables if we lack permissions

### DIFF
--- a/test/support/factory/character_factory.ex
+++ b/test/support/factory/character_factory.ex
@@ -9,6 +9,7 @@ if Mix.env() == :test do
     alias Sequin.Test.Support.Models.CharacterDetailed
     alias Sequin.Test.Support.Models.CharacterIdentFull
     alias Sequin.Test.Support.Models.CharacterMultiPK
+    alias Sequin.Test.Support.Models.CharactersRestricted
 
     def character(attrs \\ []) do
       attrs = Map.new(attrs)
@@ -136,6 +137,32 @@ if Mix.env() == :test do
 
       %CharacterDetailed{}
       |> CharacterDetailed.changeset(attrs)
+      |> repo.insert!()
+    end
+
+    def characters_restricted(attrs \\ []) do
+      attrs = Map.new(attrs)
+
+      merge_attributes(
+        %CharactersRestricted{
+          name: Faker.Person.name()
+        },
+        attrs
+      )
+    end
+
+    def characters_restricted_attrs(attrs \\ []) do
+      attrs
+      |> characters_restricted()
+      |> Sequin.Map.from_ecto()
+    end
+
+    def insert_characters_restricted!(attrs \\ [], opts \\ []) do
+      repo = Keyword.get(opts, :repo, Repo)
+      attrs = characters_restricted_attrs(attrs)
+
+      %CharactersRestricted{}
+      |> CharactersRestricted.changeset(attrs)
       |> repo.insert!()
     end
   end

--- a/test/support/models/restricted_character.ex
+++ b/test/support/models/restricted_character.ex
@@ -1,0 +1,19 @@
+defmodule Sequin.Test.Support.Models.CharactersRestricted do
+  @moduledoc false
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @schema_prefix :restricted
+  schema "characters_restricted" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  def changeset(character, attrs) do
+    character
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end


### PR DESCRIPTION
It is possible that we receive replication messages for tables which our user does not have access to query.

In this PR, we simply skip these messages.

It would be preferable to alert the user. There are two levels of alerting when we do not have access:
1. A table is configured in the publication
2. A table is configured in the publication AND they have a consumer using that table

2 deserves sufficient alerting. 1 might not.