### PR TITLE
Add accounts lifecycle

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -8,6 +8,7 @@
         "@intercom/messenger-js-sdk": "^0.0.13",
         "bits-ui": "^0.21.16",
         "clsx": "^2.1.1",
+        "cmdk-sv": "^0.0.18",
         "date-fns": "^3.6.0",
         "live_svelte": "file:../deps/live_svelte",
         "lucide-svelte": "^0.428.0",
@@ -938,6 +939,35 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk-sv": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/cmdk-sv/-/cmdk-sv-0.0.18.tgz",
+      "integrity": "sha512-istixiQSy9Ez/mQ4VXWB69btqNyDZckbd1XFEwR46Vw+n5zjdmvoWAcOTj0uX3FZXtw9ikwLVmfoW2nwwMClRg==",
+      "dependencies": {
+        "bits-ui": "^0.21.12",
+        "nanoid": "^5.0.7"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.1"
+      }
+    },
+    "node_modules/cmdk-sv/node_modules/nanoid": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/code-red": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -18,6 +18,7 @@
     "@intercom/messenger-js-sdk": "^0.0.13",
     "bits-ui": "^0.21.16",
     "clsx": "^2.1.1",
+    "cmdk-sv": "^0.0.18",
     "date-fns": "^3.6.0",
     "live_svelte": "file:../deps/live_svelte",
     "lucide-svelte": "^0.428.0",

