### PR TITLE
Add WalEventServer and refactor replication lifecycle

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@intercom/messenger-js-sdk": "^0.0.13",
-        "bits-ui": "^0.21.13",
+        "bits-ui": "^0.21.16",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "live_svelte": "file:../deps/live_svelte",
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/bits-ui": {
-      "version": "0.21.13",
-      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-0.21.13.tgz",
-      "integrity": "sha512-7nmOh6Ig7ND4DXZHv1FhNsY9yUGrad0+mf3tc4YN//3MgnJT1LnHtk4HZAKgmxCOe7txSX7/39LtYHbkrXokAQ==",
+      "version": "0.21.16",
+      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-0.21.16.tgz",
+      "integrity": "sha512-XFZ7/bK7j/K+5iktxX/ZpmoFHjYjpPzP5EOO/4bWiaFg5TG1iMcfjDhlBTQnJxD6BoVoHuqeZPHZvaTgF4Iv3Q==",
       "dependencies": {
         "@internationalized/date": "^3.5.1",
         "@melt-ui/svelte": "0.76.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@intercom/messenger-js-sdk": "^0.0.13",
-    "bits-ui": "^0.21.13",
+    "bits-ui": "^0.21.16",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "live_svelte": "file:../deps/live_svelte",

--- a/assets/svelte/components/CodeWithCopy.svelte
+++ b/assets/svelte/components/CodeWithCopy.svelte
@@ -4,19 +4,22 @@
   export let language: string = "";
   export let code: string = "";
   export let maxWidth: string = "100%";
+  export let copyIconPosition: "center" | "top" = "center";
 
   $: codeContent = code.trim();
 </script>
 
 <div
-  class="flex flex-row items-center bg-muted p-4 rounded-md overflow-hidden"
+  class="flex flex-row bg-muted p-4 rounded-md overflow-hidden"
   style="max-width: {maxWidth}"
 >
   <pre class="text-sm overflow-x-auto flex flex-grow"><code class={language}
       >{codeContent}</code
     >
   </pre>
-  <span class="ml-4 flex-shrink-0">
+  <span
+    class={`ml-4 flex-shrink-0 ${copyIconPosition === "top" ? "self-start" : "self-center"}`}
+  >
     <CopyIcon content={codeContent} />
   </span>
 </div>

--- a/assets/svelte/components/Sidenav.svelte
+++ b/assets/svelte/components/Sidenav.svelte
@@ -12,8 +12,7 @@
     LogOut,
     ChevronLeft,
     ChevronRight,
-    Activity,
-    Inbox,
+    Logs,
   } from "lucide-svelte";
 
   export let currentPath: string;
@@ -23,6 +22,7 @@
     { path: "/consumers", text: "Consumers", icon: Radio },
     { path: "/databases", text: "Databases", icon: Database },
     { path: "/http-endpoints", text: "HTTP Endpoints", icon: Webhook },
+    { path: "/wal-projections", text: "WAL Projections", icon: Logs },
   ];
 
   function navLink(path: string) {

--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -21,9 +21,17 @@
     RefreshCwIcon,
     CheckIcon,
     DatabaseIcon,
+    Logs,
+    Info,
+    Plus,
   } from "lucide-svelte";
   import { Button } from "$lib/components/ui/button";
   import { onMount } from "svelte";
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import { Badge } from "$lib/components/ui/badge";
+  import * as Dialog from "$lib/components/ui/dialog";
+  import CodeWithCopy from "./CodeWithCopy.svelte";
+  import { Label } from "$lib/components/ui/label";
 
   export let databases: Array<{
     id: string;
@@ -32,6 +40,7 @@
       oid: number;
       schema: string;
       name: string;
+      isEventTable?: boolean;
     }>;
   }>;
   export let onSelect: (event: {
@@ -45,6 +54,7 @@
   ) => void;
   export let selectedDatabaseId: string | undefined;
   export let selectedTableOid: number | null;
+  export let onlyEventTables: boolean = false;
 
   let selectedDatabase;
   let autoRefreshedDatabaseTables = [];
@@ -62,6 +72,10 @@
           .toLowerCase()
           .includes((searchQuery || "").toLowerCase())
       ) || [];
+
+    if (onlyEventTables) {
+      filteredTables = filteredTables.filter((table) => table.isEventTable);
+    }
   }
 
   $: {
@@ -121,6 +135,65 @@
       handleDbChange({ value: databases[0].id });
     }
   });
+
+  let createEventTableDialogOpen = false;
+  let destinationTableName = "my_events";
+  let retentionDays = 30;
+
+  function openCreateEventTableDialog() {
+    createEventTableDialogOpen = true;
+  }
+
+  $: createTableDDL = `
+create table ${destinationTableName} (
+  id serial primary key,
+  seq bigint not null,
+  source_database_id uuid not null,
+  source_table_oid bigint not null,
+  record_pk text not null,
+  record jsonb not null,
+  changes jsonb,
+  action text not null,
+  committed_at timestamp with time zone not null,
+  inserted_at timestamp with time zone not null default now()
+);
+
+create unique index on ${destinationTableName} (source_database_id, seq, record_pk);
+create index on ${destinationTableName} (seq);
+create index on ${destinationTableName} (source_table_oid);
+create index on ${destinationTableName} (committed_at);
+
+-- important comment to identify this table as a sequin events table
+comment on table ${destinationTableName} is '$sequin-events$';
+`;
+
+  $: retentionPolicyDDL = `
+-- create required extensions
+create extension if not exists pg_partman;
+create extension if not exists pg_cron;
+
+-- set up pg_partman for time-based partitioning
+select partman.create_parent(
+  p_parent_table => '${destinationTableName}',
+  p_control => 'committed_at',
+  p_type => 'native',
+  p_interval => 'daily',
+  p_premake => 30
+);
+
+-- set up retention policy
+select partman.add_to_part_config(
+  p_parent_table => '${destinationTableName}',
+  p_retention => '${retentionDays} days',
+  p_retention_keep_table => false
+);
+
+-- setup cron job to run maintenance for pg_partman every hour
+-- this is necessary to clean up old partitions (i.e. drop stale data)
+select cron.schedule('partman_maintenance', '0 * * * *', $$
+  select partman.run_maintenance(p_analyze := false);
+$$);
+`;
 </script>
 
 <div class="w-full mx-auto space-y-4">
