### PR TITLE
Rename "WAL Pipelines" to "Change Capture Pipelines"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Sequin connects to any Postgres database. To stream data, you'll create [Streams
 
 As rows are inserted or updated, Sequin will redeliver them to consumers until acknowledged.
 
-With [WAL Pipelines](#wal-pipelines), you can capture discrete changes to your tables, including `OLD` values for updates and hard-deletes. Sequin will write changes to an event log table in your database, so you can stream these changes with Sequin.
+With [Change Capture Pipelines](https://sequinstream.com/docs/capture-changes/wal-pipelines), you can capture discrete changes to your tables, including `OLD` values for updates and hard-deletes. Sequin will write changes to an event log table in your database, so you can stream these changes with Sequin.
 
 Sequin comes with a web console/UI for configuration:
 
@@ -127,7 +127,7 @@ Like Sequin, you can use Debezium + Kafka to replicate data or build event proce
 
 Debezium is a complex system that requires a lot of setup and configuration.
 
-Sequin is simpler to setup and operate, yet is quickly becoming as comprehensive as Debezium. Sequin comes with a much more comprehensive UI for configuration and monitoring. And Sequin doesn't require another messaging system like Kafka to learn and operate. With [WAL Pipelines](#wal-pipelines) you can capture the same changes that Debezium does.
+Sequin is simpler to setup and operate, yet is quickly becoming as comprehensive as Debezium. Sequin comes with a much more comprehensive UI for configuration and monitoring. And Sequin doesn't require another messaging system like Kafka to learn and operate. With [Change Capture Pipelines](https://sequinstream.com/docs/capture-changes/wal-pipelines) you can capture the same changes that Debezium does.
 
 </details>
 

--- a/assets/svelte/components/Sidenav.svelte
+++ b/assets/svelte/components/Sidenav.svelte
@@ -58,7 +58,11 @@
       heading: "Resources",
       items: [
         { path: "/databases", text: "Databases", icon: Database },
-        { path: "/wal-pipelines", text: "WAL Pipelines", icon: Logs },
+        {
+          path: "/change-capture-pipelines",
+          text: "Change Capture Pipelines",
+          icon: Logs,
+        },
         { path: "/http-endpoints", text: "HTTP Endpoints", icon: Webhook },
       ],
     },

--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -421,8 +421,8 @@ where parent_table = '${destinationSchemaName}.${destinationTableName}';
     <Dialog.Header>
       <Dialog.Title>Create event table</Dialog.Title>
       <Dialog.Description>
-        Set up an event table for your WAL Pipeline to write to. For more
-        information, <a
+        Set up an event table for your Change Capture Pipeline to write to. For
+        more information, <a
           href="https://sequinstream.com/docs/capture-changes/wal-pipelines"
           target="_blank"
           class="text-blue-500 underline">see the docs ↗</a

--- a/assets/svelte/databases/WalProjections.svelte
+++ b/assets/svelte/databases/WalProjections.svelte
@@ -27,18 +27,18 @@
 
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
-    <h2 class="text-2xl font-semibold">WAL Pipelines</h2>
+    <h2 class="text-2xl font-semibold">Change Capture Pipelines</h2>
     <Button on:click={() => pushEvent("new_wal_pipeline", {})}>
       <Plus class="h-4 w-4 mr-2" />
-      Create WAL Pipeline
+      Create Change Capture Pipeline
     </Button>
   </div>
 
   {#if walPipelines.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-600 mb-4">No WAL Pipelines found</p>
+      <p class="text-gray-600 mb-4">No Change Capture Pipelines found</p>
       <Button on:click={() => pushEvent("new_wal_pipeline", {})}>
-        Create WAL Pipeline
+        Create Change Capture Pipeline
       </Button>
     </div>
   {:else}

--- a/assets/svelte/wal_pipelines/Form.svelte
+++ b/assets/svelte/wal_pipelines/Form.svelte
@@ -88,7 +88,9 @@
 </script>
 
 <FullPageModal
-  title={isEdit ? "Edit WAL Pipeline" : "Create WAL Pipeline"}
+  title={isEdit
+    ? "Edit Change Capture Pipeline"
+    : "Create Change Capture Pipeline"}
   bind:open={dialogOpen}
   bind:showConfirmDialog
   on:close={handleClose}
@@ -103,9 +105,9 @@
       </CardHeader>
       <CardContent>
         <p class="mb-4 text-secondary-foreground text-sm" class:hidden={isEdit}>
-          With a WAL Pipeline, you can capture every insert, update, or delete
-          that happens to one or more tables into another table in your
-          database. Then, you can stream these events with Sequin.
+          With a Change Capture Pipeline, you can capture every insert, update,
+          or delete that happens to one or more tables into another table in
+          your database. Then, you can stream these events with Sequin.
         </p>
 
         <div class="space-y-4">
@@ -232,7 +234,7 @@
       <CardContent>
         <div class="space-y-4 my-4">
           <div class="space-y-2">
-            <Label for="name">WAL Pipeline name</Label>
+            <Label for="name">Change Capture Pipeline name</Label>
             <Input id="name" bind:value={form.name} />
             {#if errors.name}
               <p class="text-red-500 text-sm">{errors.name}</p>
@@ -246,7 +248,7 @@
               type="submit"
               disabled={!form.tableOid || !form.destinationTableOid}
             >
-              {walPipeline.id ? "Update" : "Create"} WAL Pipeline
+              {walPipeline.id ? "Update" : "Create"} Change Capture Pipeline
             </Button>
           </div>
         </div>

--- a/assets/svelte/wal_pipelines/Index.svelte
+++ b/assets/svelte/wal_pipelines/Index.svelte
@@ -27,20 +27,23 @@
 </script>
 
 <div class="container mx-auto py-10">
-  <DatabaseConnectionAlert show={!hasDatabases} entityName="WAL pipeline" />
+  <DatabaseConnectionAlert
+    show={!hasDatabases}
+    entityName="Change Capture Pipeline"
+  />
 
   <div class="flex justify-between items-center mb-4">
     <div class="flex items-center">
       <Logs class="h-6 w-6 mr-2" />
-      <h1 class="text-2xl font-bold">WAL Pipelines</h1>
+      <h1 class="text-2xl font-bold">Change Capture Pipelines</h1>
     </div>
     {#if walPipelines.length > 0 && hasDatabases}
       <a
-        href="/wal-pipelines/new"
+        href="/change-capture-pipelines/new"
         data-phx-link="redirect"
         data-phx-link-state="push"
       >
-        <Button>Create WAL Pipeline</Button>
+        <Button>Create Change Capture Pipeline</Button>
       </a>
     {/if}
   </div>
@@ -48,29 +51,31 @@
   {#if walPipelines.length === 0}
     <div class="w-full rounded-lg border-2 border-dashed border-gray-300">
       <div class="text-center py-12 w-1/2 mx-auto my-auto">
-        <h2 class="text-xl font-semibold mb-4">No WAL Pipelines found</h2>
+        <h2 class="text-xl font-semibold mb-4">
+          No Change Capture Pipelines found
+        </h2>
         <p class="text-gray-600 mb-6">
           With a
           <a
             href="https://sequinstream.com/docs/capture-changes/wal-pipelines"
             target="_blank"
-            class="text-blue-500 hover:underline">WAL Pipeline</a
+            class="text-blue-500 hover:underline">Change Capture Pipeline</a
           >, Sequin captures all of a table's insert, update, and delete events
           and stores them in an event log table.
         </p>
         {#if hasDatabases}
           <a
-            href="/wal-pipelines/new"
+            href="/change-capture-pipelines/new"
             data-phx-link="redirect"
             data-phx-link-state="push"
           >
-            <Button>Create WAL Pipeline</Button>
+            <Button>Create Change Capture Pipeline</Button>
           </a>
         {:else}
-          <Button disabled>Create WAL Pipeline</Button>
+          <Button disabled>Create Change Capture Pipeline</Button>
           <p class="text-gray-600 mt-4">
-            You need to connect a database to Sequin before you can create a WAL
-            pipeline.
+            You need to connect a database to Sequin before you can create a
+            Change Capture Pipeline.
           </p>
         {/if}
       </div>
@@ -91,7 +96,7 @@
           <Table.Row
             class="cursor-pointer"
             on:click={() => {
-              const url = `/wal-pipelines/${pipeline.id}`;
+              const url = `/change-capture-pipelines/${pipeline.id}`;
               window.history.pushState({}, "", url);
               dispatchEvent(new PopStateEvent("popstate"));
             }}

--- a/assets/svelte/wal_pipelines/Show.svelte
+++ b/assets/svelte/wal_pipelines/Show.svelte
@@ -63,7 +63,7 @@
   function handleRefreshReplicaWarning() {
     refreshReplicaWarningLoading = true;
     live.pushEventTo(
-      "#wal-pipeline-show",
+      "#change-capture-pipeline-show",
       "refresh_replica_warning",
       {},
       () => {
@@ -73,7 +73,11 @@
   }
 
   function handleDismissReplicaWarning() {
-    live.pushEventTo("#wal-pipeline-show", "dismiss_replica_warning", {});
+    live.pushEventTo(
+      "#change-capture-pipeline-show",
+      "dismiss_replica_warning",
+      {},
+    );
   }
 </script>
 
@@ -82,7 +86,7 @@
     <div class="container mx-auto px-4 py-4">
       <div class="flex items-center justify-between">
         <div class="flex items-center space-x-4">
-          <LinkPushNavigate href="/wal-pipelines">
+          <LinkPushNavigate href="/change-capture-pipelines">
             <Button variant="ghost" size="sm">
               <ArrowLeft class="h-4 w-4" />
             </Button>
@@ -112,7 +116,7 @@
             </div>
           </div>
           <a
-            href="/wal-pipelines/{walPipeline.id}/edit"
+            href="/change-capture-pipelines/{walPipeline.id}/edit"
             data-phx-link="redirect"
             data-phx-link-state="push"
           >
@@ -304,7 +308,8 @@
                 No filters applied
               </h4>
               <p class="text-sm text-gray-500 mb-4">
-                This WAL Pipeline will process all data from the source table.
+                This Change Capture Pipeline will process all data from the
+                source table.
               </p>
             </div>
           {/if}
@@ -318,7 +323,7 @@
   <Dialog.Content>
     <Dialog.Header>
       <Dialog.Title
-        >Are you sure you want to delete this WAL Pipeline?</Dialog.Title
+        >Are you sure you want to delete this Change Capture Pipeline?</Dialog.Title
       >
       <Dialog.Description>This action cannot be undone.</Dialog.Description>
     </Dialog.Header>

--- a/docs/capture-changes/wal-pipelines.mdx
+++ b/docs/capture-changes/wal-pipelines.mdx
@@ -1,22 +1,22 @@
 ---
-title: "WAL Pipelines"
-sidebarTitle: "WAL Pipelines"
-description: "Capture changes with WAL Pipelines"
+title: "Change Capture Pipelines"
+sidebarTitle: "Change Capture Pipelines"
+description: "Capture changes with Change Capture Pipelines"
 icon: "timeline"
 iconType: "solid"
 ---
 
 Sequin streams the latest version of rows out of Postgres tables. But sometimes you need to capture every discrete change to your tables, not just the latest state of each row.
 
-**WAL Pipelines** allow you to capture every insert, update, and delete event that happens in your database, storing them in an event log table. That event log table can live in the same database or a different one. Then, you can stream these events using Sequin's standard consumption methods:
+**Change Capture Pipelines** allow you to capture every insert, update, and delete event that happens in your database, storing them in an event log table. That event log table can live in the same database or a different one. Then, you can stream these events using Sequin's standard consumption methods:
 
 <Frame>
-  <img style={{maxWidth: "800px"}} src="/images/guides/wal-pipelines/wal-pipeline-arch.png" alt="Architecture diagram of WAL Pipelines, with the source table on the left and the event log table on the right" />
+  <img style={{maxWidth: "800px"}} src="/images/guides/wal-pipelines/wal-pipeline-arch.png" alt="Architecture diagram of Change Capture Pipelines, with the source table on the left and the event log table on the right" />
 </Frame>
 
 ## Overview
 
-WAL Pipelines:
+Change Capture Pipelines:
 
 - Capture discrete change events (inserts, updates, and/or deletes)
 - Write changes to an event log table in your database
@@ -25,9 +25,9 @@ WAL Pipelines:
 - Allow SQL filtering on changes
 - Support configurable retention policies
 
-## Creating WAL Pipelines
+## Creating Change Capture Pipelines
 
-You can create WAL Pipelines in the Sequin console by navigating to the **WAL Pipelines** tab and clicking **Create WAL Pipeline**.
+You can create Change Capture Pipelines in the Sequin console by navigating to the **Change Capture Pipelines** tab and clicking **Create Change Capture Pipeline**.
 
 Under **Source configuration**, select the table you want to capture changes from:
 
@@ -53,13 +53,13 @@ Clicking **Create new event table** will open a modal that will provide instruct
   <img style={{maxWidth: "500px"}} src="/images/guides/wal-pipelines/create-event-table-modal.png" alt="The create event table modal, showing some configuration options and a series of SQL DDL commands to create the table" />
 </Frame>
 
-After creating your event table, click **Done** to close the modal. Your new table should now appear in the destination list. Select it and click **Create** to finish creating your WAL Pipeline.
+After creating your event table, click **Done** to close the modal. Your new table should now appear in the destination list. Select it and click **Create** to finish creating your Change Capture Pipeline.
 
 ## Event table
 
 ### Schema
 
-WAL Pipelines write changes to an **event table** in your database. This event table has a schema specified by Sequin.
+Change Capture Pipelines write changes to an **event table** in your database. This event table has a schema specified by Sequin.
 
 Event tables look like this:
 
@@ -254,7 +254,7 @@ Create a Stream for your event table to begin streaming the changes to your appl
 
 ## Event Examples
 
-Below are some examples of events that WAL Pipelines capture:
+Below are some examples of events that Change Capture Pipelines capture:
 
 ### Insert Event
 
@@ -270,7 +270,7 @@ record                | {
                       |   "updated_at": "2024-10-28T21:37:53",
                       |   "inserted_at": "2024-10-28T21:37:53"
                       | }
-changes               | 
+changes               |
 ```
 
 ### Update Event
@@ -309,5 +309,5 @@ record                | {
                       |   "updated_at": "2024-10-28T21:39:21",
                       |   "inserted_at": "2024-10-28T21:37:53"
                       | }
-changes               | 
+changes               |
 ```

--- a/lib/sequin_web/live/wal_pipelines/form.ex
+++ b/lib/sequin_web/live/wal_pipelines/form.ex
@@ -33,7 +33,7 @@ defmodule SequinWeb.WalPipelinesLive.Form do
          |> assign_changeset(%{})}
 
       {:error, _reason} ->
-        {:ok, push_navigate(socket, to: ~p"/wal-pipelines")}
+        {:ok, push_navigate(socket, to: ~p"/change-capture-pipelines")}
     end
   end
 
@@ -99,7 +99,7 @@ defmodule SequinWeb.WalPipelinesLive.Form do
         {:noreply,
          socket
          |> put_flash(:toast, %{kind: :info, title: toast_title})
-         |> push_navigate(to: ~p"/wal-pipelines/#{wal_pipeline.id}")}
+         |> push_navigate(to: ~p"/change-capture-pipelines/#{wal_pipeline.id}")}
       else
         {:error, %Ecto.Changeset{} = changeset} ->
           {:noreply, assign(socket, changeset: changeset, show_errors?: true)}
@@ -139,9 +139,9 @@ defmodule SequinWeb.WalPipelinesLive.Form do
   def handle_event("form_closed", _params, socket) do
     socket =
       if socket.assigns.is_edit do
-        push_navigate(socket, to: ~p"/wal-pipelines/#{socket.assigns.wal_pipeline.id}")
+        push_navigate(socket, to: ~p"/change-capture-pipelines/#{socket.assigns.wal_pipeline.id}")
       else
-        push_navigate(socket, to: ~p"/wal-pipelines")
+        push_navigate(socket, to: ~p"/change-capture-pipelines")
       end
 
     {:noreply, socket}

--- a/lib/sequin_web/live/wal_pipelines/show.ex
+++ b/lib/sequin_web/live/wal_pipelines/show.ex
@@ -18,7 +18,7 @@ defmodule SequinWeb.WalPipelinesLive.Show do
 
     case Replication.get_wal_pipeline_for_account(account_id, id) do
       nil ->
-        {:ok, push_navigate(socket, to: ~p"/wal-pipelines")}
+        {:ok, push_navigate(socket, to: ~p"/change-capture-pipelines")}
 
       wal_pipeline ->
         wal_pipeline = Repo.preload(wal_pipeline, [:source_database, :destination_database])
@@ -43,7 +43,7 @@ defmodule SequinWeb.WalPipelinesLive.Show do
   def handle_event("delete_wal_pipeline", _, socket) do
     case Replication.delete_wal_pipeline_with_lifecycle(socket.assigns.wal_pipeline) do
       {:ok, _} ->
-        {:noreply, push_navigate(socket, to: ~p"/wal-pipelines")}
+        {:noreply, push_navigate(socket, to: ~p"/change-capture-pipelines")}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to delete WAL Pipeline")}

--- a/lib/sequin_web/router.ex
+++ b/lib/sequin_web/router.ex
@@ -109,10 +109,10 @@ defmodule SequinWeb.Router do
       live "/http-endpoints/:id", HttpEndpointsLive.Show, :show
       live "/http-endpoints/:id/edit", HttpEndpointsLive.Form, :edit
 
-      live "/wal-pipelines", WalPipelinesLive.Index, :index
-      live "/wal-pipelines/new", WalPipelinesLive.Form, :new
-      live "/wal-pipelines/:id", WalPipelinesLive.Show, :show
-      live "/wal-pipelines/:id/edit", WalPipelinesLive.Form, :edit
+      live "/change-capture-pipelines", WalPipelinesLive.Index, :index
+      live "/change-capture-pipelines/new", WalPipelinesLive.Form, :new
+      live "/change-capture-pipelines/:id", WalPipelinesLive.Show, :show
+      live "/change-capture-pipelines/:id/edit", WalPipelinesLive.Form, :edit
 
       live "/streams", SequencesLive.Index, :index
       live "/streams/new", SequencesLive.Index, :new


### PR DESCRIPTION
### TL;DR

Renamed "WAL Pipelines" to "Change Capture Pipelines" across the application and documentation.

### What changed?

- Updated all UI references from "WAL Pipelines" to "Change Capture Pipelines"
- Modified navigation links and routes from `/wal-pipelines` to `/change-capture-pipelines`
- Updated some documentation to reflect the new terminology (replacing the rest in another PR)
- Changed button labels and form titles to use the new naming
- Updated external documentation links to use the new terminology

### Why make this change?

The term "Change Capture Pipelines" better describes the feature's functionality and is more accessible to users who may not be familiar with WAL (Write-Ahead Logging) terminology. This change makes the feature more intuitive and easier to understand while maintaining all existing functionality.