### PR TITLE
Filter out columns that don't have a Postgrex encoders

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,7 +32,13 @@ config :sentry,
 config :sequin, Oban,
   prefix: sequin_config_schema,
   queues: [default: 10],
-  repo: Sequin.Repo
+  repo: Sequin.Repo,
+  plugins: [
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"0 */6 * * *", Sequin.Databases.EnqueueDatabaseUpdateWorker}
+     ]}
+  ]
 
 config :sequin, Sequin.Mailer, adapter: Swoosh.Adapters.Local
 

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -747,7 +747,10 @@ defmodule Sequin.Consumers do
         "where (#{pk_column_names}) in (#{value_params})"
       end
 
-    query = "select * from #{Postgres.quote_name(table.schema, table.name)} #{where_clause}"
+    select_columns = Postgres.safe_select_columns(table)
+
+    query =
+      "select #{select_columns} from #{Postgres.quote_name(table.schema, table.name)} #{where_clause}"
 
     # Execute the query
     with {:ok, result} <- Postgres.query(postgres_db, query, casted_pks) do

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -757,7 +757,7 @@ defmodule Sequin.Consumers do
       # Convert result to map
       rows = Postgres.result_to_maps(result)
 
-      rows = PostgresDatabase.cast_rows(table, rows)
+      rows = Postgres.load_rows(table, rows)
 
       # Match the results with the original records
       updated_records =

--- a/lib/sequin/databases/database_update_worker.ex
+++ b/lib/sequin/databases/database_update_worker.ex
@@ -1,0 +1,31 @@
+defmodule Sequin.Databases.DatabaseUpdateWorker do
+  @moduledoc false
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Sequin.Databases
+
+  # 5 minutes in seconds
+  @default_unique_period 5 * 60
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"postgres_database_id" => postgres_database_id}}) do
+    with {:ok, database} <- Databases.get_db(postgres_database_id) do
+      Databases.update_tables(database)
+    end
+  end
+
+  def enqueue(postgres_database_id, opts \\ []) do
+    new_opts =
+      case Keyword.get(opts, :unique_period, @default_unique_period) do
+        0 ->
+          []
+
+        unique_period ->
+          [unique: [period: unique_period, keys: [:postgres_database_id]]]
+      end
+
+    %{postgres_database_id: postgres_database_id}
+    |> new(new_opts)
+    |> Oban.insert()
+  end
+end

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -330,7 +330,7 @@ defmodule Sequin.Databases do
   defp update_tables(conn, %PostgresDatabase{} = db) do
     with {:ok, schemas} <- list_schemas(conn),
          {:ok, tables} <- Postgres.fetch_tables_with_columns(conn, schemas) do
-      tables = PostgresDatabase.tables_to_map(tables)
+      tables = Postgres.tables_to_map(tables)
 
       db
       |> PostgresDatabase.changeset(%{tables: tables, tables_refreshed_at: DateTime.utc_now()})

--- a/lib/sequin/databases/enqueue_database_update_worker.ex
+++ b/lib/sequin/databases/enqueue_database_update_worker.ex
@@ -1,0 +1,15 @@
+defmodule Sequin.Databases.EnqueueDatabaseUpdateWorker do
+  @moduledoc false
+  use Oban.Worker
+
+  alias Sequin.Databases
+  alias Sequin.Databases.DatabaseUpdateWorker
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    Enum.each(Databases.list_dbs(), fn db -> DatabaseUpdateWorker.enqueue(db.id) end)
+    Logger.info("[EnqueueDatabaseUpdateWorker] Enqueue complete")
+  end
+end

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -7,7 +7,6 @@ defmodule Sequin.Databases.PostgresDatabase do
 
   alias __MODULE__
   alias Ecto.Queryable
-  alias Sequin.Databases.PostgresDatabase.Table
   alias Sequin.Replication.PostgresReplicationSlot
 
   require Logger
@@ -134,33 +133,6 @@ defmodule Sequin.Databases.PostgresDatabase do
     column
     |> cast(attrs, [:attnum, :name, :type, :is_pk?])
     |> validate_required([:attnum, :name, :type, :is_pk?])
