### PR TITLE
Auto-create replication slots for Neon databases

### DIFF
--- a/lib/sequin/databases/create_replication_slot_worker.ex
+++ b/lib/sequin/databases/create_replication_slot_worker.ex
@@ -1,0 +1,41 @@
+defmodule Sequin.Workers.CreateReplicationSlotWorker do
+  @moduledoc false
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Sequin.Databases
+  alias Sequin.Postgres
+  alias Sequin.Replication.PostgresReplicationSlot
+  alias Sequin.ReplicationRuntime.Supervisor, as: ReplicationRuntimeSupervisor
+  alias Sequin.Repo
+
+  # 15 minutes in seconds
+  @unique_period 15 * 60
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"replication_slot_id" => replication_slot_id}}) do
+    with {:ok, replication_slot} <- get_replication_slot(replication_slot_id),
+         {:ok, database} <- Databases.get_db(replication_slot.postgres_database_id),
+         :ok <- create_replication_slot(database, replication_slot) do
+      ReplicationRuntimeSupervisor.restart_replication(replication_slot)
+    end
+  end
+
+  def enqueue(replication_slot_id) do
+    %{replication_slot_id: replication_slot_id}
+    |> new(unique: [period: @unique_period, keys: [:replication_slot_id]])
+    |> Oban.insert()
+  end
+
+  defp get_replication_slot(id) do
+    case Repo.get(PostgresReplicationSlot, id) do
+      nil -> {:error, :replication_slot_not_found}
+      slot -> {:ok, slot}
+    end
+  end
+
+  defp create_replication_slot(database, replication_slot) do
+    Databases.with_connection(database, fn conn ->
+      Postgres.create_replication_slot(conn, replication_slot.slot_name)
+    end)
+  end
+end


### PR DESCRIPTION
Neon databases cull their replication slots after 45min of inactivity. This commit ensures we recreate them, should the db have gone dormant.

Long term, we want to keep track of the LSN that we last ack'd for the rep slot, so we can also rewind the slot on create. And probably turn this into an opt-in option for dev databases.

For now, this level of inactivity is only expected for dev dbs.