### PR TITLE
:bug: Fix issue with null UUIDs

### DIFF
--- a/lib/sequin/bench/end_to_end.ex
+++ b/lib/sequin/bench/end_to_end.ex
@@ -264,7 +264,7 @@ defmodule Sequin.Bench.EndToEnd do
       ON CONFLICT (stream_id, key) DO NOTHING
       """
 
-      Repo.query!(query, [UUID.string_to_binary!(stream_id), batch_size], timeout: :timer.minutes(2))
+      Repo.query!(query, [Sequin.String.string_to_binary!(stream_id), batch_size], timeout: :timer.minutes(2))
     end)
 
     Logger.info("Seeded database with #{count} messages")

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -573,7 +573,7 @@ defmodule Sequin.Consumers do
         {:ok, events} =
           Query.receive_consumer_events(
             batch_size: batch_size,
-            consumer_id: UUID.string_to_binary!(consumer.id),
+            consumer_id: Sequin.String.string_to_binary!(consumer.id),
             not_visible_until: not_visible_until,
             now: now
           )
@@ -621,7 +621,7 @@ defmodule Sequin.Consumers do
         {:ok, records} =
           Query.receive_consumer_records(
             batch_size: batch_size,
-            consumer_id: UUID.string_to_binary!(consumer.id),
+            consumer_id: Sequin.String.string_to_binary!(consumer.id),
             not_visible_until: not_visible_until,
             now: now
           )
@@ -808,7 +808,7 @@ defmodule Sequin.Consumers do
   end
 
   # Helper function to cast values using Ecto's type system
-  defp cast_value(value, "uuid"), do: UUID.string_to_binary!(value)
+  defp cast_value(value, "uuid"), do: Sequin.String.string_to_binary!(value)
 
   defp cast_value(value, pg_type) do
     ecto_type = Postgres.pg_type_to_ecto_type(pg_type)

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -149,8 +149,14 @@ defmodule Sequin.Databases.PostgresDatabase do
   def cast_rows(%Table{} = table, rows) do
     Enum.map(rows, fn row ->
       Map.new(table.columns, fn col ->
+        value = row[col.name]
+
         casted_val =
-          if col.type == "uuid", do: UUID.binary_to_string!(row[col.name]), else: row[col.name]
+          if col.type == "uuid" do
+            value && Sequin.String.binary_to_string!(value)
+          else
+            value
+          end
 
         {col.name, casted_val}
       end)

--- a/lib/sequin/databases_runtime/table_producer.ex
+++ b/lib/sequin/databases_runtime/table_producer.ex
@@ -145,15 +145,19 @@ defmodule Sequin.DatabasesRuntime.TableProducer do
     uuid_columns = Enum.filter(columns, &(&1.type == "uuid"))
 
     Enum.reduce(uuid_columns, map, fn column, acc ->
-      Map.update(acc, column.name, nil, fn uuid_string ->
-        case Ecto.UUID.load(uuid_string) do
-          {:ok, uuid} ->
-            uuid
+      Map.update(acc, column.name, nil, fn
+        nil ->
+          nil
 
-          :error ->
-            Logger.error("[TableProducer] Invalid UUID: #{inspect(uuid_string)}", column: column, columns: columns)
-            raise "Got invalid UUID: #{inspect(uuid_string)} for column: #{column.name}"
-        end
+        uuid_string ->
+          case Sequin.String.binary_to_string(uuid_string) do
+            {:ok, uuid} ->
+              uuid
+
+            :error ->
+              Logger.error("[TableProducer] Invalid UUID: #{inspect(uuid_string)}", column: column, columns: columns)
+              raise "Got invalid UUID: #{inspect(uuid_string)} for column: #{column.name}"
+          end
       end)
     end)
   end

--- a/lib/sequin/replication_runtime/wal_pipeline_server.ex
+++ b/lib/sequin/replication_runtime/wal_pipeline_server.ex
@@ -354,7 +354,7 @@ defmodule Sequin.ReplicationRuntime.WalPipelineServer do
       |> Enum.map(fn wal_event ->
         [
           wal_event.commit_lsn,
-          UUID.string_to_binary!(state.replication_slot.postgres_database_id),
+          Sequin.String.string_to_binary!(state.replication_slot.postgres_database_id),
           wal_event.source_table_oid,
           wal_event.source_table_schema,
           wal_event.source_table_name,

--- a/lib/sequin/streams/message.ex
+++ b/lib/sequin/streams/message.ex
@@ -98,7 +98,7 @@ defmodule Sequin.Streams.Message do
 
   def where_key_and_stream_id_in(query \\ base_query(), key_stream_id_pairs) do
     {keys, stream_ids} = Enum.unzip(key_stream_id_pairs)
-    stream_ids = Enum.map(stream_ids, &UUID.string_to_binary!/1)
+    stream_ids = Enum.map(stream_ids, &Sequin.String.string_to_binary!/1)
 
     from([message: m] in query,
       where:

--- a/lib/sequin/string.ex
+++ b/lib/sequin/string.ex
@@ -48,9 +48,21 @@ defmodule Sequin.String do
   end
 
   def binary_to_string(uuid) when is_binary(uuid) do
-    UUID.binary_to_string!(uuid)
-  rescue
-    ArgumentError -> uuid
+    Ecto.UUID.load(uuid)
+  end
+
+  def binary_to_string!(uuid) when is_binary(uuid) do
+    case binary_to_string(uuid) do
+      {:ok, uuid} ->
+        uuid
+
+      :error ->
+        raise "Invalid UUID: #{inspect(uuid)}"
+    end
+  end
+
+  def string_to_binary!(uuid) when is_binary(uuid) do
+    UUID.string_to_binary!(uuid)
   end
 
   @doc """