--- a/assets/svelte/components/ui/button/index.ts
+++ b/assets/svelte/components/ui/button/index.ts
@@ -15,12 +15,14 @@ const buttonVariants = tv({
       ghost: "hover:bg-accent hover:text-accent-foreground",
       link: "text-primary underline-offset-4 hover:underline",
       magic: "border-input text-blue-600 border-blue-600 bg-background hover:bg-blue-100 hover:text-blue-800 border",
+      settings: "w-full flex flex-row justify-start text-muted hover:text-basis hover:bg-canvasSubtle",
     },
     size: {
       default: "h-10 px-4 py-2",
       sm: "h-9 rounded-md px-3",
       lg: "h-11 rounded-md px-8",
       icon: "h-10 w-10",
+      settings: "h-8 px-1.5 py-2",
     },
   },
   defaultVariants: {

--- a/assets/svelte/components/ui/command/command-dialog.svelte
+++ b/assets/svelte/components/ui/command/command-dialog.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { Dialog as DialogPrimitive } from "bits-ui";
+	import type { Command as CommandPrimitive } from "cmdk-sv";
+	import Command from "./command.svelte";
+	import * as Dialog from "$lib/components/ui/dialog/index.js";
+
+	type $$Props = DialogPrimitive.Props & CommandPrimitive.CommandProps;
+
+	export let open: $$Props["open"] = false;
+	export let value: $$Props["value"] = undefined;
+</script>
+
+<Dialog.Root bind:open {...$$restProps}>
+	<Dialog.Content class="overflow-hidden p-0 shadow-lg">
+		<Command
+			class="[&_[data-cmdk-group-heading]]:text-muted-foreground [&_[data-cmdk-group-heading]]:px-2 [&_[data-cmdk-group-heading]]:font-medium [&_[data-cmdk-group]:not([hidden])_~[data-cmdk-group]]:pt-0 [&_[data-cmdk-group]]:px-2 [&_[data-cmdk-input-wrapper]_svg]:h-5 [&_[data-cmdk-input-wrapper]_svg]:w-5 [&_[data-cmdk-input]]:h-12 [&_[data-cmdk-item]]:px-2 [&_[data-cmdk-item]]:py-3 [&_[data-cmdk-item]_svg]:h-5 [&_[data-cmdk-item]_svg]:w-5"
+			{...$$restProps}
+			bind:value
+		>
+			<slot />
+		</Command>
+	</Dialog.Content>
+</Dialog.Root>

--- a/assets/svelte/components/ui/command/command-empty.svelte
+++ b/assets/svelte/components/ui/command/command-empty.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = CommandPrimitive.EmptyProps;
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<CommandPrimitive.Empty class={cn("py-6 text-center text-sm", className)} {...$$restProps}>
+	<slot />
+</CommandPrimitive.Empty>

--- a/assets/svelte/components/ui/command/command-group.svelte
+++ b/assets/svelte/components/ui/command/command-group.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import { cn } from "$lib/utils.js";
+	type $$Props = CommandPrimitive.GroupProps;
+
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<CommandPrimitive.Group
+	class={cn(
+		"text-foreground [&_[data-cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[data-cmdk-group-heading]]:px-2 [&_[data-cmdk-group-heading]]:py-1.5 [&_[data-cmdk-group-heading]]:text-xs [&_[data-cmdk-group-heading]]:font-medium",
+		className
+	)}
+	{...$$restProps}
+>
+	<slot />
+</CommandPrimitive.Group>

--- a/assets/svelte/components/ui/command/command-input.svelte
+++ b/assets/svelte/components/ui/command/command-input.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import Search from "lucide-svelte/icons/search";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = CommandPrimitive.InputProps;
+
+	let className: string | undefined | null = undefined;
+	export { className as class };
+	export let value: string = "";
+</script>
+
+<div class="flex items-center border-b px-2" data-cmdk-input-wrapper="">
+	<Search class="mr-2 h-4 w-4 shrink-0 opacity-50" />
+	<CommandPrimitive.Input
+		class={cn(
+			"placeholder:text-muted-foreground flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50",
+			className
+		)}
+		{...$$restProps}
+		bind:value
+	/>
+</div>

--- a/assets/svelte/components/ui/command/command-item.svelte
+++ b/assets/svelte/components/ui/command/command-item.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = CommandPrimitive.ItemProps;
+
+	export let asChild = false;
+
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<CommandPrimitive.Item
+	{asChild}
+	class={cn(
+		"aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+		className
+	)}
+	{...$$restProps}
+	let:action
+	let:attrs
+>
+	<slot {action} {attrs} />
+</CommandPrimitive.Item>

--- a/assets/svelte/components/ui/command/command-list.svelte
+++ b/assets/svelte/components/ui/command/command-list.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = CommandPrimitive.ListProps;
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<CommandPrimitive.List
+	class={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+	{...$$restProps}
+>
+	<slot />
+</CommandPrimitive.List>

--- a/assets/svelte/components/ui/command/command-separator.svelte
+++ b/assets/svelte/components/ui/command/command-separator.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = CommandPrimitive.SeparatorProps;
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<CommandPrimitive.Separator class={cn("bg-border -mx-1 h-px", className)} {...$$restProps} />

--- a/assets/svelte/components/ui/command/command-shortcut.svelte
+++ b/assets/svelte/components/ui/command/command-shortcut.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = HTMLAttributes<HTMLSpanElement>;
+
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<span
+	class={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
+	{...$$restProps}
+>
+	<slot />
+</span>

--- a/assets/svelte/components/ui/command/command.svelte
+++ b/assets/svelte/components/ui/command/command.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "cmdk-sv";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = CommandPrimitive.CommandProps;
+
+	export let value: $$Props["value"] = undefined;
+
+	let className: string | undefined | null = undefined;
+	export { className as class };
+</script>
+
+<CommandPrimitive.Root
+	class={cn(
+		"bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+		className
+	)}
+	bind:value
+	{...$$restProps}
+>
+	<slot />
+</CommandPrimitive.Root>

--- a/assets/svelte/components/ui/command/index.ts
+++ b/assets/svelte/components/ui/command/index.ts
@@ -1,0 +1,37 @@
+import { Command as CommandPrimitive } from "cmdk-sv";
+
+import Root from "./command.svelte";
+import Dialog from "./command-dialog.svelte";
+import Empty from "./command-empty.svelte";
+import Group from "./command-group.svelte";
+import Item from "./command-item.svelte";
+import Input from "./command-input.svelte";
+import List from "./command-list.svelte";
+import Separator from "./command-separator.svelte";
+import Shortcut from "./command-shortcut.svelte";
+
+const Loading = CommandPrimitive.Loading;
+
+export {
+	Root,
+	Dialog,
+	Empty,
+	Group,
+	Item,
+	Input,
+	List,
+	Separator,
+	Shortcut,
+	Loading,
+	//
+	Root as Command,
+	Dialog as CommandDialog,
+	Empty as CommandEmpty,
+	Group as CommandGroup,
+	Item as CommandItem,
+	Input as CommandInput,
+	List as CommandList,
+	Separator as CommandSeparator,
+	Shortcut as CommandShortcut,
+	Loading as CommandLoading,
+};

--- a/assets/svelte/settings/AccountSettings.svelte
+++ b/assets/svelte/settings/AccountSettings.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import { Button } from "$lib/components/ui/button";
+  import * as Card from "$lib/components/ui/card";
+  import * as Select from "$lib/components/ui/select";
+  import { Input } from "$lib/components/ui/input";
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Cog } from "lucide-svelte";
+
+  interface Account {
+    id: string;
+    name: string;
+  }
+
+  export let accounts: Account[];
+  export let selectedAccount: Account;
+
+  export let parent: string;
+  export let live;
+
+  let form = { ...selectedAccount };
+  let renameLoading = false;
+  let renameErrorMessage: string | null = null;
+  let showDeleteConfirmDialog = false;
+  let deleteConfirmDialogLoading = false;
+  let deleteErrorMessage: string | null = null;
+  $: renameDisabled = selectedAccount.name === form.name;
+
+  function handleAccountSelect(accountId: string) {
+    live.pushEventTo(`#${parent}`, "change_selected_account", {
+      accountId: accountId,
+    });
+  }
+
+  function handleRenameAccount(event: Event) {
+    event.preventDefault();
+    renameLoading = true;
+    live.pushEventTo(
+      `#${parent}`,
+      "rename_account",
+      {
+        accountId: selectedAccount.id,
+        name: form.name,
+      },
+      (res: any) => {
+        renameLoading = false;
+        if (res.error) {
+          renameErrorMessage = res.error;
+        }
+      }
+    );
+  }
+
+  function handleDeleteAccount() {
+    deleteConfirmDialogLoading = true;
+    deleteErrorMessage = null;
+    live.pushEventTo(
+      `#${parent}`,
+      "delete_account",
+      {
+        accountId: selectedAccount.id,
+      },
+      (res: any) => {
+        deleteConfirmDialogLoading = false;
+        if (res.error) {
+          console.error(res.error);
+          deleteErrorMessage = res.error;
+        } else {
+          showDeleteConfirmDialog = false;
+        }
+      }
+    );
+  }
+</script>
+
+<div>
+  <div class="flex justify-between items-center mb-4">
+    <div class="flex items-center">
+      <Cog class="h-6 w-6 mr-2" />
+      <h1 class="text-2xl font-bold">Account Settings</h1>
+    </div>
+    <Select.Root
+      selected={{ value: selectedAccount.id, label: selectedAccount.name }}
+      onSelectedChange={(event) => handleAccountSelect(event.value)}
+    >
+      <Select.Trigger id="account-select" class="w-[200px]">
+        <Select.Value>{selectedAccount.name}</Select.Value>
+      </Select.Trigger>
+      <Select.Content>
+        {#each accounts as account}
+          <Select.Item value={account.id}>{account.name}</Select.Item>
+        {/each}
+      </Select.Content>
+    </Select.Root>
+  </div>
+
+  <div class="w-full rounded-lg border-2 border-dashed border-gray-300 mb-6">
+    <div class="text-center py-12 w-1/2 mx-auto my-auto">
+      <h2 class="text-xl font-semibold mb-4">Invite your team</h2>
+      <p class="text-gray-600 mb-6">
+        Invite your team to your account to allow them to access your Sequin
+        resources. Coming by the end of October 2024 - send us a note if you
+        want this right away.
+      </p>
+      <a
+        href="/http-endpoints/new"
+        data-phx-link="redirect"
+        data-phx-link-state="push"
+      >
+        <Button disabled>Add a team member</Button>
+      </a>
+    </div>
+  </div>
+
+  <Card.Root class="mb-6">
+    <Card.Header>
+      <Card.Title>Rename Account</Card.Title>
+    </Card.Header>
+    <Card.Content>
+      {#if renameErrorMessage}
+        <p class="text-destructive text-sm mt-2 mb-4">{renameErrorMessage}</p>
+      {/if}
+      <form on:submit={handleRenameAccount} class="flex space-x-4">
+        <Input type="text" bind:value={form.name} />
+        <Button
+          variant="default"
+          type="submit"
+          disabled={renameDisabled}
+          loading={renameLoading}
+        >
+          Rename
+        </Button>
+      </form>
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header>
+      <Card.Title>Delete this account</Card.Title>
+    </Card.Header>
+    <Card.Content>
+      <div class="flex items-center justify-between space-x-4">
+        <p>
+          Permanently delete this account ({selectedAccount.name}). There is no
+          going back.
+        </p>
+        <Button
+          variant="destructive"
+          on:click={() => (showDeleteConfirmDialog = true)}
+        >
+          Delete Account
+        </Button>
+      </div>
+    </Card.Content>
+  </Card.Root>
+</div>
+
+<Dialog.Root bind:open={showDeleteConfirmDialog}>
+  <Dialog.Content>
+    <Dialog.Header>
+      <Dialog.Title>Are you sure you want to delete this Account?</Dialog.Title>
+      <Dialog.Description>This action cannot be undone.</Dialog.Description>
+    </Dialog.Header>
+    {#if deleteErrorMessage}
+      <p class="text-destructive text-sm mt-2 mb-4">{deleteErrorMessage}</p>
+    {/if}
+    <Dialog.Footer>
+      <Button
+        variant="outline"
+        on:click={() => (showDeleteConfirmDialog = false)}
+      >
+        Cancel
+      </Button>
+      <Button
+        variant="destructive"
+        on:click={handleDeleteAccount}
+        disabled={deleteConfirmDialogLoading}
+        loading={deleteConfirmDialogLoading}
+      >
+        Delete
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/lib/sequin/accounts/account.ex
+++ b/lib/sequin/accounts/account.ex
@@ -3,14 +3,20 @@ defmodule Sequin.Accounts.Account do
   use Sequin.ConfigSchema
 
   import Ecto.Changeset
+  import Ecto.Query
 
   alias Sequin.Accounts.Account
-  alias Sequin.Name
+  alias Sequin.Accounts.AccountUser
+
+  @derive {Jason.Encoder, only: [:id, :name, :inserted_at, :updated_at]}
 
   @type id :: String.t()
 
   typed_schema "accounts" do
     field :name, :string
+
+    has_many :accounts_users, AccountUser
+    has_many :users, through: [:accounts_users, :user]
 
     timestamps()
   end
@@ -19,17 +25,42 @@ defmodule Sequin.Accounts.Account do
     account
     |> cast(attrs, [:name])
     |> maybe_put_name()
+    |> validate_required([:name])
+    |> validate_length(:name, max: 80, message: "Account name cannot be longer than 80 characters")
+    |> validate_account_name()
   end
 
   defp maybe_put_name(changeset) do
     if fetch_field!(changeset, :name) do
       changeset
     else
-      put_change(changeset, :name, Name.generate())
+      put_change(changeset, :name, "Personal")
     end
   end
 
-  # defp base_query(query \\ __MODULE__) do
-  #   from(a in query, as: :account)
-  # end
+  defp validate_account_name(changeset) do
+    name = get_field(changeset, :name)
+
+    if is_nil(name) || String.trim(name) == "" do
+      add_error(changeset, :name, "Account name cannot be blank")
+    else
+      changeset
+    end
+  end
+
+  def where_id(query \\ base_query(), id) do
+    from(a in query, where: a.id == ^id)
+  end
+
+  def where_user_id(query \\ base_query(), user_id) do
+    from(a in query,
+      join: au in AccountUser,
+      on: au.account_id == a.id,
+      where: au.user_id == ^user_id
+    )
+  end
+
+  defp base_query(query \\ __MODULE__) do
+    from(a in query, as: :account)
+  end
 end

--- a/lib/sequin/accounts/account_user.ex
+++ b/lib/sequin/accounts/account_user.ex
@@ -1,0 +1,28 @@
+defmodule Sequin.Accounts.AccountUser do
+  @moduledoc """
+  Schema and changeset for the accounts_users join table.
+  """
+  use Sequin.ConfigSchema
+
+  import Ecto.Changeset
+
+  alias Sequin.Accounts.Account
+  alias Sequin.Accounts.User
+
+  @derive {Jason.Encoder, only: [:id, :user_id, :account_id, :current, :inserted_at, :updated_at]}
+
+  typed_schema "accounts_users" do
+    belongs_to :user, User
+    belongs_to :account, Account
+    field :current, :boolean, default: false
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset function for the AccountUser schema.
+  """
+  def changeset(account_user, attrs) do
+    cast(account_user, attrs, [:current])
+  end
+end

--- a/lib/sequin_web/components/layouts/app.html.heex
+++ b/lib/sequin_web/components/layouts/app.html.heex
@@ -1,9 +1,13 @@
 <div class="flex min-h-screen">
-  <SequinWeb.Components.Sidenav.render
-    :if={@show_nav}
-    current_path={@current_path}
-    account_name={@account_name}
-  />
+  <%= if @show_nav do %>
+    <.live_component
+      module={SequinWeb.Components.Sidenav}
+      id="sidenav"
+      current_path={@current_path}
+      current_user={@current_user}
+    />
+  <% end %>
+
   <%= if @no_main do %>
     <.flash_group flash={@flash} />
     <%= @inner_content %>

--- a/lib/sequin_web/components/sidenav.ex
+++ b/lib/sequin_web/components/sidenav.ex
@@ -1,18 +1,86 @@
 defmodule SequinWeb.Components.Sidenav do
+  # Change this line
   @moduledoc false
-  use Phoenix.Component
+  use SequinWeb, :live_component
 
   import LiveSvelte
 
+  alias Sequin.Accounts
+  alias Sequin.Accounts.User
+  alias Sequin.Error
+
+  @impl Phoenix.LiveComponent
+  def handle_event("change_selected_account", %{"accountId" => account_id}, socket) do
+    user = current_user(socket)
+    account = Sequin.Enum.find!(user.accounts, &(&1.id == account_id))
+
+    case Accounts.set_current_account_for_user(user.id, account.id) do
+      {:ok, updated_user} ->
+        {:noreply,
+         socket
+         |> assign(current_user: updated_user)
+         |> push_navigate(to: socket.assigns.current_path)}
+
+      {:error, _changeset} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("create_account", %{"accountName" => account_name}, socket) do
+    user = current_user(socket)
+
+    case create_and_associate_account(account_name, user) do
+      {:ok, user} ->
+        {:noreply,
+         socket
+         |> assign(current_user: user)
+         |> push_navigate(to: socket.assigns.current_path)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        error = Error.validation(changeset: changeset)
+        {:reply, %{error: Error.ValidationError.message(error)}, socket}
+
+      {:error, _} ->
+        {:reply, %{error: "Failed to create account"}, socket}
+    end
+  end
+
+  defp create_and_associate_account(account_name, user) do
+    with {:ok, account} <- Accounts.create_account(%{name: account_name}),
+         {:ok, _account_user} <- Accounts.associate_user_with_account(user, account) do
+      Accounts.set_current_account_for_user(user.id, account.id)
+    else
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
+      error -> error
+    end
+  end
+
   attr :current_path, :string, required: true
-  attr :account_name, :string, required: true
+  attr :current_user, :map, required: true
 
   def render(assigns) do
+    assigns =
+      assigns
+      |> assign(:parent_id, "sidenav")
+      |> assign(:current_account, User.current_account(assigns.current_user))
+
     ~H"""
-    <.svelte
-      name="components/Sidenav"
-      props={%{currentPath: @current_path, accountName: @account_name}}
-    />
+    <div id={@parent_id}>
+      <.svelte
+        name="components/Sidenav"
+        props={
+          %{
+            currentPath: @current_path,
+            currentAccountId: @current_account.id,
+            accountList: Enum.sort_by(@current_user.accounts, & &1.inserted_at, DateTime),
+            currentUser: @current_user,
+            parent: @parent_id
+          }
+        }
+        socket={@socket}
+      />
+    </div>
     """
   end
 end

--- a/lib/sequin_web/live/consumers/index.ex
+++ b/lib/sequin_web/live/consumers/index.ex
@@ -25,7 +25,7 @@ defmodule SequinWeb.ConsumersLive.Index do
           userId: user.id,
           userEmail: user.email,
           userName: user.name,
-          accountId: user.account_id,
+          accountId: account.id,
           accountName: account.name,
           createdAt: user.inserted_at
         })

--- a/lib/sequin_web/live/settings/account_settings_live.ex
+++ b/lib/sequin_web/live/settings/account_settings_live.ex
@@ -1,0 +1,85 @@
+defmodule SequinWeb.Settings.AccountSettingsLive do
+  @moduledoc false
+  use SequinWeb, :live_view
+
+  import LiveSvelte
+
+  alias Sequin.Accounts
+  alias Sequin.Accounts.User
+  alias Sequin.Error
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_event("change_selected_account", %{"accountId" => account_id}, socket) do
+    user = current_user(socket)
+    account = Sequin.Enum.find!(user.accounts, &(&1.id == account_id))
+
+    case Accounts.set_current_account_for_user(user.id, account.id) do
+      {:ok, updated_user} ->
+        {:noreply,
+         socket
+         |> assign(current_user: updated_user)
+         |> push_navigate(to: socket.assigns.current_path)}
+
+      {:error, _changeset} ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("rename_account", %{"accountId" => account_id, "name" => new_name}, socket) do
+    user = current_user(socket)
+    account = Sequin.Enum.find!(user.accounts, &(&1.id == account_id))
+
+    case Accounts.update_account(account, %{name: new_name}) do
+      {:ok, _updated_account} ->
+        {:noreply,
+         socket
+         |> assign(current_user: Accounts.get_user_with_preloads!(user.id))
+         |> push_navigate(to: socket.assigns.current_path)}
+
+      {:error, changeset} ->
+        error = Error.validation(changeset: changeset)
+        {:reply, %{error: Error.ValidationError.message(error)}, socket}
+    end
+  end
+
+  def handle_event("delete_account", %{"accountId" => account_id}, socket) do
+    user = current_user(socket)
+    account = Sequin.Enum.find!(user.accounts, &(&1.id == account_id))
+
+    case Accounts.delete_account_and_account_resources(account, delete_users: false) do
+      {:ok, _deleted_account} ->
+        {:reply, %{ok: true}, push_navigate(socket, to: socket.assigns.current_path)}
+
+      {:error, %Error.InvariantError{} = error} ->
+        {:reply, %{error: error.message}, socket}
+
+      {:error, changeset} ->
+        error = Error.validation(changeset: changeset)
+        {:reply, %{error: Error.ValidationError.message(error)}, socket}
+    end
+  end
+
+  def render(assigns) do
+    assigns = assign(assigns, :parent_id, "account_settings")
+    assigns = assign(assigns, :current_account, User.current_account(assigns.current_user))
+
+    ~H"""
+    <div id={@parent_id}>
+      <.svelte
+        name="settings/AccountSettings"
+        props={
+          %{
+            accounts: Enum.sort_by(@current_user.accounts, & &1.inserted_at, DateTime),
+            selectedAccount: @current_account,
+            parent: @parent_id
+          }
+        }
+        socket={@socket}
+      />
+    </div>
+    """
+  end
+end

--- a/lib/sequin_web/live_helpers.ex
+++ b/lib/sequin_web/live_helpers.ex
@@ -28,16 +28,25 @@ defmodule SequinWeb.LiveHelpers do
     if user && user.impersonating_account do
       user.impersonating_account
     else
-      user && user.account
+      user && User.current_account(user)
     end
   end
 
   @spec current_account_id(Socket.t()) :: Account.id() | nil
   def current_account_id(socket) do
     user = current_user(socket)
-    impersonating_account_id = user && user.impersonating_account && user.impersonating_account.id
 
-    impersonating_account_id || user.account.id
+    cond do
+      user && user.impersonating_account ->
+        user.impersonating_account.id
+
+      user ->
+        current_account = User.current_account(user)
+        current_account && current_account.id
+
+      true ->
+        nil
+    end
   end
 
   def blank?(value) when is_list(value) do

--- a/lib/sequin_web/router.ex
+++ b/lib/sequin_web/router.ex
@@ -72,7 +72,8 @@ defmodule SequinWeb.Router do
     delete "/logout", UserSessionController, :delete
 
     live_session :current_user,
-      on_mount: [{SequinWeb.UserAuth, :mount_current_user}] do
+      on_mount: [{SequinWeb.UserAuth, :mount_current_user}],
+      layout: {SequinWeb.Layouts, :app_no_sidenav} do
       live "/users/confirm/:token", UserConfirmationLive, :edit
       live "/users/confirm", UserConfirmationInstructionsLive, :new
     end
@@ -109,6 +110,8 @@ defmodule SequinWeb.Router do
       get "/easter-egg", EasterEggController, :home
 
       live "/outbox", OutboxLive, :index
+
+      live "/settings/accounts", Settings.AccountSettingsLive, :index
     end
 
     get "/admin/impersonate/:secret", UserSessionController, :impersonate

--- a/priv/repo/migrations/20241003014334_create_users_accounts_and_modify_users_for_many_accounts.exs
+++ b/priv/repo/migrations/20241003014334_create_users_accounts_and_modify_users_for_many_accounts.exs
@@ -1,0 +1,119 @@
+defmodule Sequin.Repo.Migrations.CreateUsersAccountsAndModifyUsers do
+  use Ecto.Migration
+
+  @config_schema Application.compile_env(:sequin, [Sequin.Repo, :config_schema_prefix])
+
+  def up do
+    # 1. Create the accounts_users join table
+    create table(:accounts_users, prefix: @config_schema) do
+      add :user_id, references(:users, on_delete: :delete_all, prefix: @config_schema),
+        null: false
+
+      add :account_id, references(:accounts, on_delete: :delete_all, prefix: @config_schema),
+        null: false
+
+      add :current, :boolean, default: false, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:accounts_users, [:user_id, :account_id], prefix: @config_schema)
+
+    create unique_index(:accounts_users, [:user_id, :current],
+             prefix: @config_schema,
+             where: "current = true",
+             name: "idx_users_current"
+           )
+
+    # 2. Create a function to migrate data and call it
+    execute """
+    INSERT INTO #{@config_schema}.accounts_users (user_id, account_id, current, inserted_at, updated_at)
+    SELECT id, account_id, true, inserted_at, NOW()
+    FROM #{@config_schema}.users
+    WHERE account_id IS NOT NULL
+    """
+
+    # 3. Create a constraint to ensure at least one accounts_users row for a user
+    execute """
+    CREATE OR REPLACE FUNCTION #{@config_schema}.ensure_user_has_account()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM #{@config_schema}.users WHERE id = OLD.user_id) AND
+         (SELECT COUNT(*) FROM #{@config_schema}.accounts_users WHERE user_id = OLD.user_id) = 1 THEN
+        RAISE EXCEPTION 'User must have at least one associated account';
+      END IF;
+      RETURN OLD;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER ensure_user_has_account_trigger
+    BEFORE DELETE ON #{@config_schema}.accounts_users
+    FOR EACH ROW
+    EXECUTE FUNCTION #{@config_schema}.ensure_user_has_account();
+    """
+
+    # 4. Add trigger to prevent updates to account_id and user_id
+    execute """
+    CREATE OR REPLACE FUNCTION #{@config_schema}.prevent_account_user_update()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      IF OLD.account_id != NEW.account_id OR OLD.user_id != NEW.user_id THEN
+        RAISE EXCEPTION 'For security, you cannot change account_id or user_id in accounts_users table.';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER prevent_account_user_update_trigger
+    BEFORE UPDATE ON #{@config_schema}.accounts_users
+    FOR EACH ROW
+    EXECUTE FUNCTION #{@config_schema}.prevent_account_user_update();
+    """
+
+    # 5. Remove the NOT NULL constraint on user.account_id
+    alter table(:users, prefix: @config_schema) do
+      modify :account_id, :uuid, null: true
+    end
+  end
+
+  def down do
+    # Revert the changes in reverse order
+
+    # 6. Update null account_id values in users table
+    execute """
+    UPDATE #{@config_schema}.users u
+    SET account_id = COALESCE(
+      (SELECT account_id FROM #{@config_schema}.accounts_users au
+       WHERE au.user_id = u.id AND au.current = true
+       LIMIT 1),
+      (SELECT account_id FROM #{@config_schema}.accounts_users au
+       WHERE au.user_id = u.id
+       ORDER BY au.inserted_at ASC
+       LIMIT 1)
+    )
+    WHERE u.account_id IS NULL;
+    """
+
+    # 5. Add the NOT NULL constraint back to user.account_id
+    alter table(:users, prefix: @config_schema) do
+      modify :account_id, :uuid, null: false
+    end
+
+    # 4. Remove the trigger and function for preventing updates
+    execute "DROP TRIGGER IF EXISTS prevent_account_user_update_trigger ON #{@config_schema}.accounts_users;"
+    execute "DROP FUNCTION IF EXISTS #{@config_schema}.prevent_account_user_update() CASCADE;"
+
+    # 3. Remove the trigger and function
+    execute "DROP FUNCTION IF EXISTS #{@config_schema}.ensure_user_has_account() CASCADE;"
+    execute "DROP TRIGGER IF EXISTS ensure_user_has_account_trigger ON #{@config_schema}.users;"
+
+    # 2. No need to revert the data migration, as the join table will be dropped
+
+    # 1. Drop the accounts_users table
+    drop table(:accounts_users, prefix: @config_schema)
+  end
+end

--- a/test/support/factory/accounts_factory.ex
+++ b/test/support/factory/accounts_factory.ex
@@ -48,7 +48,6 @@ defmodule Sequin.Factory.AccountsFactory do
         name: "User #{:rand.uniform(1000)}",
         email: email(),
         password: password(),
-        account_id: Factory.uuid(),
         auth_provider: auth_provider,
         auth_provider_id: auth_provider_id,
         inserted_at: Factory.utc_datetime(),
@@ -76,10 +75,10 @@ defmodule Sequin.Factory.AccountsFactory do
 
     changeset =
       if attrs.auth_provider in [:identity, "identity"] do
-        User.registration_changeset(%User{account_id: account_id}, attrs, hash_password: true)
+        User.registration_changeset(%User{}, attrs, hash_password: true)
       else
         User.provider_registration_changeset(
-          %User{account_id: account_id},
+          %User{},
           attrs
         )
       end
@@ -88,5 +87,8 @@ defmodule Sequin.Factory.AccountsFactory do
     |> Repo.insert!()
     # Some tests need to then use the password
     |> Map.put(:password, attrs.password)
+    |> tap(fn user ->
+      Sequin.Accounts.associate_user_with_account(user, %Sequin.Accounts.Account{id: account_id})
+    end)
   end
 end


### PR DESCRIPTION
### TL;DR

Implemented multi-account support for users, allowing them to create and switch between multiple accounts.

### What changed?

- Added a new `users_accounts` join table to support many-to-many relationship between users and accounts
- Modified the `users` table, renaming `account_id` to `current_account_id`
- Updated the Sidenav component to include account switching and creation functionality
- Added a new AccountSettings live view for managing accounts
- Updated various components and functions to work with the new multi-account structure

![CleanShot 2024-10-08 at 14.03.46@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/da9838eb-fed7-4ae2-b890-8036b0e979d1.png)

![CleanShot 2024-10-08 at 14.03.38@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/2a57a37e-e41d-4e4e-8d7d-4f5e5dc386a3.png)

![CleanShot 2024-10-08 at 14.03.56@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/cc663fa8-c3fb-4528-bca4-1d4cab30ded8.png)

