### PR TITLE
Add cron job for periodic database updates

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,7 +32,13 @@ config :sentry,
 config :sequin, Oban,
   prefix: sequin_config_schema,
   queues: [default: 10],
-  repo: Sequin.Repo
+  repo: Sequin.Repo,
+  plugins: [
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"0 */6 * * *", Sequin.Databases.EnqueueDatabaseUpdateWorker}
+     ]}
+  ]
 
 config :sequin, Sequin.Mailer, adapter: Swoosh.Adapters.Local
 

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -757,7 +757,7 @@ defmodule Sequin.Consumers do
       # Convert result to map
       rows = Postgres.result_to_maps(result)
 
-      rows = PostgresDatabase.cast_rows(table, rows)
+      rows = Postgres.load_rows(table, rows)
 
       # Match the results with the original records
       updated_records =

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -330,7 +330,7 @@ defmodule Sequin.Databases do
   defp update_tables(conn, %PostgresDatabase{} = db) do
     with {:ok, schemas} <- list_schemas(conn),
          {:ok, tables} <- Postgres.fetch_tables_with_columns(conn, schemas) do
-      tables = PostgresDatabase.tables_to_map(tables)
+      tables = Postgres.tables_to_map(tables)
 
       db
       |> PostgresDatabase.changeset(%{tables: tables, tables_refreshed_at: DateTime.utc_now()})

--- a/lib/sequin/databases/enqueue_database_update_worker.ex
+++ b/lib/sequin/databases/enqueue_database_update_worker.ex
@@ -1,0 +1,15 @@
+defmodule Sequin.Databases.EnqueueDatabaseUpdateWorker do
+  @moduledoc false
+  use Oban.Worker
+
+  alias Sequin.Databases
+  alias Sequin.Databases.DatabaseUpdateWorker
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    Enum.each(Databases.list_dbs(), fn db -> DatabaseUpdateWorker.enqueue(db.id) end)
+    Logger.info("[EnqueueDatabaseUpdateWorker] Enqueue complete")
+  end
+end

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -7,7 +7,6 @@ defmodule Sequin.Databases.PostgresDatabase do
 
   alias __MODULE__
   alias Ecto.Queryable
-  alias Sequin.Databases.PostgresDatabase.Table
   alias Sequin.Replication.PostgresReplicationSlot
 
   require Logger
@@ -134,33 +133,6 @@ defmodule Sequin.Databases.PostgresDatabase do
     column
     |> cast(attrs, [:attnum, :name, :type, :is_pk?])
     |> validate_required([:attnum, :name, :type, :is_pk?])
-  end
-
-  def tables_to_map(tables) do
-    Enum.map(tables, fn table ->
-      table
-      |> Sequin.Map.from_ecto()
-      |> Map.update!(:columns, fn columns ->
-        Enum.map(columns, &Sequin.Map.from_ecto/1)
-      end)
-    end)
-  end
-
-  def cast_rows(%Table{} = table, rows) do
-    Enum.map(rows, fn row ->
-      Map.new(table.columns, fn col ->
-        value = row[col.name]
-
-        casted_val =
-          if col.type == "uuid" do
-            value && Sequin.String.binary_to_string!(value)
-          else
-            value
-          end
-
-        {col.name, casted_val}
-      end)
-    end)
   end
 
   @spec where_account(Queryable.t(), String.t()) :: Queryable.t()


### PR DESCRIPTION
This pull request introduces a new scheduled task to periodically update databases. It adds a cron job configuration to Oban in `config/config.exs`, which runs every 6 hours. The new `EnqueueDatabaseUpdateWorker` module is created to handle this task, iterating through all databases and enqueueing individual update jobs for each one. This enhancement ensures regular database updates without manual intervention.