--- a/test/sequin/keyset_cursor_test.exs
+++ b/test/sequin/keyset_cursor_test.exs
@@ -81,7 +81,7 @@ defmodule Sequin.DatabasesRuntime.KeysetCursorTest do
 
       result = KeysetCursor.casted_cursor_values(table, cursor)
 
-      assert result == ["2023-01-01", 123, UUID.string_to_binary!("550e8400-e29b-41d4-a716-446655440000")]
+      assert result == ["2023-01-01", 123, Sequin.String.string_to_binary!("550e8400-e29b-41d4-a716-446655440000")]
     end
   end
 
@@ -91,7 +91,7 @@ defmodule Sequin.DatabasesRuntime.KeysetCursorTest do
 
       result = %Postgrex.Result{
         columns: ["updated_at", "id1", "id2"],
-        rows: [["2023-01-01", 123, UUID.string_to_binary!("550e8400-e29b-41d4-a716-446655440000")]],
+        rows: [["2023-01-01", 123, Sequin.String.string_to_binary!("550e8400-e29b-41d4-a716-446655440000")]],
         num_rows: 1
       }
 

--- a/test/support/factory/character_factory.ex
+++ b/test/support/factory/character_factory.ex
@@ -119,7 +119,8 @@ if Mix.env() == :test do
             "alignment" => Factory.one_of(["good", "neutral", "evil"])
           },
           rating: Decimal.from_float(Factory.float(max: 10)),
-          avatar: :crypto.strong_rand_bytes(16)
+          avatar: :crypto.strong_rand_bytes(16),
+          house_id: UUID.uuid4()
         },
         attrs
       )

--- a/test/support/models/character_detailed.ex
+++ b/test/support/models/character_detailed.ex
@@ -18,6 +18,7 @@ defmodule Sequin.Test.Support.Models.CharacterDetailed do
     field :metadata, :map
     field :rating, :decimal
     field :avatar, :binary
+    field :house_id, Ecto.UUID
 
     timestamps()
   end
@@ -46,7 +47,8 @@ defmodule Sequin.Test.Support.Models.CharacterDetailed do
       :powers,
       :metadata,
       :rating,
-      :avatar
+      :avatar,
+      :house_id
     ])
   end
 end

--- a/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
+++ b/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
@@ -49,6 +49,7 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
       add :metadata, :map
       add :rating, :decimal
       add :avatar, :binary
+      add :house_id, :uuid
 
       timestamps()
     end


### PR DESCRIPTION
Postgrex does not automatically convert string UUIDs to binary before querying, nor convert to UTF8 string on load. This means we have to use column types to determine when to do this coercion. However, we were improperly handling situations where the value of a UUID field is null.

s/o to @aglassman for both reporting and identifying the root cause of this issue! :pray: