### PR TITLE
Use original Wistia embed without `<iframe>`

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -55,24 +55,26 @@ With Sequin, you can:
 
 Watch a recent demo of Sequin in action:
 
-<div className="wistia_responsive_padding" style={{ padding: '56.88% 0 0 0', position: 'relative' }}>
-  <div className="wistia_responsive_wrapper" style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}>
-    <iframe
-      src="https://fast.wistia.net/embed/iframe/ya5uv992hi?seo=true&videoFoam=true"
-      title="Overview of Postgres streaming with Sequin Video"
-      allow="autoplay; fullscreen"
-      allowTransparency={true}
-      frameBorder="0"
-      scrolling="no"
-      className="wistia_embed"
-      name="wistia_embed"
-      msAllowFullScreen
-      style={{ width: '100%', height: '100%' }}
-    >
-    </iframe>
+<script src="https://fast.wistia.com/embed/medias/ya5uv992hi.jsonp" async></script>
+<script src="https://fast.wistia.com/assets/external/E-v1.js" async></script>
+<div className="wistia_responsive_padding" style={{ padding: "56.88% 0 0 0", position: "relative" }}>
+  <div className="wistia_responsive_wrapper" style={{ height: "100%", left: "0", position: "absolute", top: "0", width: "100%" }}>
+    <div className="wistia_embed wistia_async_ya5uv992hi seo=true videoFoam=true" style={{ height: "100%", position: "relative", width: "100%" }}>
+      <div className="wistia_swatch" style={{ height: "100%", left: "0", opacity: "0", overflow: "hidden", position: "absolute", top: "0", transition: "opacity 200ms", width: "100%" }}>
+        <img
+          src="https://fastwistiacom/embed/medias/ya5uv992hi/swatch" style={{ filter: "blur(5px)", height: "100%", objectFit: "contain", width: "100%" }}
+          alt=""
+          aria-hidden="true"
+          onLoad={(e) => {
+            if (e.currentTarget.parentElement) {
+              e.currentTarget.parentElement.style.opacity = "1";
+            }
+          }}
+        />
+      </div>
+    </div>
   </div>
 </div>
-<script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 
 ## Getting started
 


### PR DESCRIPTION
Hi there! Found the issue with the embed, the HTML given from the Wistia site is not valid JSX, so the markdown parsing broke. 

I fixed it in this PR to replace the `<iframe>`. Just the style props were broken (since HTML has strings for style props instead of objects which JSX takes), and the `onLoad` props which had a string instead of Javascript.

Thank you!