@@ -199,23 +272,73 @@
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Table Name</TableHead>
+                <TableHead>
+                  {#if onlyEventTables}
+                    <div class="flex items-center justify-between gap-2">
+                      Event tables
+                      <Tooltip.Root>
+                        <Tooltip.Trigger>
+                          <Badge variant="default">
+                            <Info class="mr-1 h-4 w-4" />
+                            Filtered
+                          </Badge>
+                        </Tooltip.Trigger>
+                        <Tooltip.Content>
+                          <p class="text-xs">
+                            Filtered down to source tables that look like Sequin
+                            events tables.
+                          </p>
+                        </Tooltip.Content>
+                      </Tooltip.Root>
+                    </div>
+                  {:else}
+                    Tables
+                  {/if}
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {#each filteredTables as table}
-                <TableRow
-                  on:click={() => handleTableSelect(table)}
-                  class="cursor-pointer {table.oid === selectedTableOid
-                    ? 'bg-blue-50 hover:bg-blue-100'
-                    : 'hover:bg-gray-100'}"
-                >
-                  <TableCell class="flex items-center space-x-2">
-                    <TableIcon class="h-4 w-4 text-gray-400" />
-                    <span>{table.schema}.{table.name}</span>
+              {#if filteredTables.length === 0 && onlyEventTables}
+                <TableRow>
+                  <TableCell colspan="2" class="text-center py-8">
+                    <p class="text-gray-500 mb-4">
+                      No event tables found in the destination.
+                    </p>
+                    <Button on:click={openCreateEventTableDialog}>
+                      <Plus class="mr-2 h-4 w-4" /> Create event table
+                    </Button>
                   </TableCell>
                 </TableRow>
-              {/each}
+              {:else}
+                {#each filteredTables as table}
+                  <TableRow
+                    on:click={() => handleTableSelect(table)}
+                    class="cursor-pointer {table.oid === selectedTableOid
+                      ? 'bg-blue-50 hover:bg-blue-100'
+                      : 'hover:bg-gray-100'}"
+                  >
+                    <TableCell class="flex items-center space-x-2">
+                      {#if onlyEventTables}
+                        <Logs class="h-4 w-4 text-gray-400" />
+                      {:else}
+                        <TableIcon class="h-4 w-4 text-gray-400" />
+                      {/if}
+                      <span>{table.schema}.{table.name}</span>
+                    </TableCell>
+                  </TableRow>
+                {/each}
+                {#if onlyEventTables}
+                  <TableRow
+                    on:click={openCreateEventTableDialog}
+                    class="cursor-pointer bg-gray-50 hover:bg-gray-100"
+                  >
+                    <TableCell class="flex items-center space-x-2">
+                      <Plus class="h-4 w-4 text-gray-400" />
+                      <span class="text-gray-600">Create new event table</span>
+                    </TableCell>
+                  </TableRow>
+                {/if}
+              {/if}
             </TableBody>
           </Table>
         </div>
@@ -223,3 +346,67 @@
     </div>
   {/if}
 </div>
+
+<Dialog.Root
+  bind:open={createEventTableDialogOpen}
+  id="create-event-table-dialog"
+>
+  <Dialog.Content class="w-4/5 max-w-[80%] flex flex-col">
+    <Dialog.Header>
+      <Dialog.Title>Create Event Table</Dialog.Title>
+      <Dialog.Description>
+        Set up your event table with the correct schema and retention policy.
+      </Dialog.Description>
+    </Dialog.Header>
+    <div class="space-y-4 flex-grow overflow-y-auto">
+      <div class="space-y-2">
+        <Label for="destinationTableName">Desired table name</Label>
+        <Input id="destinationTableName" bind:value={destinationTableName} />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="retentionDays">Desired retention period (days)</Label>
+        <Input type="number" id="retentionDays" bind:value={retentionDays} />
+      </div>
+
+      {#if destinationTableName}
+        <div class="mt-4">
+          <p class="mb-2"><strong>Create your event table</strong></p>
+          <p class="mb-2">
+            Create an event table with the following DDL, including indexes:
+          </p>
+          <CodeWithCopy
+            language="sql"
+            code={createTableDDL}
+            copyIconPosition="top"
+          />
+        </div>
+        <div class="mt-4">
+          <p class="mb-2"><strong>Create your retention policy</strong></p>
+          <p class="mb-2">
+            We recommend using the pg_partman extension to enforce a retention
+            policy. Here's what it looks like to enforce a retention of {retentionDays}
+            days:
+          </p>
+          <CodeWithCopy
+            language="sql"
+            code={retentionPolicyDDL}
+            copyIconPosition="top"
+          />
+        </div>
+      {/if}
+    </div>
+    <Dialog.Footer class="py-4 sticky bottom-0 bg-background">
+      <Button
+        variant="outline"
+        on:click={() => (createEventTableDialogOpen = false)}>Cancel</Button
+      >
+      <Button
+        on:click={() => {
+          createEventTableDialogOpen = false;
+          refreshTables();
+        }}>Done</Button
+      >
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -60,7 +60,7 @@
       selectedDatabase?.tables.filter((table) =>
         `${table.schema}.${table.name}`
           .toLowerCase()
-          .includes(searchQuery.toLowerCase())
+          .includes((searchQuery || "").toLowerCase())
       ) || [];
   }
 

--- a/assets/svelte/components/ui/sheet/index.ts
+++ b/assets/svelte/components/ui/sheet/index.ts
@@ -1,0 +1,106 @@
+import { Dialog as SheetPrimitive } from "bits-ui";
+import { type VariantProps, tv } from "tailwind-variants";
+
+import Portal from "./sheet-portal.svelte";
+import Overlay from "./sheet-overlay.svelte";
+import Content from "./sheet-content.svelte";
+import Header from "./sheet-header.svelte";
+import Footer from "./sheet-footer.svelte";
+import Title from "./sheet-title.svelte";
+import Description from "./sheet-description.svelte";
+
+const Root = SheetPrimitive.Root;
+const Close = SheetPrimitive.Close;
+const Trigger = SheetPrimitive.Trigger;
+
+export {
+	Root,
+	Close,
+	Trigger,
+	Portal,
+	Overlay,
+	Content,
+	Header,
+	Footer,
+	Title,
+	Description,
+	//
+	Root as Sheet,
+	Close as SheetClose,
+	Trigger as SheetTrigger,
+	Portal as SheetPortal,
+	Overlay as SheetOverlay,
+	Content as SheetContent,
+	Header as SheetHeader,
+	Footer as SheetFooter,
+	Title as SheetTitle,
+	Description as SheetDescription,
+};
+
+export const sheetVariants = tv({
+	base: "bg-background fixed z-50 gap-4 p-6 shadow-lg",
+	variants: {
+		side: {
+			top: "inset-x-0 top-0 border-b",
+			bottom: "inset-x-0 bottom-0 border-t",
+			left: "inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+			right: "inset-y-0 right-0 h-full w-3/4  border-l sm:max-w-sm",
+		},
+	},
+	defaultVariants: {
+		side: "right",
+	},
+});
+
+export const sheetTransitions = {
+	top: {
+		in: {
+			y: "-100%",
+			duration: 500,
+			opacity: 1,
+		},
+		out: {
+			y: "-100%",
+			duration: 300,
+			opacity: 1,
+		},
+	},
+	bottom: {
+		in: {
+			y: "100%",
+			duration: 500,
+			opacity: 1,
+		},
+		out: {
+			y: "100%",
+			duration: 300,
+			opacity: 1,
+		},
+	},
+	left: {
+		in: {
+			x: "-100%",
+			duration: 500,
+			opacity: 1,
+		},
+		out: {
+			x: "-100%",
+			duration: 300,
+			opacity: 1,
+		},
+	},
+	right: {
+		in: {
+			x: "100%",
+			duration: 500,
+			opacity: 1,
+		},
+		out: {
+			x: "100%",
+			duration: 300,
+			opacity: 1,
+		},
+	},
+};
+
+export type Side = VariantProps<typeof sheetVariants>["side"];

--- a/assets/svelte/components/ui/sheet/sheet-content.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-content.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import X from "lucide-svelte/icons/x";
+	import { fly } from "svelte/transition";
+	import {
+		SheetOverlay,
+		SheetPortal,
+		type Side,
+		sheetTransitions,
+		sheetVariants,
+	} from "./index.js";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = SheetPrimitive.ContentProps & {
+		side?: Side;
+	};
+
+	let className: $$Props["class"] = undefined;
+	export let side: $$Props["side"] = "right";
+	export { className as class };
+	export let inTransition: $$Props["inTransition"] = fly;
+	export let inTransitionConfig: $$Props["inTransitionConfig"] =
+		sheetTransitions[side ?? "right"].in;
+	export let outTransition: $$Props["outTransition"] = fly;
+	export let outTransitionConfig: $$Props["outTransitionConfig"] =
+		sheetTransitions[side ?? "right"].out;
+</script>
+
+<SheetPortal>
+	<SheetOverlay />
+	<SheetPrimitive.Content
+		{inTransition}
+		{inTransitionConfig}
+		{outTransition}
+		{outTransitionConfig}
+		class={cn(sheetVariants({ side }), className)}
+		{...$$restProps}
+	>
+		<slot />
+		<SheetPrimitive.Close
+			class="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none"
+		>
+			<X class="h-4 w-4" />
+			<span class="sr-only">Close</span>
+		</SheetPrimitive.Close>
+	</SheetPrimitive.Content>
+</SheetPortal>

--- a/assets/svelte/components/ui/sheet/sheet-description.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-description.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = SheetPrimitive.DescriptionProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<SheetPrimitive.Description class={cn("text-muted-foreground text-sm", className)} {...$$restProps}>
+	<slot />
+</SheetPrimitive.Description>

--- a/assets/svelte/components/ui/sheet/sheet-footer.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-footer.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = HTMLAttributes<HTMLDivElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<div
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+	{...$$restProps}
+>
+	<slot />
+</div>

--- a/assets/svelte/components/ui/sheet/sheet-header.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-header.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = HTMLAttributes<HTMLDivElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
+	<slot />
+</div>

--- a/assets/svelte/components/ui/sheet/sheet-overlay.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-overlay.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { fade } from "svelte/transition";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = SheetPrimitive.OverlayProps;
+
+	let className: $$Props["class"] = undefined;
+	export let transition: $$Props["transition"] = fade;
+	export let transitionConfig: $$Props["transitionConfig"] = {
+		duration: 150,
+	};
+	export { className as class };
+</script>
+
+<SheetPrimitive.Overlay
+	{transition}
+	{transitionConfig}
+	class={cn("bg-background/80 fixed inset-0 z-50 backdrop-blur-sm ", className)}
+	{...$$restProps}
+/>

--- a/assets/svelte/components/ui/sheet/sheet-portal.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-portal.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = SheetPrimitive.PortalProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<SheetPrimitive.Portal class={cn(className)} {...$$restProps}>
+	<slot />
+</SheetPrimitive.Portal>

--- a/assets/svelte/components/ui/sheet/sheet-title.svelte
+++ b/assets/svelte/components/ui/sheet/sheet-title.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = SheetPrimitive.TitleProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<SheetPrimitive.Title
+	class={cn("text-foreground text-lg font-semibold", className)}
+	{...$$restProps}
+>
+	<slot />
+</SheetPrimitive.Title>

--- a/assets/svelte/consumers/ShowMessages.svelte
+++ b/assets/svelte/consumers/ShowMessages.svelte
@@ -97,7 +97,6 @@
 
       if (rowHeight > 0) {
         const calculatedPageSize = Math.floor(totalAvailableHeight / rowHeight);
-        console.log("calculatedPageSize", calculatedPageSize);
         if (calculatedPageSize !== pageSize) {
           pageSize = calculatedPageSize;
           // Send new pageSize to backend

--- a/assets/svelte/databases/Show.svelte
+++ b/assets/svelte/databases/Show.svelte
@@ -58,12 +58,8 @@
   export let metrics: {
     avg_latency: number;
   };
-  export let live_action: string;
 
   let refreshingTables = writable(false);
-
-  // Determine the active tab based on the current URL
-  $: activeTab = $live_action === "messages" ? "messages" : "overview";
 
   function pushEvent(event: string, params = {}, callback: any = () => {}) {
     live.pushEventTo("#" + parent, event, params, callback);
@@ -79,192 +75,182 @@
 
 <div class="min-h-screen font-sans">
   <main class="container mx-auto px-4 py-8">
-    {#if activeTab === "overview"}
-      <!-- Existing overview content -->
-      <div class="grid gap-6 md:grid-cols-3 mb-6">
-        <HealthComponent health={database.health} />
+    <!-- Existing overview content -->
+    <div class="grid gap-6 md:grid-cols-3 mb-6">
+      <HealthComponent health={database.health} />
 
-        <Card>
-          <CardContent class="p-6">
-            <div class="flex justify-between items-center mb-4">
-              <span class="text-sm font-medium text-gray-500">Tables</span>
-              <Button
-                variant="ghost"
-                size="sm"
-                on:click={handleRefreshTables}
-                disabled={$refreshingTables}
-              >
-                {#if $refreshingTables}
-                  <span class="sr-only">Refreshing tables</span>
-                  <Loader2 class="h-4 w-4 animate-spin" />
-                {:else}
-                  <span class="sr-only">Refresh tables</span>
-                  <RefreshCw class="h-4 w-4 text-gray-500" />
-                {/if}
-              </Button>
-            </div>
-            <div class="text-4xl font-bold">{database.tables.length}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent class="p-6">
-            <div class="flex justify-between items-center mb-4">
-              <span class="text-sm font-medium text-gray-500">Avg. Latency</span
-              >
-              <Clock class="h-5 w-5 text-blue-500" />
-            </div>
-            {#if metrics.avg_latency}
-              <div class="text-4xl font-bold">{metrics.avg_latency} ms</div>
-            {:else}
-              <div class="flex items-center">
-                <Loader2 class="h-8 w-8 text-gray-400 animate-spin mr-2" />
-                <span class="text-4xl font-bold text-gray-500">ms</span>
-              </div>
-            {/if}
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card class="mb-6">
+      <Card>
         <CardContent class="p-6">
-          <h2 class="text-lg font-semibold mb-4">Configuration</h2>
-          <div class="grid grid-cols-2 gap-4">
-            <div>
-              <p class="text-sm text-gray-500">Hostname</p>
-              <p class="font-medium text-wrap break-all">{database.hostname}</p>
-            </div>
-            <div>
-              <p class="text-sm text-gray-500">Port</p>
-              <p class="font-medium">{database.port}</p>
-            </div>
-            <div>
-              <p class="text-sm text-gray-500">Database</p>
-              <p class="font-medium">{database.database}</p>
-            </div>
-            <div>
-              <p class="text-sm text-gray-500">Username</p>
-              <p class="font-medium">{database.username}</p>
-            </div>
-            <div>
-              <p class="text-sm text-gray-500">SSL</p>
-              <p class="font-medium">{database.ssl ? "Enabled" : "Disabled"}</p>
-            </div>
-            <div>
-              <p class="text-sm text-gray-500">Pool Size</p>
-              <p class="font-medium">{database.pool_size}</p>
-            </div>
-            <!-- <div>
-              <p class="text-sm text-gray-500">Queue Interval</p>
-              <p class="font-medium">{database.queue_interval} ms</p>
-            </div> -->
+          <div class="flex justify-between items-center mb-4">
+            <span class="text-sm font-medium text-gray-500">Tables</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              on:click={handleRefreshTables}
+              disabled={$refreshingTables}
+            >
+              {#if $refreshingTables}
+                <span class="sr-only">Refreshing tables</span>
+                <Loader2 class="h-4 w-4 animate-spin" />
+              {:else}
+                <span class="sr-only">Refresh tables</span>
+                <RefreshCw class="h-4 w-4 text-gray-500" />
+              {/if}
+            </Button>
           </div>
+          <div class="text-4xl font-bold">{database.tables.length}</div>
         </CardContent>
       </Card>
 
-      <Card class="mb-6">
+      <Card>
         <CardContent class="p-6">
-          <h2 class="text-lg font-semibold mb-4">Consumers</h2>
-          {#if database.consumers && database.consumers.length > 0}
-            <div class="flex flex-wrap gap-4">
-              {#each database.consumers as consumer}
-                <Card class="w-full">
-                  <CardContent class="p-4">
-                    <div class="flex items-center justify-between mb-6">
-                      <div class="flex items-center">
-                        <Radio class="h-4 w-4 mr-2" />
-                        <span class="font-medium">{consumer.name}</span>
-                      </div>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        href={`/consumers/${consumer.id}`}
-                      >
-                        <ExternalLink class="h-4 w-4 mr-2" />
-                        View Consumer
-                      </Button>
-                    </div>
-                    <div
-                      class="grid grid-cols-[auto_1fr] gap-x-2 gap-y-3 mb-2 auto-rows-fr items-center"
-                    >
-                      <p class="text-sm text-gray-500 justify-self-end">
-                        Tables:
-                      </p>
-                      <div class="flex flex-wrap align-center">
-                        {#each consumer.source_tables as table}
-                          <div
-                            class="inline-flex items-center text-sm font-medium text-black"
-                          >
-                            <icon
-                              class="hero-table-cells w-5 h-5 mr-1 rounded {getColorFromName(
-                                `${table.schema_name}.${table.table_name}`
-                              )}"
-                            ></icon>
-
-                            <pre
-                              class="font-medium">{table.schema_name}.{table.table_name}</pre>
-                          </div>
-                        {/each}
-                      </div>
-                      <p class="text-sm text-gray-500 justify-self-end">
-                        Stream type:
-                      </p>
-                      <div class="flex flex-wrap align-center">
-                        {#if consumer.message_kind === "event"}
-                          <Badge variant="default">
-                            <SquareStack class="h-4 w-4 mr-1" />
-                            Changes
-                          </Badge>
-                        {:else if consumer.message_kind === "record"}
-                          <Badge variant="default">
-                            <SquareStack class="h-4 w-4 mr-1" />
-                            Rows
-                          </Badge>
-                        {/if}
-                      </div>
-                      <p class="text-sm text-gray-500 justify-self-end">
-                        Consumer type:
-                      </p>
-                      <div class="flex flex-wrap align-center">
-                        {#if consumer.consumer_kind === "http_push"}
-                          <Badge variant="default">
-                            <ArrowRightToLine class="h-4 w-4 mr-1" />
-                            Push consumer
-                          </Badge>
-                        {:else if consumer.consumer_kind === "http_pull"}
-                          <Badge variant="default">
-                            <ArrowLeftFromLine class="h-4 w-4 mr-1" />
-                            Pull consumer
-                          </Badge>
-                        {/if}
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              {/each}
-            </div>
+          <div class="flex justify-between items-center mb-4">
+            <span class="text-sm font-medium text-gray-500">Avg. Latency</span>
+            <Clock class="h-5 w-5 text-blue-500" />
+          </div>
+          {#if metrics.avg_latency}
+            <div class="text-4xl font-bold">{metrics.avg_latency} ms</div>
           {:else}
-            <div
-              class="bg-gray-100 p-6 rounded-lg flex flex-col items-center justify-center"
-            >
-              <Radio class="h-12 w-12 mb-4 text-gray-400" />
-              <p class="text-sm font-medium text-gray-900 mb-3">
-                No consumers attached to database
-              </p>
-              <Button href="/consumers/new" variant="outline"
-                >Add a consumer</Button
-              >
+            <div class="flex items-center">
+              <Loader2 class="h-8 w-8 text-gray-400 animate-spin mr-2" />
+              <span class="text-4xl font-bold text-gray-500">ms</span>
             </div>
           {/if}
         </CardContent>
       </Card>
-    {:else if activeTab === "messages"}
-      <!-- New Messages content -->
-      <div class="bg-white rounded-lg shadow">
-        <h2 class="text-lg font-semibold p-4 border-b">Database Messages</h2>
-        <!-- Add your messages content here -->
-        <p class="p-4">Messages for this database will be displayed here.</p>
-      </div>
-    {/if}
+    </div>
+
+    <Card class="mb-6">
+      <CardContent class="p-6">
+        <h2 class="text-lg font-semibold mb-4">Configuration</h2>
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <p class="text-sm text-gray-500">Hostname</p>
+            <p class="font-medium text-wrap break-all">{database.hostname}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Port</p>
+            <p class="font-medium">{database.port}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Database</p>
+            <p class="font-medium">{database.database}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Username</p>
+            <p class="font-medium">{database.username}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">SSL</p>
+            <p class="font-medium">{database.ssl ? "Enabled" : "Disabled"}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Pool Size</p>
+            <p class="font-medium">{database.pool_size}</p>
+          </div>
+          <!-- <div>
+              <p class="text-sm text-gray-500">Queue Interval</p>
+              <p class="font-medium">{database.queue_interval} ms</p>
+            </div> -->
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card class="mb-6">
+      <CardContent class="p-6">
+        <h2 class="text-lg font-semibold mb-4">Consumers</h2>
+        {#if database.consumers && database.consumers.length > 0}
+          <div class="flex flex-wrap gap-4">
+            {#each database.consumers as consumer}
+              <Card class="w-full">
+                <CardContent class="p-4">
+                  <div class="flex items-center justify-between mb-6">
+                    <div class="flex items-center">
+                      <Radio class="h-4 w-4 mr-2" />
+                      <span class="font-medium">{consumer.name}</span>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      href={`/consumers/${consumer.id}`}
+                    >
+                      <ExternalLink class="h-4 w-4 mr-2" />
+                      View Consumer
+                    </Button>
+                  </div>
+                  <div
+                    class="grid grid-cols-[auto_1fr] gap-x-2 gap-y-3 mb-2 auto-rows-fr items-center"
+                  >
+                    <p class="text-sm text-gray-500 justify-self-end">
+                      Tables:
+                    </p>
+                    <div class="flex flex-wrap align-center">
+                      {#each consumer.source_tables as table}
+                        <div
+                          class="inline-flex items-center text-sm font-medium text-black"
+                        >
+                          <icon
+                            class="hero-table-cells w-5 h-5 mr-1 rounded {getColorFromName(
+                              `${table.schema_name}.${table.table_name}`
+                            )}"
+                          ></icon>
+
+                          <pre
+                            class="font-medium">{table.schema_name}.{table.table_name}</pre>
+                        </div>
+                      {/each}
+                    </div>
+                    <p class="text-sm text-gray-500 justify-self-end">
+                      Stream type:
+                    </p>
+                    <div class="flex flex-wrap align-center">
+                      {#if consumer.message_kind === "event"}
+                        <Badge variant="default">
+                          <SquareStack class="h-4 w-4 mr-1" />
+                          Changes
+                        </Badge>
+                      {:else if consumer.message_kind === "record"}
+                        <Badge variant="default">
+                          <SquareStack class="h-4 w-4 mr-1" />
+                          Rows
+                        </Badge>
+                      {/if}
+                    </div>
+                    <p class="text-sm text-gray-500 justify-self-end">
+                      Consumer type:
+                    </p>
+                    <div class="flex flex-wrap align-center">
+                      {#if consumer.consumer_kind === "http_push"}
+                        <Badge variant="default">
+                          <ArrowRightToLine class="h-4 w-4 mr-1" />
+                          Push consumer
+                        </Badge>
+                      {:else if consumer.consumer_kind === "http_pull"}
+                        <Badge variant="default">
+                          <ArrowLeftFromLine class="h-4 w-4 mr-1" />
+                          Pull consumer
+                        </Badge>
+                      {/if}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            {/each}
+          </div>
+        {:else}
+          <div
+            class="bg-gray-100 p-6 rounded-lg flex flex-col items-center justify-center"
+          >
+            <Radio class="h-12 w-12 mb-4 text-gray-400" />
+            <p class="text-sm font-medium text-gray-900 mb-3">
+              No consumers attached to database
+            </p>
+            <Button href="/consumers/new" variant="outline"
+              >Add a consumer</Button
+            >
+          </div>
+        {/if}
+      </CardContent>
+    </Card>
   </main>
 </div>

--- a/assets/svelte/databases/ShowHeader.svelte
+++ b/assets/svelte/databases/ShowHeader.svelte
@@ -11,7 +11,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
 
   export let database;
-  export let live_action;
+  export let activeTab;
   export let live;
   export let parent;
 
@@ -48,8 +48,6 @@
   function handleDelete() {
     showDeleteConfirmDialog = true;
   }
-  // Determine the active tab based on the current URL
-  $: activeTab = live_action === "messages" ? "messages" : "overview";
 </script>
 
 <div class="bg-white border-b sticky top-0 z-10">

--- a/assets/svelte/databases/WalProjections.svelte
+++ b/assets/svelte/databases/WalProjections.svelte
@@ -20,8 +20,6 @@
   export let live: any;
   export let parent: string;
 
-  console.log(walProjections);
-
   function pushEvent(event: string, params = {}) {
     live.pushEventTo("#" + parent, event, params);
   }
@@ -32,7 +30,7 @@
     <h2 class="text-2xl font-semibold">WAL Projections</h2>
     <Button on:click={() => pushEvent("new_wal_projection", {})}>
       <Plus class="h-4 w-4 mr-2" />
-      New WAL Projection
+      Create WAL Projection
     </Button>
   </div>
 

--- a/assets/svelte/databases/WalProjections.svelte
+++ b/assets/svelte/databases/WalProjections.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import * as Table from "$lib/components/ui/table";
+  import { Button } from "$lib/components/ui/button";
+  import { Plus } from "lucide-svelte";
+  import { formatRelativeTimestamp } from "$lib/utils";
+
+  export let walProjections: Array<{
+    id: string;
+    name: string;
+    source_table: {
+      table_name: string;
+      schema_name: string;
+    } | null;
+    destination_table: {
+      table_name: string;
+      schema_name: string;
+    } | null;
+    inserted_at: string;
+  }>;
+  export let live: any;
+  export let parent: string;
+
+  console.log(walProjections);
+
+  function pushEvent(event: string, params = {}) {
+    live.pushEventTo("#" + parent, event, params);
+  }
+</script>
+
+<div class="container mx-auto px-4 py-8">
+  <div class="flex justify-between items-center mb-6">
+    <h2 class="text-2xl font-semibold">WAL Projections</h2>
+    <Button on:click={() => pushEvent("new_wal_projection", {})}>
+      <Plus class="h-4 w-4 mr-2" />
+      New WAL Projection
+    </Button>
+  </div>
+
+  {#if walProjections.length === 0}
+    <div class="text-center py-12">
+      <p class="text-gray-600 mb-4">No WAL Projections found</p>
+      <Button on:click={() => pushEvent("new_wal_projection", {})}>
+        Create your first WAL Projection
+      </Button>
+    </div>
+  {:else}
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>Name</Table.Head>
+          <Table.Head>Source table</Table.Head>
+          <Table.Head>Destination table</Table.Head>
+          <Table.Head>Created at</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {#each walProjections as projection}
+          <Table.Row>
+            <Table.Cell>{projection.name}</Table.Cell>
+            <Table.Cell>
+              {#if projection.source_table}
+                {projection.source_table.schema_name}.{projection.source_table
+                  .table_name}
+              {:else}
+                Error - N/A
+              {/if}
+            </Table.Cell>
+            <Table.Cell>
+              {#if projection.destination_table}
+                {projection.destination_table.schema_name}.{projection
+                  .destination_table.table_name}
+              {:else}
+                Error - N/A
+              {/if}
+            </Table.Cell>
+            <Table.Cell
+              >{formatRelativeTimestamp(projection.inserted_at)}</Table.Cell
+            >
+          </Table.Row>
+        {/each}
+      </Table.Body>
+    </Table.Root>
+  {/if}
+</div>

--- a/assets/svelte/health/HealthComponent.svelte
+++ b/assets/svelte/health/HealthComponent.svelte
@@ -61,7 +61,7 @@
   <div class="flex items-center justify-between mb-2">
     <div class="flex items-center">
       <HealthIcon status={health.status} />
-      <h2 class="text-lg font-medium ml-2">{health.name}</h2>
+      <h2 class="text-lg font-medium ml-2">Health</h2>
     </div>
     <Popover.Root>
       <Popover.Trigger asChild let:builder>

--- a/assets/svelte/wal_projections/Form.svelte
+++ b/assets/svelte/wal_projections/Form.svelte
@@ -28,6 +28,8 @@
     AccordionItem,
     AccordionTrigger,
   } from "$lib/components/ui/accordion";
+  import { Info } from "lucide-svelte";
+  import * as Tooltip from "$lib/components/ui/tooltip";
 
   export let walProjection: any;
   export let databases: any[];
@@ -43,9 +45,9 @@
   let form = {
     name: walProjection.name || "",
     status: walProjection.status || "active",
-    sourceDatabaseId: walProjection.sourceDatabaseId || "",
+    postgresDatabaseId: walProjection.postgresDatabaseId || "",
     destinationDatabaseId: walProjection.destinationDatabaseId || "",
-    sourceTableOid: walProjection.sourceTables?.[0]?.oid || "",
+    tableOid: walProjection.sourceTables?.[0]?.oid || "",
     destinationTableOid: walProjection.destinationOid || "",
     sourceTableActions: walProjection.sourceTables?.[0]?.actions || [
       "insert",
@@ -59,18 +61,21 @@
   let selectedDestinationDatabase: any;
   let selectedSourceTable: any;
   let selectedDestinationTable: any;
-  let destinationTableName = "my_events";
-  let retentionDays = 30;
 
   $: {
-    if (form.sourceDatabaseId) {
+    if (form.postgresDatabaseId) {
       selectedSourceDatabase = databases.find(
-        (db) => db.id === form.sourceDatabaseId
+        (db) => db.id === form.postgresDatabaseId
       );
     }
     if (form.destinationDatabaseId) {
       selectedDestinationDatabase = databases.find(
         (db) => db.id === form.destinationDatabaseId
+      );
+    }
+    if (form.tableOid) {
+      selectedSourceTable = selectedSourceDatabase.tables.find(
+        (table) => table.oid === form.tableOid
       );
     }
   }
@@ -81,54 +86,6 @@
 
   $: pushEvent("validate", { wal_projection: form });
 
-  $: createTableDDL = `
-create table ${destinationTableName ? destinationTableName : "my_events"} (
-  id serial primary key,
-  seq bigint not null,
-  source_database_id uuid not null,
-  source_table_oid bigint not null,
-  record_pk text not null,
-  record jsonb not null,
-  changes jsonb,
-  action text not null,
-  committed_at timestamp with time zone not null,
-  inserted_at timestamp with time zone not null default now()
-);
-
-create unique index on ${destinationTableName} (seq, source_database_id);
-create index on ${destinationTableName} (seq);
-create index on ${destinationTableName} (source_table_oid);
-create index on ${destinationTableName} (committed_at);
-`;
-
-  $: retentionPolicyDDL = `
--- create required extensions
-create extension if not exists pg_partman;
-create extension if not exists pg_cron;
-
--- set up pg_partman for time-based partitioning
-select partman.create_parent(
-  p_parent_table => '${destinationTableName}',
-  p_control => 'committed_at',
-  p_type => 'native',
-  p_interval => 'daily',
-  p_premake => 30
-);
-
--- set up retention policy
-select partman.add_to_part_config(
-  p_parent_table => '${destinationTableName}',
-  p_retention => '${retentionDays} days',
-  p_retention_keep_table => false
-);
-
--- setup cron job to run maintenance for pg_partman every hour
--- this is necessary to clean up old partitions (i.e. drop stale data)
-select cron.schedule('partman_maintenance', '0 * * * *', $$
-  select partman.run_maintenance(p_analyze := false);
-$$);
-`;
-
   let dialogOpen = true;
   let showConfirmDialog = false;
 
@@ -138,7 +95,7 @@ $$);
 </script>
 
 <FullPageModal
-  title="WAL Projection"
+  title="Create WAL Projection"
   bind:open={dialogOpen}
   bind:showConfirmDialog
   on:close={handleClose}
@@ -148,7 +105,9 @@ $$);
     class="space-y-6 max-w-3xl mx-auto mt-6"
   >
     <Card>
-      <CardHeader></CardHeader>
+      <CardHeader>
+        <CardTitle>Source configuration</CardTitle>
+      </CardHeader>
       <CardContent>
         <p class="mb-4 text-secondary-foreground text-sm" class:hidden={isEdit}>
           With a WAL Projection, you can capture every insert, update, or delete
@@ -162,11 +121,11 @@ $$);
             {pushEvent}
             {databases}
             onSelect={({ databaseId, tableOid }) => {
-              form.sourceDatabaseId = databaseId;
-              form.sourceTableOid = tableOid;
+              form.postgresDatabaseId = databaseId;
+              form.tableOid = tableOid;
             }}
-            selectedDatabaseId={form.sourceDatabaseId}
-            selectedTableOid={form.sourceTableOid}
+            selectedDatabaseId={form.postgresDatabaseId}
+            selectedTableOid={form.tableOid}
           />
 
           {#if selectedSourceTable}
@@ -177,7 +136,7 @@ $$);
               selectedTable={selectedSourceTable}
               bind:form
               {errors}
-              isEditMode={false}
+              isEditMode={isEdit}
               onFilterChange={(filters) => (form.sourceTableFilters = filters)}
             />
           {/if}
@@ -191,82 +150,9 @@ $$);
       </CardHeader>
       <CardContent>
         <div class="space-y-4">
-          <Accordion class="space-y-2" value="instructions" type="single">
-            <AccordionItem value="instructions">
-              <AccordionTrigger class="text-sm font-medium">
-                Don't have an events table yet? See instructions
-              </AccordionTrigger>
-              <AccordionContent>
-                <div class="space-y-4">
-                  <div class="space-y-2">
-                    <Label for="destinationTableName">Desired table name</Label>
-                    <Input
-                      id="destinationTableName"
-                      bind:value={destinationTableName}
-                    />
-                  </div>
-
-                  <div class="space-y-2">
-                    <Label for="retentionDays"
-                      >Desired retention period (days)</Label
-                    >
-                    <Input
-                      type="number"
-                      id="retentionDays"
-                      bind:value={retentionDays}
-                    />
-                  </div>
-
-                  {#if destinationTableName}
-                    <div class="mt-4">
-                      <p class="mb-2">
-                        <strong>Create your event table</strong>
-                      </p>
-                      <p class="mb-2">
-                        Create an event table with the following DDL, including
-                        indexes:
-                      </p>
-                      <CodeWithCopy
-                        language="sql"
-                        code={createTableDDL}
-                        copyIconPosition="top"
-                      />
-                    </div>
-                    <div class="mt-4">
-                      <p class="mb-2">
-                        <strong>Create your retention policy</strong>
-                      </p>
-                      <p class="mb-2">
-                        We recommend using the pg_partman extension to enforce a
-                        retention policy. Here's what it looks like to enforce a
-                        retention of {retentionDays} days:
-                      </p>
-                      <CodeWithCopy
-                        language="sql"
-                        code={retentionPolicyDDL}
-                        copyIconPosition="top"
-                      />
-                    </div>
-                  {/if}
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-
-          <Label>Destination database</Label>
-          <Select bind:value={form.destinationDatabaseId}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select a database" />
-            </SelectTrigger>
-            <SelectContent>
-              {#each databases as database}
-                <SelectItem value={database.id}>{database.name}</SelectItem>
-              {/each}
-            </SelectContent>
-          </Select>
-
-          <Label>Destination Table</Label>
+          <Label>Destination table</Label>
           <TableSelector
+            {pushEvent}
             {databases}
             onSelect={({ databaseId, tableOid }) => {
               form.destinationDatabaseId = databaseId;
@@ -274,6 +160,7 @@ $$);
             }}
             selectedDatabaseId={form.destinationDatabaseId}
             selectedTableOid={form.destinationTableOid}
+            onlyEventTables
           />
         </div>
       </CardContent>
@@ -292,7 +179,7 @@ $$);
           <div class="flex justify-end">
             <Button
               type="submit"
-              disabled={!form.sourceTableOid || !form.destinationTableOid}
+              disabled={!form.tableOid || !form.destinationTableOid}
             >
               {walProjection.id ? "Update" : "Create"} WAL Projection
             </Button>

--- a/assets/svelte/wal_projections/Form.svelte
+++ b/assets/svelte/wal_projections/Form.svelte
@@ -1,0 +1,304 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import * as RadioGroup from "$lib/components/ui/radio-group";
+  import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+  } from "$lib/components/ui/select";
+  import { Checkbox } from "$lib/components/ui/checkbox";
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import TableSelector from "../components/TableSelector.svelte";
+  import CodeWithCopy from "../components/CodeWithCopy.svelte";
+  import SortAndFilterCard from "../components/SortAndFilterCard.svelte";
+  import FullPageModal from "../components/FullPageModal.svelte";
+  import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+  } from "$lib/components/ui/accordion";
+
+  export let walProjection: any;
+  export let databases: any[];
+  export let errors: any = {};
+  export let parent: string;
+  export let isEdit: boolean;
+  export let live;
+
+  const pushEvent = (event, payload = {}, cb = (event: any) => {}) => {
+    return live.pushEventTo("#" + parent, event, payload, cb);
+  };
+
+  let form = {
+    name: walProjection.name || "",
+    status: walProjection.status || "active",
+    sourceDatabaseId: walProjection.sourceDatabaseId || "",
+    destinationDatabaseId: walProjection.destinationDatabaseId || "",
+    sourceTableOid: walProjection.sourceTables?.[0]?.oid || "",
+    destinationTableOid: walProjection.destinationOid || "",
+    sourceTableActions: walProjection.sourceTables?.[0]?.actions || [
+      "insert",
+      "update",
+      "delete",
+    ],
+    sourceTableFilters: walProjection.sourceTables?.[0]?.columnFilters || [],
+  };
+
+  let selectedSourceDatabase: any;
+  let selectedDestinationDatabase: any;
+  let selectedSourceTable: any;
+  let selectedDestinationTable: any;
+  let destinationTableName = "my_events";
+  let retentionDays = 30;
+
+  $: {
+    if (form.sourceDatabaseId) {
+      selectedSourceDatabase = databases.find(
+        (db) => db.id === form.sourceDatabaseId
+      );
+    }
+    if (form.destinationDatabaseId) {
+      selectedDestinationDatabase = databases.find(
+        (db) => db.id === form.destinationDatabaseId
+      );
+    }
+  }
+
+  function handleSubmit() {
+    pushEvent("save", { wal_projection: form });
+  }
+
+  $: pushEvent("validate", { wal_projection: form });
+
+  $: createTableDDL = `
+create table ${destinationTableName ? destinationTableName : "my_events"} (
+  id serial primary key,
+  seq bigint not null,
+  source_database_id uuid not null,
+  source_table_oid bigint not null,
+  record_pk text not null,
+  record jsonb not null,
+  changes jsonb,
+  action text not null,
+  committed_at timestamp with time zone not null,
+  inserted_at timestamp with time zone not null default now()
+);
+
+create unique index on ${destinationTableName} (seq, source_database_id);
+create index on ${destinationTableName} (seq);
+create index on ${destinationTableName} (source_table_oid);
+create index on ${destinationTableName} (committed_at);
+`;
+
+  $: retentionPolicyDDL = `
+-- create required extensions
+create extension if not exists pg_partman;
+create extension if not exists pg_cron;
+
+-- set up pg_partman for time-based partitioning
+select partman.create_parent(
+  p_parent_table => '${destinationTableName}',
+  p_control => 'committed_at',
+  p_type => 'native',
+  p_interval => 'daily',
+  p_premake => 30
+);
+
+-- set up retention policy
+select partman.add_to_part_config(
+  p_parent_table => '${destinationTableName}',
+  p_retention => '${retentionDays} days',
+  p_retention_keep_table => false
+);
+
+-- setup cron job to run maintenance for pg_partman every hour
+-- this is necessary to clean up old partitions (i.e. drop stale data)
+select cron.schedule('partman_maintenance', '0 * * * *', $$
+  select partman.run_maintenance(p_analyze := false);
+$$);
+`;
+
+  let dialogOpen = true;
+  let showConfirmDialog = false;
+
+  function handleClose() {
+    pushEvent("form_closed");
+  }
+</script>
+
+<FullPageModal
+  title="WAL Projection"
+  bind:open={dialogOpen}
+  bind:showConfirmDialog
+  on:close={handleClose}
+>
+  <form
+    on:submit|preventDefault={handleSubmit}
+    class="space-y-6 max-w-3xl mx-auto mt-6"
+  >
+    <Card>
+      <CardHeader></CardHeader>
+      <CardContent>
+        <p class="mb-4 text-secondary-foreground text-sm" class:hidden={isEdit}>
+          With a WAL Projection, you can capture every insert, update, or delete
+          that happens to one or more tables into another table in your
+          database. Then, you can stream these events with Sequin.
+        </p>
+
+        <div class="space-y-4">
+          <Label>Source table</Label>
+          <TableSelector
+            {pushEvent}
+            {databases}
+            onSelect={({ databaseId, tableOid }) => {
+              form.sourceDatabaseId = databaseId;
+              form.sourceTableOid = tableOid;
+            }}
+            selectedDatabaseId={form.sourceDatabaseId}
+            selectedTableOid={form.sourceTableOid}
+          />
+
+          {#if selectedSourceTable}
+            <SortAndFilterCard
+              showCardTitle={false}
+              showTableInfo
+              messageKind="event"
+              selectedTable={selectedSourceTable}
+              bind:form
+              {errors}
+              isEditMode={false}
+              onFilterChange={(filters) => (form.sourceTableFilters = filters)}
+            />
+          {/if}
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Destination configuration</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div class="space-y-4">
+          <Accordion class="space-y-2" value="instructions" type="single">
+            <AccordionItem value="instructions">
+              <AccordionTrigger class="text-sm font-medium">
+                Don't have an events table yet? See instructions
+              </AccordionTrigger>
+              <AccordionContent>
+                <div class="space-y-4">
+                  <div class="space-y-2">
+                    <Label for="destinationTableName">Desired table name</Label>
+                    <Input
+                      id="destinationTableName"
+                      bind:value={destinationTableName}
+                    />
+                  </div>
+
+                  <div class="space-y-2">
+                    <Label for="retentionDays"
+                      >Desired retention period (days)</Label
+                    >
+                    <Input
+                      type="number"
+                      id="retentionDays"
+                      bind:value={retentionDays}
+                    />
+                  </div>
+
+                  {#if destinationTableName}
+                    <div class="mt-4">
+                      <p class="mb-2">
+                        <strong>Create your event table</strong>
+                      </p>
+                      <p class="mb-2">
+                        Create an event table with the following DDL, including
+                        indexes:
+                      </p>
+                      <CodeWithCopy
+                        language="sql"
+                        code={createTableDDL}
+                        copyIconPosition="top"
+                      />
+                    </div>
+                    <div class="mt-4">
+                      <p class="mb-2">
+                        <strong>Create your retention policy</strong>
+                      </p>
+                      <p class="mb-2">
+                        We recommend using the pg_partman extension to enforce a
+                        retention policy. Here's what it looks like to enforce a
+                        retention of {retentionDays} days:
+                      </p>
+                      <CodeWithCopy
+                        language="sql"
+                        code={retentionPolicyDDL}
+                        copyIconPosition="top"
+                      />
+                    </div>
+                  {/if}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+
+          <Label>Destination database</Label>
+          <Select bind:value={form.destinationDatabaseId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a database" />
+            </SelectTrigger>
+            <SelectContent>
+              {#each databases as database}
+                <SelectItem value={database.id}>{database.name}</SelectItem>
+              {/each}
+            </SelectContent>
+          </Select>
+
+          <Label>Destination Table</Label>
+          <TableSelector
+            {databases}
+            onSelect={({ databaseId, tableOid }) => {
+              form.destinationDatabaseId = databaseId;
+              form.destinationTableOid = tableOid;
+            }}
+            selectedDatabaseId={form.destinationDatabaseId}
+            selectedTableOid={form.destinationTableOid}
+          />
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardContent>
+        <div class="space-y-4 my-4">
+          <div class="space-y-2">
+            <Label for="name">WAL Projection name</Label>
+            <Input id="name" bind:value={form.name} />
+            {#if errors.name}
+              <p class="text-red-500 text-sm">{errors.name}</p>
+            {/if}
+          </div>
+          <div class="flex justify-end">
+            <Button
+              type="submit"
+              disabled={!form.sourceTableOid || !form.destinationTableOid}
+            >
+              {walProjection.id ? "Update" : "Create"} WAL Projection
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  </form>
+</FullPageModal>

--- a/assets/svelte/wal_projections/Form.svelte
+++ b/assets/svelte/wal_projections/Form.svelte
@@ -30,6 +30,7 @@
   } from "$lib/components/ui/accordion";
   import { Info } from "lucide-svelte";
   import * as Tooltip from "$lib/components/ui/tooltip";
+  import { cn } from "$lib/utils";
 
   export let walProjection: any;
   export let databases: any[];
@@ -47,14 +48,14 @@
     status: walProjection.status || "active",
     postgresDatabaseId: walProjection.postgresDatabaseId || "",
     destinationDatabaseId: walProjection.destinationDatabaseId || "",
-    tableOid: walProjection.sourceTables?.[0]?.oid || "",
-    destinationTableOid: walProjection.destinationOid || "",
-    sourceTableActions: walProjection.sourceTables?.[0]?.actions || [
+    tableOid: walProjection.tableOid || "",
+    destinationTableOid: walProjection.destinationTableOid || "",
+    sourceTableActions: walProjection.sourceTableActions || [
       "insert",
       "update",
       "delete",
     ],
-    sourceTableFilters: walProjection.sourceTables?.[0]?.columnFilters || [],
+    sourceTableFilters: walProjection.sourceTableFilters || [],
   };
 
   let selectedSourceDatabase: any;
@@ -78,6 +79,11 @@
         (table) => table.oid === form.tableOid
       );
     }
+    if (form.destinationTableOid) {
+      selectedDestinationTable = selectedDestinationDatabase.tables.find(
+        (table) => table.oid === form.destinationTableOid
+      );
+    }
   }
 
   function handleSubmit() {
@@ -95,7 +101,7 @@
 </script>
 
 <FullPageModal
-  title="Create WAL Projection"
+  title={isEdit ? "Edit WAL Projection" : "Create WAL Projection"}
   bind:open={dialogOpen}
   bind:showConfirmDialog
   on:close={handleClose}
@@ -117,16 +123,51 @@
 
         <div class="space-y-4">
           <Label>Source table</Label>
-          <TableSelector
-            {pushEvent}
-            {databases}
-            onSelect={({ databaseId, tableOid }) => {
-              form.postgresDatabaseId = databaseId;
-              form.tableOid = tableOid;
-            }}
-            selectedDatabaseId={form.postgresDatabaseId}
-            selectedTableOid={form.tableOid}
-          />
+          {#if isEdit}
+            <Select
+              disabled
+              selected={{
+                value: form.postgresDatabaseId,
+                label: selectedSourceDatabase?.name || "Selected database",
+              }}
+            >
+              <SelectTrigger
+                class={cn(
+                  "w-full",
+                  "bg-muted text-muted-foreground opacity-100"
+                )}
+              >
+                <SelectValue placeholder="Selected database" />
+              </SelectTrigger>
+            </Select>
+            <Select
+              disabled
+              selected={{
+                value: form.tableOid,
+                label: selectedSourceTable?.name || "Selected table",
+              }}
+            >
+              <SelectTrigger
+                class={cn(
+                  "w-full",
+                  "bg-muted text-muted-foreground opacity-100"
+                )}
+              >
+                <SelectValue placeholder="Selected table" />
+              </SelectTrigger>
+            </Select>
+          {:else}
+            <TableSelector
+              {pushEvent}
+              {databases}
+              onSelect={({ databaseId, tableOid }) => {
+                form.postgresDatabaseId = databaseId;
+                form.tableOid = tableOid;
+              }}
+              selectedDatabaseId={form.postgresDatabaseId}
+              selectedTableOid={form.tableOid}
+            />
+          {/if}
 
           {#if selectedSourceTable}
             <SortAndFilterCard
@@ -151,17 +192,52 @@
       <CardContent>
         <div class="space-y-4">
           <Label>Destination table</Label>
-          <TableSelector
-            {pushEvent}
-            {databases}
-            onSelect={({ databaseId, tableOid }) => {
-              form.destinationDatabaseId = databaseId;
-              form.destinationTableOid = tableOid;
-            }}
-            selectedDatabaseId={form.destinationDatabaseId}
-            selectedTableOid={form.destinationTableOid}
-            onlyEventTables
-          />
+          {#if isEdit}
+            <Select
+              disabled
+              selected={{
+                value: form.destinationDatabaseId,
+                label: selectedDestinationDatabase?.name || "Selected database",
+              }}
+            >
+              <SelectTrigger
+                class={cn(
+                  "w-full",
+                  "bg-muted text-muted-foreground opacity-100"
+                )}
+              >
+                <SelectValue placeholder="Selected database" />
+              </SelectTrigger>
+            </Select>
+            <Select
+              disabled
+              selected={{
+                value: form.destinationTableOid,
+                label: selectedDestinationTable?.name || "Selected table",
+              }}
+            >
+              <SelectTrigger
+                class={cn(
+                  "w-full",
+                  "bg-muted text-muted-foreground opacity-100"
+                )}
+              >
+                <SelectValue placeholder="Selected table" />
+              </SelectTrigger>
+            </Select>
+          {:else}
+            <TableSelector
+              {pushEvent}
+              {databases}
+              onSelect={({ databaseId, tableOid }) => {
+                form.destinationDatabaseId = databaseId;
+                form.destinationTableOid = tableOid;
+              }}
+              selectedDatabaseId={form.destinationDatabaseId}
+              selectedTableOid={form.destinationTableOid}
+              onlyEventTables
+            />
+          {/if}
         </div>
       </CardContent>
     </Card>

--- a/assets/svelte/wal_projections/Index.svelte
+++ b/assets/svelte/wal_projections/Index.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import * as Table from "$lib/components/ui/table";
+  import { Button } from "$lib/components/ui/button";
+  import { formatRelativeTimestamp } from "$lib/utils";
+  import { Logs } from "lucide-svelte";
+  import HealthPill from "../health/HealthPill.svelte";
+
+  export let walProjections: Array<{
+    id: string;
+    name: string;
+    source_table: {
+      schema_name: string;
+      table_name: string;
+    };
+    destination_table: {
+      schema_name: string;
+      table_name: string;
+    };
+    inserted_at: string;
+    health: {
+      status: "healthy" | "warning" | "error" | "initializing";
+    };
+  }>;
+</script>
+
+<div class="container mx-auto py-10">
+  <div class="flex justify-between items-center mb-4">
+    <div class="flex items-center">
+      <Logs class="h-6 w-6 mr-2" />
+      <h1 class="text-2xl font-bold">WAL Projections</h1>
+    </div>
+    {#if walProjections.length > 0}
+      <a
+        href="/wal-projections/new"
+        data-phx-link="redirect"
+        data-phx-link-state="push"
+      >
+        <Button>New WAL Projection</Button>
+      </a>
+    {/if}
+  </div>
+
+  {#if walProjections.length === 0}
+    <div class="w-full rounded-lg border-2 border-dashed border-gray-300">
+      <div class="text-center py-12 w-1/2 mx-auto my-auto">
+        <h2 class="text-xl font-semibold mb-4">No WAL Projections found</h2>
+        <p class="text-gray-600 mb-6">
+          WAL Projections allow you to replicate data from one table to another
+          using the WAL.
+        </p>
+        <a
+          href="/wal-projections/new"
+          data-phx-link="redirect"
+          data-phx-link-state="push"
+        >
+          <Button>Create your first WAL Projection</Button>
+        </a>
+      </div>
+    </div>
+  {:else}
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>Name</Table.Head>
+          <Table.Head>Health</Table.Head>
+          <Table.Head>Source</Table.Head>
+          <Table.Head>Destination</Table.Head>
+          <Table.Head>Created at</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {#each walProjections as projection}
+          <Table.Row
+            class="cursor-pointer"
+            on:click={() => {
+              const url = `/wal-projections/${projection.id}`;
+              window.history.pushState({}, "", url);
+              dispatchEvent(new PopStateEvent("popstate"));
+            }}
+          >
+            <Table.Cell>{projection.name}</Table.Cell>
+            <Table.Cell>
+              <HealthPill status={projection.health.status} />
+            </Table.Cell>
+            <Table.Cell>
+              {projection.source_table.schema_name}.{projection.source_table
+                .table_name}
+            </Table.Cell>
+            <Table.Cell>
+              {projection.destination_table.schema_name}.{projection
+                .destination_table.table_name}
+            </Table.Cell>
+            <Table.Cell>
+              {formatRelativeTimestamp(projection.inserted_at)}
+            </Table.Cell>
+          </Table.Row>
+        {/each}
+      </Table.Body>
+    </Table.Root>
+  {/if}
+</div>

--- a/assets/svelte/wal_projections/Index.svelte
+++ b/assets/svelte/wal_projections/Index.svelte
@@ -35,7 +35,7 @@
         data-phx-link="redirect"
         data-phx-link-state="push"
       >
-        <Button>New WAL Projection</Button>
+        <Button>Create WAL Projection</Button>
       </a>
     {/if}
   </div>

--- a/assets/svelte/wal_projections/Show.svelte
+++ b/assets/svelte/wal_projections/Show.svelte
@@ -32,10 +32,6 @@
   let deleteConfirmDialogLoading = false;
   let deleteErrorMessage: string | null = null;
 
-  function handleEdit() {
-    // TODO: Implement edit functionality
-  }
-
   function handleDelete() {
     showDeleteConfirmDialog = true;
   }
@@ -95,8 +91,13 @@
               >
             </div>
           </div>
-          <Button variant="outline" size="sm" on:click={handleEdit}>Edit</Button
+          <a
+            href="/wal-projections/{walProjection.id}/edit"
+            data-phx-link="redirect"
+            data-phx-link-state="push"
           >
+            <Button variant="outline" size="sm">Edit</Button>
+          </a>
           <Button
             variant="outline"
             size="sm"

--- a/assets/svelte/wal_projections/Show.svelte
+++ b/assets/svelte/wal_projections/Show.svelte
@@ -34,7 +34,6 @@
 
   function handleEdit() {
     // TODO: Implement edit functionality
-    console.log("Edit WAL Projection");
   }
 
   function handleDelete() {

--- a/assets/svelte/wal_projections/Show.svelte
+++ b/assets/svelte/wal_projections/Show.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  import { Button } from "$lib/components/ui/button";
+  import { Card, CardContent } from "$lib/components/ui/card";
+  import {
+    ArrowLeft,
+    Database,
+    ExternalLink,
+    Clock,
+    RefreshCw,
+    Loader2,
+    MoreHorizontal,
+    Logs,
+  } from "lucide-svelte";
+  import { formatRelativeTimestamp, getColorFromName } from "$lib/utils";
+  import * as Dialog from "$lib/components/ui/dialog";
+  import HealthComponent from "$lib/health/HealthComponent.svelte";
+  import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+  } from "$lib/components/ui/table";
+  import * as Popover from "$lib/components/ui/popover";
+
+  export let walProjection;
+  export let live;
+  export let metrics;
+
+  let showDeleteConfirmDialog = false;
+  let deleteConfirmDialogLoading = false;
+  let deleteErrorMessage: string | null = null;
+
+  function handleEdit() {
+    // TODO: Implement edit functionality
+    console.log("Edit WAL Projection");
+  }
+
+  function handleDelete() {
+    showDeleteConfirmDialog = true;
+  }
+
+  function confirmDelete() {
+    deleteConfirmDialogLoading = true;
+    deleteErrorMessage = null;
+    live.pushEvent("delete_wal_projection", {}, (res: any) => {
+      deleteConfirmDialogLoading = false;
+      if (res.error) {
+        deleteErrorMessage = res.error;
+      } else {
+        showDeleteConfirmDialog = false;
+      }
+    });
+  }
+
+  function cancelDelete() {
+    showDeleteConfirmDialog = false;
+    deleteErrorMessage = null;
+  }
+</script>
+
+<div class="min-h-screen font-sans">
+  <div class="bg-white border-b sticky top-0 z-10">
+    <div class="container mx-auto px-4 py-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center space-x-4">
+          <a href="/wal-projections">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft class="h-4 w-4" />
+            </Button>
+          </a>
+          <div class="flex items-center">
+            <Logs class="h-6 w-6 mr-2" />
+            <h1 class="text-xl font-semibold">{walProjection.name}</h1>
+          </div>
+        </div>
+        <div class="flex items-center space-x-4">
+          <div
+            class="hidden lg:flex flex-col items-left gap-1 text-xs text-gray-500"
+          >
+            <div class="flex items-center gap-2">
+              <Clock class="h-4 w-4" />
+              <span
+                >Created {formatRelativeTimestamp(
+                  walProjection.inserted_at
+                )}</span
+              >
+            </div>
+            <div class="flex items-center gap-2">
+              <RefreshCw class="h-4 w-4" />
+              <span
+                >Updated {formatRelativeTimestamp(
+                  walProjection.updated_at
+                )}</span
+              >
+            </div>
+          </div>
+          <Button variant="outline" size="sm" on:click={handleEdit}>Edit</Button
+          >
+          <Button
+            variant="outline"
+            size="sm"
+            class="text-red-600 hover:text-red-700"
+            on:click={handleDelete}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <main class="container mx-auto px-4 py-8">
+    <div class="grid gap-6 md:grid-cols-2 mb-6">
+      <HealthComponent health={walProjection.health} />
+
+      <Card>
+        <CardContent class="p-6">
+          <Popover.Root>
+            <div class="flex justify-between items-center mb-4">
+              <h2 class="text-lg font-semibold">Metrics</h2>
+              <Popover.Trigger asChild let:builder>
+                <Button builders={[builder]} variant="ghost" size="icon">
+                  <MoreHorizontal class="h-4 w-4" />
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content class="w-56">
+                <div class="space-y-2">
+                  <div>
+                    <span class="text-sm text-gray-500">Pending events</span>
+                    <div class="text-lg font-bold">{metrics.count}</div>
+                  </div>
+                  <div>
+                    <span class="text-sm text-gray-500">Earliest pending</span>
+                    <div class="text-sm">{metrics.min ?? "-"}</div>
+                  </div>
+                  <div>
+                    <span class="text-sm text-gray-500"
+                      >Most recent pending</span
+                    >
+                    <div class="text-sm">{metrics.max ?? "-"}</div>
+                  </div>
+                </div>
+              </Popover.Content>
+            </div>
+          </Popover.Root>
+          <div class="space-y-2">
+            <div>
+              <span class="text-sm text-gray-500">Pending events</span>
+              <div
+                class="text-lg font-bold"
+                class:text-green-500={walProjection.health.status === "healthy"}
+              >
+                {metrics.count}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+
+    <Card class="mb-6">
+      <CardContent class="p-6">
+        <h2 class="text-lg font-semibold mb-4">Details</h2>
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <p class="text-sm text-gray-500">Source Database</p>
+            <p class="font-medium">{walProjection.source_database.name}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Source Table</p>
+            <p class="font-medium">{walProjection.source_table}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Destination Database</p>
+            <p class="font-medium">{walProjection.destination_database.name}</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Destination Table</p>
+            <p class="font-medium">{walProjection.destination_table}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardContent class="p-6">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-lg font-semibold">Source table</h2>
+          <a
+            href="/databases/{walProjection.source_database.id}"
+            data-phx-link="redirect"
+            data-phx-link-state="push"
+          >
+            <Button variant="outline" size="sm">
+              <ExternalLink class="h-4 w-4 mr-2" />
+              View Database
+            </Button>
+          </a>
+        </div>
+        <div class="mb-4 flex items-center space-x-2">
+          <Database class="h-5 w-5 text-gray-400" />
+          <pre class="font-medium">{walProjection.source_database.name}</pre>
+        </div>
+        <div class="mb-4 flex items-center space-x-2">
+          <icon
+            class="hero-table-cells w-6 h-6 rounded {getColorFromName(
+              walProjection.source_table
+            )}"
+          ></icon>
+          <pre class="font-medium">{walProjection.source_table}</pre>
+        </div>
+        <div class="mb-4">
+          <h3 class="text-md font-semibold mb-2">Filters</h3>
+          {#if walProjection.source_filters.length > 0}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Column</TableHead>
+                  <TableHead>Operator</TableHead>
+                  <TableHead>Value</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {#each walProjection.source_filters as filter}
+                  <TableRow>
+                    <TableCell><code>{filter.column}</code></TableCell>
+                    <TableCell><code>{filter.operator}</code></TableCell>
+                    <TableCell><code>{filter.value}</code></TableCell>
+                  </TableRow>
+                {/each}
+              </TableBody>
+            </Table>
+          {:else}
+            <div
+              class="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center"
+            >
+              <h4 class="text-sm font-medium text-gray-900 mb-1">
+                No filters applied
+              </h4>
+              <p class="text-sm text-gray-500 mb-4">
+                This WAL Projection will process all data from the source table.
+              </p>
+            </div>
+          {/if}
+        </div>
+      </CardContent>
+    </Card>
+  </main>
+</div>
+
+<Dialog.Root bind:open={showDeleteConfirmDialog}>
+  <Dialog.Content>
+    <Dialog.Header>
+      <Dialog.Title
+        >Are you sure you want to delete this WAL Projection?</Dialog.Title
+      >
+      <Dialog.Description>This action cannot be undone.</Dialog.Description>
+    </Dialog.Header>
+    {#if deleteErrorMessage}
+      <p class="text-destructive text-sm mt-2 mb-4">{deleteErrorMessage}</p>
+    {/if}
+    <Dialog.Footer>
+      <Button variant="outline" on:click={cancelDelete}>Cancel</Button>
+      <Button
+        variant="destructive"
+        on:click={confirmDelete}
+        disabled={deleteConfirmDialogLoading}
+      >
+        {#if deleteConfirmDialogLoading}
+          <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+          Deleting...
+        {:else}
+          Delete
+        {/if}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/lib/sequin/application.ex
+++ b/lib/sequin/application.ex
@@ -5,6 +5,7 @@ defmodule Sequin.Application do
   use Application
 
   alias Sequin.Databases.ConnectionCache
+  alias Sequin.MutexedSupervisor
 
   @impl true
   def start(_type, _args) do
@@ -32,6 +33,7 @@ defmodule Sequin.Application do
   defp children(_) do
     base_children() ++
       [
+        MutexedSupervisor.child_spec(Sequin.ReplicationRuntime.MutexedSupervisor, [Sequin.ReplicationRuntime.Supervisor]),
         Sequin.ReplicationRuntime.Supervisor,
         Sequin.ConsumersRuntime.Supervisor,
         Sequin.DatabasesRuntime.Supervisor,

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -329,6 +329,13 @@ defmodule Sequin.Databases do
     end
   end
 
+  def update_tables!(%PostgresDatabase{} = db) do
+    case update_tables(db) do
+      {:ok, db} -> db
+      {:error, error} -> raise error
+    end
+  end
+
   def list_schemas(%PostgresDatabase{} = database) do
     with_connection(database, &list_schemas/1)
   end

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -65,6 +65,7 @@ defmodule Sequin.Databases.PostgresDatabase do
 
     belongs_to(:account, Sequin.Accounts.Account)
     has_one(:replication_slot, PostgresReplicationSlot, foreign_key: :postgres_database_id)
+    has_many(:wal_projections, through: [:replication_slot, :wal_projections])
 
     timestamps()
   end

--- a/lib/sequin/error.ex
+++ b/lib/sequin/error.ex
@@ -90,6 +90,18 @@ defmodule Sequin.Error do
       |> JSON.decode_atom("service")
       |> JSON.struct(__MODULE__)
     end
+
+    def from_postgrex(summary_prefix \\ "Postgres error: ", %Postgrex.Error{} = error) do
+      pg_code = error.postgres && error.postgres.code
+      message = error.message || (error.postgres && error.postgres.message)
+      code = if pg_code, do: pg_code, else: :postgrex_error
+
+      %__MODULE__{
+        service: :postgres,
+        message: summary_prefix <> message,
+        code: code
+      }
+    end
   end
 
   defmodule TimeoutError do

--- a/lib/sequin/health/health.ex
+++ b/lib/sequin/health/health.ex
@@ -463,4 +463,13 @@ defmodule Sequin.Health do
     new_status = calculate_overall_status(updated_checks)
     %{health | status: new_status, checks: updated_checks}
   end
+
+  @doc """
+  Resets the health for the given entity to initializing.
+  """
+  @spec reset(entity()) :: {:ok, Health.t()} | {:error, Error.t()}
+  def reset(entity) when is_entity(entity) do
+    new_health = initial_health(entity)
+    set_health(entity.id, new_health)
+  end
 end

--- a/lib/sequin/health/health.ex
+++ b/lib/sequin/health/health.ex
@@ -1,8 +1,6 @@
 defmodule Sequin.Health do
   @moduledoc """
   This module tracks the health of various entities in the system.
-
-  Notably, this module does not track the health of `%Resource{}` entities. See `Ix.SyncHealth`.
   """
 
   use TypedStruct

--- a/lib/sequin/health/health.ex
+++ b/lib/sequin/health/health.ex
@@ -187,7 +187,7 @@ defmodule Sequin.Health do
     end
   end
 
-  @wal_projection_checks [:filters, :ingestion, :projection]
+  @wal_projection_checks [:filters, :ingestion, :destination_insert]
   defp expected_check(%WalProjection{}, check_id, status, error) when check_id in @wal_projection_checks do
     case check_id do
       :filters ->
@@ -196,8 +196,14 @@ defmodule Sequin.Health do
       :ingestion ->
         %Check{id: :ingestion, name: "Ingestion", status: status, error: error, created_at: DateTime.utc_now()}
 
-      :projection ->
-        %Check{id: :projection, name: "Projection", status: status, error: error, created_at: DateTime.utc_now()}
+      :destination_insert ->
+        %Check{
+          id: :destination_insert,
+          name: "Destination insert",
+          status: status,
+          error: error,
+          created_at: DateTime.utc_now()
+        }
     end
   end
 
@@ -297,8 +303,8 @@ defmodule Sequin.Health do
         %Check{id: :ingestion} = check ->
           %{check | message: "Ingesting changes from the source table."}
 
-        %Check{id: :projection} = check ->
-          %{check | message: "Projecting changes to the destination table."}
+        %Check{id: :destination_insert} = check ->
+          %{check | message: "Inserting changes to the destination table."}
 
         %Check{} = check ->
           check

--- a/lib/sequin/mutex_owner.ex
+++ b/lib/sequin/mutex_owner.ex
@@ -13,7 +13,7 @@ defmodule Sequin.MutexOwner do
   defmodule State do
     @moduledoc """
     lock_expiry - how long to hold the mutex for when acquired
-    mutex_key/mutex_token - see Ix.Mutex
+    mutex_key/mutex_token - see Sequin.Mutex
     on_acquired - callback that is called when the mutex is acquired
     """
     use TypedStruct
@@ -41,7 +41,7 @@ defmodule Sequin.MutexOwner do
 
   @impl GenStateMachine
   def init(opts) do
-    Logger.metadata(sha: Application.get_env(:ix, :sha))
+    Logger.metadata(sha: Application.get_env(:sequin, :sha), mutex_key: Keyword.fetch!(opts, :mutex_key))
 
     actions = [
       {{:timeout, :acquire_mutex}, 0, nil}
@@ -73,7 +73,7 @@ defmodule Sequin.MutexOwner do
     case acquire_mutex(data) do
       :ok ->
         # just acquired lock
-        Logger.info("MutexOwner just acquired mutex")
+        Logger.info("MutexOwner just acquired mutex for #{data.mutex_key}")
         data.on_acquired.()
 
         actions = [

--- a/lib/sequin/mutexed_supervisor.ex
+++ b/lib/sequin/mutexed_supervisor.ex
@@ -54,7 +54,7 @@ defmodule Sequin.MutexedSupervisor do
   end
 
   def child_spec(id, children) do
-    Supervisor.child_spec({Ix.MutexedSupervisor, name: id, child_specs: children}, id: id)
+    Supervisor.child_spec({Sequin.MutexedSupervisor, name: id, child_specs: children}, id: id)
   end
 
   defp start_children(child_specs, child_supervisor) do

--- a/lib/sequin/replication/message_handler.ex
+++ b/lib/sequin/replication/message_handler.ex
@@ -215,7 +215,7 @@ defmodule Sequin.Replication.MessageHandler do
       wal_projection_id: projection.id,
       commit_lsn: DateTime.to_unix(message.commit_timestamp, :microsecond),
       record_pks: Enum.map(message.ids, &to_string/1),
-      record: fields_to_map(message.fields),
+      record: fields_to_map(get_fields(message)),
       changes: get_changes(message),
       action: message.action,
       committed_at: message.commit_timestamp,
@@ -229,4 +229,8 @@ defmodule Sequin.Replication.MessageHandler do
   end
 
   defp get_changes(_), do: nil
+
+  defp get_fields(%Message{action: :insert} = message), do: message.fields
+  defp get_fields(%Message{action: :update} = message), do: message.fields
+  defp get_fields(%Message{action: :delete} = message), do: message.old_fields
 end

--- a/lib/sequin/replication/replication.ex
+++ b/lib/sequin/replication/replication.ex
@@ -324,11 +324,13 @@ defmodule Sequin.Replication do
 
     {count, _} = Repo.insert_all(WalEvent, events)
 
-    Phoenix.PubSub.broadcast(
-      Sequin.PubSub,
-      "wal_event_inserted:#{wal_projection_id}",
-      {:wal_event_inserted, wal_projection_id}
-    )
+    unless Repo.in_transaction?() do
+      Phoenix.PubSub.broadcast(
+        Sequin.PubSub,
+        "wal_event_inserted:#{wal_projection_id}",
+        {:wal_event_inserted, wal_projection_id}
+      )
+    end
 
     {:ok, count}
   end

--- a/lib/sequin/replication/replication.ex
+++ b/lib/sequin/replication/replication.ex
@@ -184,10 +184,11 @@ defmodule Sequin.Replication do
     |> Repo.all()
   end
 
-  def get_wal_projection_for_account(account_id, id_or_name) do
+  def get_wal_projection_for_account(account_id, id_or_name, preloads \\ []) do
     account_id
     |> WalProjection.where_account_id()
     |> WalProjection.where_id_or_name(id_or_name)
+    |> preload(^preloads)
     |> Repo.one()
   end
 

--- a/lib/sequin/replication/replication.ex
+++ b/lib/sequin/replication/replication.ex
@@ -184,6 +184,13 @@ defmodule Sequin.Replication do
     |> Repo.all()
   end
 
+  def get_wal_projection_for_account(account_id, id_or_name) do
+    account_id
+    |> WalProjection.where_account_id()
+    |> WalProjection.where_id_or_name(id_or_name)
+    |> Repo.one()
+  end
+
   def get_wal_projection(id) do
     case Repo.get(WalProjection, id) do
       nil -> {:error, Error.not_found(entity: :wal_projection)}

--- a/lib/sequin/replication/wal_projection.ex
+++ b/lib/sequin/replication/wal_projection.ex
@@ -26,17 +26,20 @@ defmodule Sequin.Replication.WalProjection do
 
   @doc false
   def create_changeset(wal_projection, attrs) do
-    changeset(wal_projection, attrs)
+    wal_projection
+    |> cast(attrs, [:name, :status, :seq, :replication_slot_id, :destination_oid, :destination_database_id])
+    |> changeset()
   end
 
   @doc false
   def update_changeset(wal_projection, attrs) do
-    changeset(wal_projection, attrs)
+    wal_projection
+    |> cast(attrs, [:name, :status, :seq])
+    |> changeset()
   end
 
-  defp changeset(wal_projection, attrs) do
+  defp changeset(wal_projection) do
     wal_projection
-    |> cast(attrs, [:name, :status, :seq, :replication_slot_id, :destination_oid, :destination_database_id])
     |> Sequin.Changeset.cast_embed(:source_tables)
     |> validate_required([:name, :replication_slot_id, :destination_oid, :destination_database_id])
     |> unique_constraint([:replication_slot_id, :name])

--- a/lib/sequin/replication/wal_projection.ex
+++ b/lib/sequin/replication/wal_projection.ex
@@ -15,6 +15,7 @@ defmodule Sequin.Replication.WalProjection do
 
     embeds_many :source_tables, SourceTable, on_replace: :delete
     belongs_to :replication_slot, Sequin.Replication.PostgresReplicationSlot
+    has_one :source_database, through: [:replication_slot, :postgres_database]
     belongs_to :destination_database, Sequin.Databases.PostgresDatabase
     belongs_to :account, Sequin.Accounts.Account
 

--- a/lib/sequin/replication/wal_projection.ex
+++ b/lib/sequin/replication/wal_projection.ex
@@ -8,6 +8,7 @@ defmodule Sequin.Replication.WalProjection do
   alias Sequin.Consumers.SourceTable
 
   schema "wal_projections" do
+    field :status, Ecto.Enum, values: [:active, :disabled], default: :active
     field :name, :string
     field :seq, :integer
     field :destination_oid, :integer
@@ -32,7 +33,7 @@ defmodule Sequin.Replication.WalProjection do
 
   defp changeset(wal_projection, attrs) do
     wal_projection
-    |> cast(attrs, [:name, :seq, :replication_slot_id, :destination_oid, :destination_database_id])
+    |> cast(attrs, [:name, :status, :seq, :replication_slot_id, :destination_oid, :destination_database_id])
     |> Sequin.Changeset.cast_embed(:source_tables)
     |> validate_required([:name, :replication_slot_id, :destination_oid, :destination_database_id])
     |> unique_constraint([:replication_slot_id, :name])

--- a/lib/sequin/replication/wal_projection.ex
+++ b/lib/sequin/replication/wal_projection.ex
@@ -13,6 +13,8 @@ defmodule Sequin.Replication.WalProjection do
     field :seq, :integer
     field :destination_oid, :integer
 
+    field :health, :map, virtual: true
+
     embeds_many :source_tables, SourceTable, on_replace: :delete
     belongs_to :replication_slot, Sequin.Replication.PostgresReplicationSlot
     has_one :source_database, through: [:replication_slot, :postgres_database]
@@ -40,6 +42,26 @@ defmodule Sequin.Replication.WalProjection do
     |> unique_constraint([:replication_slot_id, :name])
     |> foreign_key_constraint(:replication_slot_id)
     |> foreign_key_constraint(:destination_database_id)
+  end
+
+  def where_account_id(query \\ base_query(), account_id) do
+    from([wal_projection: wp] in query, where: wp.account_id == ^account_id)
+  end
+
+  def where_id_or_name(query \\ base_query(), id_or_name) do
+    if Sequin.String.is_uuid?(id_or_name) do
+      where_id(query, id_or_name)
+    else
+      where_name(query, id_or_name)
+    end
+  end
+
+  def where_id(query \\ base_query(), id) do
+    from([wal_projection: wp] in query, where: wp.id == ^id)
+  end
+
+  def where_name(query \\ base_query(), name) do
+    from([wal_projection: wp] in query, where: wp.name == ^name)
   end
 
   def base_query(query \\ __MODULE__) do

--- a/lib/sequin/replication_runtime/starter.ex
+++ b/lib/sequin/replication_runtime/starter.ex
@@ -37,7 +37,10 @@ defmodule Sequin.ReplicationRuntime.Starter do
   end
 
   defp start do
-    Enum.each(Replication.all_active_pg_replications(), &Supervisor.start_replication(&1.id))
+    Enum.each(Replication.all_active_pg_replications(), fn pg_replication ->
+      Supervisor.start_replication(pg_replication.id)
+      Supervisor.start_wal_event_servers(pg_replication)
+    end)
   end
 
   defp logger_info(msg) do

--- a/lib/sequin/replication_runtime/supervisor.ex
+++ b/lib/sequin/replication_runtime/supervisor.ex
@@ -8,6 +8,8 @@ defmodule Sequin.ReplicationRuntime.Supervisor do
   alias Sequin.Replication.MessageHandler
   alias Sequin.Replication.PostgresReplicationSlot
   alias Sequin.ReplicationRuntime.PostgresReplicationSupervisor
+  alias Sequin.ReplicationRuntime.WalEventServer
+  alias Sequin.ReplicationRuntime.WalEventSupervisor
   alias Sequin.Repo
 
   def start_link(opts) do
@@ -89,10 +91,57 @@ defmodule Sequin.ReplicationRuntime.Supervisor do
     start_replication(supervisor, pg_replication_or_id)
   end
 
+  def start_wal_event_servers(pg_replication) do
+    pg_replication = Repo.preload(pg_replication, :wal_projections)
+
+    pg_replication.wal_projections
+    |> Enum.group_by(fn wp -> {wp.replication_slot_id, wp.destination_oid, wp.destination_database_id} end)
+    |> Enum.each(fn {{replication_slot_id, destination_oid, destination_database_id}, projections} ->
+      start_wal_event_server(replication_slot_id, destination_oid, destination_database_id, projections)
+    end)
+  end
+
+  def start_wal_event_server(replication_slot_id, destination_oid, destination_database_id, projections) do
+    opts = [
+      replication_slot_id: replication_slot_id,
+      destination_oid: destination_oid,
+      destination_database_id: destination_database_id,
+      wal_projection_ids: Enum.map(projections, & &1.id)
+    ]
+
+    Sequin.DynamicSupervisor.start_child(
+      WalEventSupervisor,
+      {WalEventServer, opts}
+    )
+  end
+
+  def stop_wal_event_servers(pg_replication) do
+    pg_replication = Repo.preload(pg_replication, :wal_projections)
+
+    pg_replication.wal_projections
+    |> Enum.group_by(fn wp -> {wp.replication_slot_id, wp.destination_oid, wp.destination_database_id} end)
+    |> Enum.each(fn {{replication_slot_id, destination_oid, destination_database_id}, _} ->
+      stop_wal_event_server(replication_slot_id, destination_oid, destination_database_id)
+    end)
+  end
+
+  def stop_wal_event_server(replication_slot_id, destination_oid, destination_database_id) do
+    Sequin.DynamicSupervisor.stop_child(
+      WalEventSupervisor,
+      WalEventServer.via_tuple({replication_slot_id, destination_oid, destination_database_id})
+    )
+  end
+
+  def restart_wal_event_servers(pg_replication) do
+    stop_wal_event_servers(pg_replication)
+    start_wal_event_servers(pg_replication)
+  end
+
   defp children do
     [
       Sequin.ReplicationRuntime.Starter,
-      Sequin.DynamicSupervisor.child_spec(name: Sequin.ReplicationRuntime.PostgresReplicationSupervisor)
+      Sequin.DynamicSupervisor.child_spec(name: Sequin.ReplicationRuntime.PostgresReplicationSupervisor),
+      Sequin.DynamicSupervisor.child_spec(name: WalEventSupervisor)
     ]
   end
 end

--- a/lib/sequin_web/live/databases/show.ex
+++ b/lib/sequin_web/live/databases/show.ex
@@ -166,14 +166,23 @@ defmodule SequinWeb.DatabasesLive.Show do
 
   @impl Phoenix.LiveView
   def render(assigns) do
+    active_tab =
+      case assigns.live_action do
+        :messages -> "messages"
+        :wal_projections -> "wal_projections"
+        _ -> "overview"
+      end
+
     assigns =
-      assign(assigns, :parent, "database-show")
+      assigns
+      |> assign(:parent, "database-show")
+      |> assign(:active_tab, active_tab)
 
     ~H"""
     <div id={@parent}>
       <.svelte
         name="databases/ShowHeader"
-        props={%{database: encode_database(@database), parent: @parent, live_action: @live_action}}
+        props={%{database: encode_database(@database), parent: @parent, activeTab: @active_tab}}
       />
       <%= case @live_action do %>
         <% :edit -> %>

--- a/lib/sequin_web/live/wal_projections/form.ex
+++ b/lib/sequin_web/live/wal_projections/form.ex
@@ -1,0 +1,293 @@
+defmodule SequinWeb.WalProjectionsLive.Form do
+  @moduledoc false
+  use SequinWeb, :live_view
+
+  alias Sequin.Consumers.SourceTable.ColumnFilter
+  alias Sequin.Databases
+  alias Sequin.Databases.PostgresDatabase.Table
+  alias Sequin.Error
+  alias Sequin.Name
+  alias Sequin.Postgres
+  alias Sequin.Posthog
+  alias Sequin.Replication
+  alias Sequin.Replication.WalProjection
+
+  require Logger
+
+  @impl Phoenix.LiveView
+  def mount(params, _session, socket) do
+    wal_projection_id = Map.get(params, "id")
+    is_edit = not is_nil(wal_projection_id)
+    socket = assign_databases(socket)
+
+    case fetch_or_build_wal_projection(socket, wal_projection_id) do
+      {:ok, wal_projection} ->
+        {:ok,
+         socket
+         |> assign(wal_projection: wal_projection)
+         |> assign(is_edit: is_edit)
+         |> assign(show_errors?: false)
+         |> assign(submit_error: nil)
+         |> assign_changeset(%{})}
+
+      {:error, _reason} ->
+        {:ok, push_navigate(socket, to: ~p"/wal-projections")}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    encoded_errors =
+      if assigns.show_errors? do
+        encode_errors(assigns.changeset)
+      else
+        %{}
+      end
+
+    assigns =
+      assign(assigns, :encoded_errors, encoded_errors)
+
+    dbg(assigns.databases)
+
+    ~H"""
+    <div id="wal-projection-form">
+      <.svelte
+        name="wal_projections/Form"
+        props={
+          %{
+            walProjection: encode_wal_projection(assigns),
+            databases: Enum.map(assigns.databases, &encode_database/1),
+            errors: @encoded_errors,
+            parent: "wal-projection-form",
+            isEdit: @is_edit
+          }
+        }
+      />
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", %{"wal_projection" => params}, socket) do
+    params =
+      params
+      |> decode_params()
+      |> maybe_put_replication_slot_id(socket)
+
+    {:noreply, assign_changeset(socket, params)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("save", %{"wal_projection" => params}, socket) do
+    params =
+      params
+      |> decode_params()
+      |> maybe_put_replication_slot_id(socket)
+
+    socket = assign_changeset(socket, params)
+
+    if socket.assigns.changeset.valid? do
+      case create_or_update_wal_projection(socket, socket.assigns.wal_projection, params) do
+        {:ok, wal_projection} ->
+          {:noreply,
+           socket
+           |> put_flash(:toast, %{kind: :info, title: "WAL Projection saved successfully"})
+           |> push_navigate(to: ~p"/wal-projections/#{wal_projection.id}")}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:noreply, assign(socket, changeset: changeset, show_errors?: true)}
+
+          # {:error, error} ->
+          #   {:noreply, assign(socket, submit_error: error_msg(error), show_errors: true)}
+      end
+    else
+      {:noreply, assign(socket, show_errors?: true)}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("refresh_databases", _params, socket) do
+    {:noreply, assign_databases(socket)}
+  end
+
+  def handle_event("refresh_tables", %{"database_id" => database_id}, socket) do
+    with index when not is_nil(index) <- Enum.find_index(socket.assigns.databases, &(&1.id == database_id)),
+         database = Enum.at(socket.assigns.databases, index),
+         {:ok, updated_database} <- Databases.update_tables(database) do
+      updated_databases = List.replace_at(socket.assigns.databases, index, updated_database)
+      {:noreply, assign(socket, databases: updated_databases)}
+    else
+      _ ->
+        {:noreply, put_flash(socket, :toast, %{kind: :error, title: "Failed to refresh tables"})}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("form_closed", _params, socket) do
+    socket =
+      if socket.assigns.is_edit? do
+        push_navigate(socket, to: ~p"/wal-projections/#{socket.assigns.wal_projection.id}")
+      else
+        push_navigate(socket, to: ~p"/wal-projections")
+      end
+
+    {:noreply, socket}
+  end
+
+  defp assign_databases(socket) do
+    databases = Databases.list_dbs_for_account(current_account_id(socket), [:replication_slot])
+    assign(socket, databases: databases)
+  end
+
+  defp fetch_or_build_wal_projection(%{assigns: %{databases: []}} = socket, nil) do
+    {:ok, %WalProjection{account_id: current_account_id(socket)}}
+  end
+
+  defp fetch_or_build_wal_projection(%{assigns: %{databases: [db | _rest]}} = socket, nil) do
+    {:ok, %WalProjection{account_id: current_account_id(socket), replication_slot: db.replication_slot}}
+  end
+
+  defp fetch_or_build_wal_projection(socket, wal_projection_id) do
+    Replication.get_wal_projection_for_account(current_account_id(socket), wal_projection_id, [
+      :replication_slot,
+      :source_database
+    ])
+  end
+
+  defp create_or_update_wal_projection(socket, wal_projection, params) do
+    account_id = current_account_id(socket)
+
+    case_result =
+      if wal_projection.id do
+        Replication.update_wal_projection_with_lifecycle(wal_projection, params)
+      else
+        Replication.create_wal_projection_with_lifecycle(account_id, params)
+      end
+
+    case case_result do
+      {:ok, updated_wal_projection} ->
+        action = if wal_projection.id, do: "Updated", else: "Created"
+
+        Posthog.capture("WAL Projection #{action}", %{
+          distinct_id: current_user_id(socket),
+          properties: %{
+            wal_projection_id: updated_wal_projection.id,
+            wal_projection_name: updated_wal_projection.name,
+            "$groups": %{account: updated_wal_projection.account_id}
+          }
+        })
+
+        {:ok, updated_wal_projection}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+
+      {:error, error} ->
+        Logger.error("Error creating/updating WAL Projection: #{inspect(error)}")
+        {:error, "An unexpected error occurred. Please try again."}
+    end
+  end
+
+  defp decode_params(form) do
+    source_table_actions = form["sourceTableActions"] || []
+
+    %{
+      "name" => form["name"],
+      "status" => form["status"],
+      "source_database_id" => form["sourceDatabaseId"],
+      "destination_database_id" => form["destinationDatabaseId"],
+      "destination_oid" => form["destinationTableOid"],
+      "source_tables" => [
+        %{
+          "oid" => form["sourceTableOid"],
+          "column_filters" => Enum.map(form["sourceTableFilters"], &ColumnFilter.from_external/1),
+          "actions" => source_table_actions
+        }
+      ]
+    }
+  end
+
+  defp maybe_put_replication_slot_id(%{"source_database_id" => nil} = params, _socket) do
+    params
+  end
+
+  defp maybe_put_replication_slot_id(%{"source_database_id" => source_database_id} = params, socket) do
+    case Enum.find(socket.assigns.databases, &(&1.id == source_database_id)) do
+      %_{replication_slot: replication_slot} ->
+        Map.put(params, "replication_slot_id", replication_slot.id)
+
+      _ ->
+        Map.merge(params, %{"replication_slot_id" => nil, "source_database_id" => nil})
+    end
+  end
+
+  defp encode_wal_projection(assigns) do
+    wal_projection = assigns.wal_projection
+    source_table = List.first(wal_projection.source_tables || [])
+    replication_slot = Ecto.Changeset.get_field(assigns.changeset, :replication_slot)
+
+    %{
+      "id" => wal_projection.id,
+      "name" => wal_projection.name || Name.generate(999),
+      "status" => wal_projection.status,
+      "sourceDatabaseId" => replication_slot && replication_slot.postgres_database_id,
+      "sourceTableOid" => source_table && source_table.oid,
+      "destinationDatabaseId" => wal_projection.destination_database_id,
+      "destinationTableOid" => wal_projection.destination_oid,
+      "sourceTableActions" => (source_table && source_table.actions) || [:insert, :update, :delete],
+      "sourceTableFilters" => source_table && Enum.map(source_table.column_filters, &ColumnFilter.to_external/1),
+      "retentionDays" => 30
+    }
+  end
+
+  defp encode_database(database) do
+    %{
+      "id" => database.id,
+      "name" => database.name,
+      "tables" =>
+        Enum.map(database.tables, fn %Table{} = table ->
+          %{
+            "oid" => table.oid,
+            "schema" => table.schema,
+            "name" => table.name,
+            "columns" =>
+              Enum.map(table.columns, fn %Table.Column{} = column ->
+                %{
+                  "attnum" => column.attnum,
+                  "isPk?" => column.is_pk?,
+                  "name" => column.name,
+                  "type" => column.type,
+                  "filterType" => Postgres.pg_simple_type_to_filter_type(column.type)
+                }
+              end)
+          }
+        end)
+    }
+  end
+
+  defp encode_errors(%Ecto.Changeset{} = changeset) do
+    Error.errors_on(changeset)
+  end
+
+  defp assign_changeset(socket, params) do
+    wal_projection = socket.assigns.wal_projection
+
+    changeset =
+      if socket.assigns.is_edit do
+        WalProjection.update_changeset(wal_projection, params)
+      else
+        WalProjection.create_changeset(wal_projection, params)
+      end
+
+    assign(socket, :changeset, changeset)
+  end
+
+  # defp error_msg(error) do
+  #   case error do
+  #     {:error, error} -> error_msg(error)
+  #     %Ecto.Changeset{} -> "Invalid params. Please check the errors below."
+  #     error when is_binary(error) -> error
+  #     _ -> "An unexpected error occurred. Please try again."
+  #   end
+  # end
+end

--- a/lib/sequin_web/live/wal_projections/form.ex
+++ b/lib/sequin_web/live/wal_projections/form.ex
@@ -122,7 +122,7 @@ defmodule SequinWeb.WalProjectionsLive.Form do
   @impl Phoenix.LiveView
   def handle_event("form_closed", _params, socket) do
     socket =
-      if socket.assigns.is_edit? do
+      if socket.assigns.is_edit do
         push_navigate(socket, to: ~p"/wal-projections/#{socket.assigns.wal_projection.id}")
       else
         push_navigate(socket, to: ~p"/wal-projections")
@@ -150,10 +150,11 @@ defmodule SequinWeb.WalProjectionsLive.Form do
   end
 
   defp fetch_or_build_wal_projection(socket, wal_projection_id) do
-    Replication.get_wal_projection_for_account(current_account_id(socket), wal_projection_id, [
-      :replication_slot,
-      :source_database
-    ])
+    {:ok,
+     Replication.get_wal_projection_for_account(current_account_id(socket), wal_projection_id, [
+       :replication_slot,
+       :source_database
+     ])}
   end
 
   defp create_or_update_wal_projection(socket, wal_projection, params) do

--- a/lib/sequin_web/live/wal_projections/index.ex
+++ b/lib/sequin_web/live/wal_projections/index.ex
@@ -1,0 +1,66 @@
+# lib/sequin_web/live/wal_projections/index.ex
+defmodule SequinWeb.WalProjectionsLive.Index do
+  @moduledoc false
+  use SequinWeb, :live_view
+
+  alias Sequin.Databases
+  alias Sequin.Repo
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    account_id = current_account_id(socket)
+    databases = Databases.list_dbs_for_account(account_id)
+
+    wal_projections =
+      Enum.flat_map(databases, fn database ->
+        Repo.preload(database, wal_projections: [:destination_database, :source_database]).wal_projections
+      end)
+
+    {:ok, assign(socket, :wal_projections, wal_projections)}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div id="wal-projections-index">
+      <.svelte
+        name="wal_projections/Index"
+        props={
+          %{
+            walProjections: encode_wal_projections(@wal_projections)
+          }
+        }
+      />
+    </div>
+    """
+  end
+
+  defp encode_wal_projections(wal_projections) do
+    Enum.map(wal_projections, fn projection ->
+      [%{oid: source_table_oid}] = projection.source_tables
+      {:ok, destination_tables} = Databases.tables(projection.destination_database)
+      {:ok, source_tables} = Databases.tables(projection.source_database)
+
+      destination_table =
+        case Enum.find(destination_tables, &(&1.oid == projection.destination_oid)) do
+          nil -> nil
+          table -> %{table_name: table.name, schema_name: table.schema}
+        end
+
+      source_table =
+        case Enum.find(source_tables, &(&1.oid == source_table_oid)) do
+          nil -> nil
+          table -> %{table_name: table.name, schema_name: table.schema}
+        end
+
+      %{
+        id: projection.id,
+        name: projection.name,
+        source_table: source_table,
+        destination_table: destination_table,
+        inserted_at: projection.inserted_at,
+        health: %{status: :healthy}
+      }
+    end)
+  end
+end

--- a/lib/sequin_web/live/wal_projections/show.ex
+++ b/lib/sequin_web/live/wal_projections/show.ex
@@ -1,0 +1,141 @@
+# lib/sequin_web/live/wal_projections/show.ex
+defmodule SequinWeb.WalProjectionsLive.Show do
+  @moduledoc false
+  use SequinWeb, :live_view
+
+  alias Sequin.Consumers.SourceTable.ColumnFilter
+  alias Sequin.Databases
+  alias Sequin.Health
+  alias Sequin.Replication
+  alias Sequin.Repo
+
+  @impl Phoenix.LiveView
+  def mount(%{"id" => id}, _session, socket) do
+    account_id = current_account_id(socket)
+
+    case Replication.get_wal_projection_for_account(account_id, id) do
+      nil ->
+        {:ok, push_navigate(socket, to: ~p"/wal-projections")}
+
+      wal_projection ->
+        wal_projection = Repo.preload(wal_projection, [:source_database, :destination_database])
+
+        socket =
+          socket
+          |> assign(:wal_projection, wal_projection)
+          |> assign_health()
+          |> assign_metrics()
+
+        if connected?(socket) do
+          Process.send_after(self(), :update_health, 1000)
+          Process.send_after(self(), :update_metrics, 1500)
+        end
+
+        {:ok, socket}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("delete_wal_projection", _, socket) do
+    case Replication.delete_wal_projection(socket.assigns.wal_projection) do
+      {:ok, _} ->
+        {:noreply, push_navigate(socket, to: ~p"/wal-projections")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to delete WAL Projection")}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info(:update_health, socket) do
+    Process.send_after(self(), :update_health, 10_000)
+    {:noreply, assign_health(socket)}
+  end
+
+  def handle_info(:update_metrics, socket) do
+    Process.send_after(self(), :update_metrics, 10_000)
+    {:noreply, assign_metrics(socket)}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div id="wal-projection-show">
+      <.svelte
+        name="wal_projections/Show"
+        props={
+          %{
+            walProjection: encode_wal_projection(@wal_projection),
+            metrics: encode_metrics(@metrics)
+          }
+        }
+      />
+    </div>
+    """
+  end
+
+  defp assign_health(socket) do
+    wal_projection = socket.assigns.wal_projection
+
+    case Health.get(wal_projection) do
+      {:ok, health} ->
+        assign(socket, :wal_projection, %{wal_projection | health: health})
+
+      {:error, _} ->
+        socket
+    end
+  end
+
+  defp assign_metrics(socket) do
+    wal_projection = socket.assigns.wal_projection
+    metrics = Replication.wal_events_metrics(wal_projection.id)
+    assign(socket, :metrics, metrics)
+  end
+
+  defp encode_metrics(metrics) do
+    %{
+      min: metrics.min,
+      max: metrics.max,
+      count: metrics.count
+    }
+  end
+
+  defp encode_wal_projection(wal_projection) do
+    {:ok, source_tables} = Databases.tables(wal_projection.source_database)
+    {:ok, destination_tables} = Databases.tables(wal_projection.destination_database)
+
+    [source_table] = wal_projection.source_tables
+    source_table_info = Enum.find(source_tables, &(&1.oid == source_table.oid))
+    destination_table_info = Enum.find(destination_tables, &(&1.oid == wal_projection.destination_oid))
+
+    %{
+      id: wal_projection.id,
+      name: wal_projection.name,
+      status: wal_projection.status,
+      source_database: %{
+        id: wal_projection.source_database.id,
+        name: wal_projection.source_database.name
+      },
+      destination_database: %{
+        id: wal_projection.destination_database.id,
+        name: wal_projection.destination_database.name
+      },
+      source_table: "#{source_table_info.schema}.#{source_table_info.name}",
+      source_filters: encode_source_filters(source_table.column_filters),
+      destination_table: "#{destination_table_info.schema}.#{destination_table_info.name}",
+      inserted_at: wal_projection.inserted_at,
+      updated_at: wal_projection.updated_at,
+      health: Health.to_external(wal_projection.health)
+    }
+  end
+
+  defp encode_source_filters(column_filters) do
+    Enum.map(column_filters, fn filter ->
+      %{
+        column: filter.column_name,
+        operator: ColumnFilter.to_external_operator(filter.operator),
+        value: filter.value.value
+      }
+    end)
+  end
+end

--- a/lib/sequin_web/live/wal_projections/show.ex
+++ b/lib/sequin_web/live/wal_projections/show.ex
@@ -37,7 +37,7 @@ defmodule SequinWeb.WalProjectionsLive.Show do
 
   @impl Phoenix.LiveView
   def handle_event("delete_wal_projection", _, socket) do
-    case Replication.delete_wal_projection(socket.assigns.wal_projection) do
+    case Replication.delete_wal_projection_with_lifecycle(socket.assigns.wal_projection) do
       {:ok, _} ->
         {:noreply, push_navigate(socket, to: ~p"/wal-projections")}
 

--- a/lib/sequin_web/router.ex
+++ b/lib/sequin_web/router.ex
@@ -99,6 +99,11 @@ defmodule SequinWeb.Router do
       live "/http-endpoints/:id", HttpEndpointsLive.Show, :show
       live "/http-endpoints/:id/edit", HttpEndpointsLive.Form, :edit
 
+      live "/wal-projections", WalProjectionsLive.Index, :index
+      live "/wal-projections/new", WalProjectionsLive.Form, :new
+      live "/wal-projections/:id", WalProjectionsLive.Show, :show
+      live "/wal-projections/:id/edit", WalProjectionsLive.Form, :edit
+
       live "/logout", UserLogoutLive, :index
 
       get "/easter-egg", EasterEggController, :home
@@ -137,21 +142,6 @@ defmodule SequinWeb.Router do
     get("/http_pull_consumers/:id_or_name/receive", PullController, :receive)
     post("/http_pull_consumers/:id_or_name/ack", PullController, :ack)
     post("/http_pull_consumers/:id_or_name/nack", PullController, :nack)
-    post("/streams/:stream_id_or_name/messages", MessageController, :publish)
-    get("/streams/:stream_id_or_name/messages", MessageController, :stream_list)
-    get("/streams/:stream_id_or_name/messages/:key", MessageController, :stream_get)
-
-    get(
-      "/streams/:stream_id_or_name/messages/:key/consumer_info",
-      MessageController,
-      :message_consumer_info
-    )
-
-    get(
-      "/streams/:stream_id_or_name/consumers/:consumer_id_or_name/messages",
-      MessageController,
-      :consumer_list
-    )
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20241004200622_create_wal_projections_and_events.exs
+++ b/priv/repo/migrations/20241004200622_create_wal_projections_and_events.exs
@@ -5,8 +5,11 @@ defmodule Sequin.Repo.Migrations.CreateWalProjections do
 
   @stream_schema Application.compile_env(:sequin, [Sequin.Repo, :stream_schema_prefix])
   def up do
+    execute "CREATE TYPE #{@config_schema}.wal_projection_status AS ENUM ('active', 'disabled');"
+
     create table(:wal_projections, prefix: @config_schema) do
       add :name, :string, null: false
+      add :status, :"#{@config_schema}.wal_projection_status", null: false
       add :seq, :integer, null: false
       add :source_tables, {:array, :jsonb}, null: false, default: "{}"
       add :destination_oid, :bigint

--- a/test/sequin/message_handler_test.exs
+++ b/test/sequin/message_handler_test.exs
@@ -213,7 +213,7 @@ defmodule Sequin.MessageHandlerTest do
     end
 
     test "inserts wal_event for wal_projection with matching source table and no filters" do
-      message = ReplicationFactory.postgres_message(table_oid: 123, action: :insert)
+      message = ReplicationFactory.postgres_message(table_oid: 123)
       source_table = ConsumersFactory.source_table(oid: 123, column_filters: [])
       wal_projection = ReplicationFactory.insert_wal_projection!(source_tables: [source_table])
       context = %MessageHandler.Context{wal_projections: [wal_projection]}
@@ -238,7 +238,7 @@ defmodule Sequin.MessageHandlerTest do
     end
 
     test "inserts wal_event for projection with matching source table and passing filters" do
-      message = ReplicationFactory.postgres_message(table_oid: 123, action: :insert)
+      message = ReplicationFactory.postgres_message(table_oid: 123)
 
       column_filter =
         ConsumersFactory.column_filter(
@@ -251,7 +251,7 @@ defmodule Sequin.MessageHandlerTest do
       wal_projection = ReplicationFactory.insert_wal_projection!(source_tables: [source_table])
 
       test_field = ReplicationFactory.field(column_attnum: 1, value: "test")
-      message = %{message | fields: [test_field | message.fields]}
+      message = %{message | fields: [test_field | message.fields], old_fields: [test_field | message.old_fields]}
 
       context = %MessageHandler.Context{wal_projections: [wal_projection]}
 

--- a/test/sequin/wal_event_server_test.exs
+++ b/test/sequin/wal_event_server_test.exs
@@ -47,9 +47,13 @@ defmodule Sequin.ReplicationRuntime.WalEventServerTest do
       Health.update(wal_projection, :filters, :healthy)
       Health.update(wal_projection, :ingestion, :healthy)
 
+      commit_lsn = ReplicationFactory.commit_lsn()
+
       # Insert some WAL events
       wal_events =
-        Enum.map(1..5, fn _ -> ReplicationFactory.insert_wal_event!(wal_projection_id: wal_projection.id) end)
+        Enum.map(1..5, fn _ ->
+          ReplicationFactory.insert_wal_event!(wal_projection_id: wal_projection.id, commit_lsn: commit_lsn)
+        end)
 
       start_supervised!(
         {WalEventServer,

--- a/test/support/factory/replication_factory.ex
+++ b/test/support/factory/replication_factory.ex
@@ -187,7 +187,8 @@ defmodule Sequin.Factory.ReplicationFactory do
         replication_slot_id: Factory.uuid(),
         destination_oid: Factory.unique_integer(),
         destination_database_id: Factory.uuid(),
-        account_id: Factory.uuid()
+        account_id: Factory.uuid(),
+        status: Factory.one_of([:active, :disabled])
       },
       attrs
     )

--- a/test/support/factory/replication_factory.ex
+++ b/test/support/factory/replication_factory.ex
@@ -13,6 +13,8 @@ defmodule Sequin.Factory.ReplicationFactory do
   alias Sequin.Replication.WalProjection
   alias Sequin.Repo
 
+  def commit_lsn, do: Factory.unique_integer()
+
   def postgres_replication(attrs \\ []) do
     attrs = Map.new(attrs)
 
@@ -249,7 +251,7 @@ defmodule Sequin.Factory.ReplicationFactory do
     merge_attributes(
       %WalEvent{
         wal_projection_id: Factory.uuid(),
-        commit_lsn: Factory.integer(),
+        commit_lsn: Factory.unique_integer(),
         record_pks: record_pks,
         record: %{"column" => Factory.word()},
         changes: if(action == :update, do: %{"column" => Factory.word()}),

--- a/test/support/models/test_event_log.ex
+++ b/test/support/models/test_event_log.ex
@@ -28,6 +28,10 @@ defmodule Sequin.Test.Support.Models.TestEventLog do
     from(tel in query, where: tel.source_table_oid == ^source_table_oid)
   end
 
+  def table_name do
+    "test_event_logs"
+  end
+
   def column_attnums do
     from(pg in "pg_attribute",
       where: pg.attrelid == ^table_oid() and pg.attnum > 0,

--- a/test/support/models/test_event_log.ex
+++ b/test/support/models/test_event_log.ex
@@ -6,7 +6,9 @@ defmodule Sequin.Test.Support.Models.TestEventLog do
 
   alias Sequin.Postgres
 
+  @primary_key false
   schema "test_event_logs" do
+    field :id, :integer, primary_key: true
     field :seq, :integer
     field :source_database_id, Ecto.UUID
     field :source_table_oid, :integer

--- a/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
+++ b/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
@@ -52,7 +52,8 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
       timestamps()
     end
 
-    create table(:test_event_logs) do
+    create table(:test_event_logs, primary_key: false) do
+      add :id, :serial, primary_key: true
       add :seq, :bigint, null: false
       add :source_database_id, :uuid, null: false
       add :source_table_oid, :bigint, null: false
@@ -65,6 +66,7 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
     end
 
     create unique_index(:test_event_logs, [:seq, :source_database_id])
+    create index(:test_event_logs, [:seq])
     create index(:test_event_logs, [:source_table_oid])
     create index(:test_event_logs, [:committed_at])
 

--- a/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
+++ b/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
@@ -65,7 +65,7 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
       add :inserted_at, :utc_datetime, null: false, default: fragment("NOW()")
     end
 
-    create unique_index(:test_event_logs, [:seq, :source_database_id])
+    create unique_index(:test_event_logs, [:source_database_id, :seq, :record_pk])
     create index(:test_event_logs, [:seq])
     create index(:test_event_logs, [:source_table_oid])
     create index(:test_event_logs, [:committed_at])


### PR DESCRIPTION
This pull request introduces several changes to improve replication handling and WAL event processing:

1. Added a MutexedSupervisor for Sequin.ReplicationRuntime.Supervisor in the application children.

2. Updated the MutexOwner module to include mutex_key in Logger metadata.

3. Enhanced the Replication module with notifications for WAL projection changes and added functionality to restart WAL event servers.

4. Modified the WalProjection schema to include a status field with :active and :disabled options.

5. Expanded the ReplicationRuntime.Supervisor to manage WAL event servers, including starting, stopping, and restarting them.

6. Updated the database migration to add a status column to the wal_projections table.

7. Adjusted the MessageHandler to handle different message actions (insert, update, delete) when getting fields.

8. Modified test factories and support files to accommodate the new WalProjection status field and updated TestEventLog schema.

9. Improved the test_event_logs table structure by adding a serial primary key and an index on the seq column.

These changes aim to enhance the replication system's flexibility and efficiency in handling WAL events and projections.