### PR TITLE
Enqueue database update on undefined column error

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,7 +32,13 @@ config :sentry,
 config :sequin, Oban,
   prefix: sequin_config_schema,
   queues: [default: 10],
-  repo: Sequin.Repo
+  repo: Sequin.Repo,
+  plugins: [
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"0 */6 * * *", Sequin.Databases.EnqueueDatabaseUpdateWorker}
+     ]}
+  ]
 
 config :sequin, Sequin.Mailer, adapter: Swoosh.Adapters.Local
 

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -757,7 +757,7 @@ defmodule Sequin.Consumers do
       # Convert result to map
       rows = Postgres.result_to_maps(result)
 
-      rows = PostgresDatabase.cast_rows(table, rows)
+      rows = Postgres.load_rows(table, rows)
 
       # Match the results with the original records
       updated_records =

--- a/lib/sequin/databases/database_update_worker.ex
+++ b/lib/sequin/databases/database_update_worker.ex
@@ -1,0 +1,31 @@
+defmodule Sequin.Databases.DatabaseUpdateWorker do
+  @moduledoc false
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Sequin.Databases
+
+  # 5 minutes in seconds
+  @default_unique_period 5 * 60
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"postgres_database_id" => postgres_database_id}}) do
+    with {:ok, database} <- Databases.get_db(postgres_database_id) do
+      Databases.update_tables(database)
+    end
+  end
+
+  def enqueue(postgres_database_id, opts \\ []) do
+    new_opts =
+      case Keyword.get(opts, :unique_period, @default_unique_period) do
+        0 ->
+          []
+
+        unique_period ->
+          [unique: [period: unique_period, keys: [:postgres_database_id]]]
+      end
+
+    %{postgres_database_id: postgres_database_id}
+    |> new(new_opts)
+    |> Oban.insert()
+  end
+end

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -330,7 +330,7 @@ defmodule Sequin.Databases do
   defp update_tables(conn, %PostgresDatabase{} = db) do
     with {:ok, schemas} <- list_schemas(conn),
          {:ok, tables} <- Postgres.fetch_tables_with_columns(conn, schemas) do
-      tables = PostgresDatabase.tables_to_map(tables)
+      tables = Postgres.tables_to_map(tables)
 
       db
       |> PostgresDatabase.changeset(%{tables: tables, tables_refreshed_at: DateTime.utc_now()})

--- a/lib/sequin/databases/enqueue_database_update_worker.ex
+++ b/lib/sequin/databases/enqueue_database_update_worker.ex
@@ -1,0 +1,15 @@
+defmodule Sequin.Databases.EnqueueDatabaseUpdateWorker do
+  @moduledoc false
+  use Oban.Worker
+
+  alias Sequin.Databases
+  alias Sequin.Databases.DatabaseUpdateWorker
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    Enum.each(Databases.list_dbs(), fn db -> DatabaseUpdateWorker.enqueue(db.id) end)
+    Logger.info("[EnqueueDatabaseUpdateWorker] Enqueue complete")
+  end
+end

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -7,7 +7,6 @@ defmodule Sequin.Databases.PostgresDatabase do
 
   alias __MODULE__
   alias Ecto.Queryable
-  alias Sequin.Databases.PostgresDatabase.Table
   alias Sequin.Replication.PostgresReplicationSlot
 
   require Logger
@@ -134,33 +133,6 @@ defmodule Sequin.Databases.PostgresDatabase do
     column
     |> cast(attrs, [:attnum, :name, :type, :is_pk?])
     |> validate_required([:attnum, :name, :type, :is_pk?])
-  end
-
-  def tables_to_map(tables) do
-    Enum.map(tables, fn table ->
-      table
-      |> Sequin.Map.from_ecto()
-      |> Map.update!(:columns, fn columns ->
-        Enum.map(columns, &Sequin.Map.from_ecto/1)
-      end)
-    end)
-  end
-
-  def cast_rows(%Table{} = table, rows) do
-    Enum.map(rows, fn row ->
-      Map.new(table.columns, fn col ->
-        value = row[col.name]
-
-        casted_val =
-          if col.type == "uuid" do
-            value && Sequin.String.binary_to_string!(value)
-          else
-            value
-          end
-
-        {col.name, casted_val}
-      end)
-    end)
   end
 
   @spec where_account(Queryable.t(), String.t()) :: Queryable.t()

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -14,6 +14,7 @@ defmodule Sequin.ConsumersTest do
   alias Sequin.Consumers.SourceTable.StringValue
   alias Sequin.Databases
   alias Sequin.Databases.ConnectionCache
+  alias Sequin.Databases.DatabaseUpdateWorker
   alias Sequin.Error.NotFoundError
   alias Sequin.Factory
   alias Sequin.Factory.AccountsFactory
@@ -482,6 +483,8 @@ defmodule Sequin.ConsumersTest do
         end)
 
       {:error, %Postgrex.Error{postgres: %{code: :undefined_column}}} = Consumers.put_source_data(consumer, [record])
+
+      assert_enqueued(worker: DatabaseUpdateWorker, args: %{postgres_database_id: consumer.postgres_database.id})
     end
 
     @tag capture_log: true


### PR DESCRIPTION
This pull request introduces a new DatabaseUpdateWorker module and enhances error handling for database queries. The changes include:

1. A new DatabaseUpdateWorker module that uses Oban for job processing, allowing for database table updates to be queued and executed asynchronously.

2. Enhanced error handling in the Postgres.query/4 function. When an undefined column error occurs, it now enqueues a database update job using the DatabaseUpdateWorker.

3. Updated tests to verify the new behavior, including an assertion to check if the DatabaseUpdateWorker job is enqueued when an undefined column error is encountered.

These changes improve the system's ability to handle database schema changes by automatically triggering updates when encountering column-related errors during queries.