### PR TITLE
Set SECRET_KEY_BASE length to 64 bytes

### DIFF
--- a/docs/self-hosting/docker-setup.mdx
+++ b/docs/self-hosting/docker-setup.mdx
@@ -61,7 +61,7 @@ To generate each secret, run the following command:
 
 ```bash
 # SECRET_KEY_BASE
-openssl rand -base64 32
+openssl rand -base64 64
 
 # VAULT_KEY - make 'em different
 openssl rand -base64 32


### PR DESCRIPTION
The doc mistakenly mentions the length of SECRET_KEY_BASE as 32 byte long. It should 64 byte long.