### PR TITLE
Refactor Postgres row loading and table mapping

### DIFF
--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -757,7 +757,7 @@ defmodule Sequin.Consumers do
       # Convert result to map
       rows = Postgres.result_to_maps(result)
 
-      rows = PostgresDatabase.cast_rows(table, rows)
+      rows = Postgres.load_rows(table, rows)
 
       # Match the results with the original records
       updated_records =

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -330,7 +330,7 @@ defmodule Sequin.Databases do
   defp update_tables(conn, %PostgresDatabase{} = db) do
     with {:ok, schemas} <- list_schemas(conn),
          {:ok, tables} <- Postgres.fetch_tables_with_columns(conn, schemas) do
-      tables = PostgresDatabase.tables_to_map(tables)
+      tables = Postgres.tables_to_map(tables)
 
       db
       |> PostgresDatabase.changeset(%{tables: tables, tables_refreshed_at: DateTime.utc_now()})

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -7,7 +7,6 @@ defmodule Sequin.Databases.PostgresDatabase do
 
   alias __MODULE__
   alias Ecto.Queryable
-  alias Sequin.Databases.PostgresDatabase.Table
   alias Sequin.Replication.PostgresReplicationSlot
 
   require Logger
@@ -134,33 +133,6 @@ defmodule Sequin.Databases.PostgresDatabase do
     column
     |> cast(attrs, [:attnum, :name, :type, :is_pk?])
     |> validate_required([:attnum, :name, :type, :is_pk?])
-  end
-
-  def tables_to_map(tables) do
-    Enum.map(tables, fn table ->
-      table
-      |> Sequin.Map.from_ecto()
-      |> Map.update!(:columns, fn columns ->
-        Enum.map(columns, &Sequin.Map.from_ecto/1)
-      end)
-    end)
-  end
-
-  def cast_rows(%Table{} = table, rows) do
-    Enum.map(rows, fn row ->
-      Map.new(table.columns, fn col ->
-        value = row[col.name]
-
-        casted_val =
-          if col.type == "uuid" do
-            value && Sequin.String.binary_to_string!(value)
-          else
-            value
-          end
-
-        {col.name, casted_val}
-      end)
-    end)
   end
 
   @spec where_account(Queryable.t(), String.t()) :: Queryable.t()


### PR DESCRIPTION
This pull request refactors and improves the handling of PostgreSQL data in the Sequin application. The main changes include:

1. Moved `tables_to_map` and `cast_rows` (renamed to `load_rows`) functions from `PostgresDatabase` to `Postgres` module for better organization.

2. Enhanced `load_rows` function to handle various data types more effectively:
   - Properly converts UUID binary to string format
   - Sets non-JSON encodable values to nil
   - Preserves nil values for optional UUID fields

3. Updated function calls in `consumers.ex` and `databases.ex` to use the new `Postgres.load_rows` and `Postgres.tables_to_map` functions.

4. Added comprehensive tests for the `load_rows` function in `postgres_test.exs` to ensure correct handling of different data types and edge cases.

These changes improve code organization, enhance data type handling, and increase test coverage for PostgreSQL-related functionality.