### PR TITLE
Handle empty arrays properly

### DIFF
--- a/lib/sequin/extensions/replication.ex
+++ b/lib/sequin/extensions/replication.ex
@@ -543,6 +543,10 @@ defmodule Sequin.Extensions.Replication do
   defp cast_value("bool", "t"), do: true
   defp cast_value("bool", "f"), do: false
 
+  defp cast_value("_" <> _type, "{}") do
+    []
+  end
+
   defp cast_value("_" <> type, array_string) when is_binary(array_string) do
     array_string
     |> String.trim("{")


### PR DESCRIPTION
Postgres' logical replication does not distinguish between `{}` and `{""}`. Both come through as `{}`.

Here, we add tests for both empty arrays and arrays with empty strings. We expect them to be returned as [].

We fix an issue where `{}` was erroneously processed as `{""}`.

https://chatgpt.com/c/67073168-6904-8006-b82e-df2a5c4ce2eb