-  end
-
-  def tables_to_map(tables) do
-    Enum.map(tables, fn table ->
-      table
-      |> Sequin.Map.from_ecto()
-      |> Map.update!(:columns, fn columns ->
-        Enum.map(columns, &Sequin.Map.from_ecto/1)
-      end)
-    end)
-  end
-
-  def cast_rows(%Table{} = table, rows) do
-    Enum.map(rows, fn row ->
-      Map.new(table.columns, fn col ->
-        value = row[col.name]
-
-        casted_val =
-          if col.type == "uuid" do
-            value && Sequin.String.binary_to_string!(value)
-          else
-            value
-          end
-
-        {col.name, casted_val}
-      end)
-    end)
   end
 
   @spec where_account(Queryable.t(), String.t()) :: Queryable.t()

--- a/lib/sequin/databases_runtime/table_producer.ex
+++ b/lib/sequin/databases_runtime/table_producer.ex
@@ -94,9 +94,11 @@ defmodule Sequin.DatabasesRuntime.TableProducer do
 
     limit = Keyword.get(opts, :limit, 1000)
 
+    select_columns = Postgres.safe_select_columns(table)
+
     sql =
       """
-      select * from #{Postgres.quote_name(table.schema, table.name)}
+      select #{select_columns} from #{Postgres.quote_name(table.schema, table.name)}
       where #{min_where_clause} and #{max_where_clause}
       order by #{order_by_clause}
       limit ?
@@ -185,8 +187,10 @@ defmodule Sequin.DatabasesRuntime.TableProducer do
   def fetch_first_row(%PostgresDatabase{} = db, %Table{} = table) do
     order_by = KeysetCursor.order_by_sql(table, "asc")
 
+    select_columns = Postgres.safe_select_columns(table)
+
     sql = """
-    select * from #{Postgres.quote_name(table.schema, table.name)}
+    select #{select_columns} from #{Postgres.quote_name(table.schema, table.name)}
     order by #{order_by}
     limit 1
     """

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -467,7 +467,7 @@ defmodule Sequin.ConsumersTest do
                Consumers.put_source_data(consumer, [record])
     end
 
-    test "handles when PostgresDatabase.tables lists a non-existent column", %{consumer: consumer} do
+    test "returns error when PostgresDatabase.tables lists a non-existent column", %{consumer: consumer} do
       character = CharacterFactory.insert_character!()
       record = build_consumer_record(consumer, character)
 
@@ -481,9 +481,7 @@ defmodule Sequin.ConsumersTest do
           end)
         end)
 
-      {:ok, [fetched_record]} = Consumers.put_source_data(consumer, [record])
-
-      assert fetched_record.data.record["non_existent_column"] == nil
+      {:error, %Postgrex.Error{postgres: %{code: :undefined_column}}} = Consumers.put_source_data(consumer, [record])
     end
 
     @tag capture_log: true

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -14,6 +14,7 @@ defmodule Sequin.ConsumersTest do
   alias Sequin.Consumers.SourceTable.StringValue
   alias Sequin.Databases
   alias Sequin.Databases.ConnectionCache
+  alias Sequin.Databases.DatabaseUpdateWorker
   alias Sequin.Error.NotFoundError
   alias Sequin.Factory
   alias Sequin.Factory.AccountsFactory
@@ -482,6 +483,8 @@ defmodule Sequin.ConsumersTest do
         end)
 
       {:error, %Postgrex.Error{postgres: %{code: :undefined_column}}} = Consumers.put_source_data(consumer, [record])
+
+      assert_enqueued(worker: DatabaseUpdateWorker, args: %{postgres_database_id: consumer.postgres_database.id})
     end
 
     @tag capture_log: true

--- a/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
+++ b/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
@@ -53,6 +53,7 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
       add :rating, :decimal
       add :avatar, :binary
       add :house_id, :uuid
+      add :net_worth, :money
 
       timestamps()
     end


### PR DESCRIPTION
This pull request enhances the handling of database column types in select queries. The main changes include:

1. Introduced a `safe_select_columns` function in the Postgres module to filter and select only columns with available Postgrex encoders.

2. Updated select queries in `Consumers` and `TableProducer` modules to use `safe_select_columns` instead of selecting all columns with `*`.

3. Added a list of safe column types and a `has_encoder?` function to determine which column types can be safely encoded.

4. Modified the behavior for handling non-existent columns in the `ConsumersTest`. Instead of silently ignoring the column, it now returns an error.

5. Added a new `net_worth` column of type `:money` to the test table in the migration file.

These changes improve the robustness of database queries by ensuring only supported column types are selected, reducing potential encoding errors and improving overall query performance.