### PR TITLE
:sparkles: Add production deployment guide

### DIFF
--- a/docs/how-to/create-audit-logs.mdx
+++ b/docs/how-to/create-audit-logs.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Create audit logs"
 description: "Create a reliable log of all changes in your database"
 ---
 
+DOCTODO: Make generic.
+
 Audit logs are an essential tool for tracking and recording changes in your database. With Sequin, you can create comprehensive audit logs of changes in your Postgres database that help you:
 
 - **Maintain compliance**: Meet regulatory requirements by tracking all data modifications

--- a/docs/how-to/deploy-to-production.mdx
+++ b/docs/how-to/deploy-to-production.mdx
@@ -1,0 +1,51 @@
+---
+title: "How to deploy to production"
+sidebarTitle: "Deploy to production"
+description: "Deploy your Sequin implementation to production"
+---
+
+Once you've created your Sequin sinks locally, you can move your implementation to production.
+
+You can use the [Sequin CLI](/reference/cli/overview) to export your local configuration and apply it to your production environment.
+
+## Prerequisites
+
+- The [Sequin CLI](/reference/cli/overview) installed locally, setup with contexts for both your local and production environments
+
+## Steps
+
+<Steps>
+  <Step title="Export your configuration">
+    Export your local configuration:
+
+    ```bash
+    sequin config export --context=local
+    ```
+
+    Replace `local` with the name of your local or development context.
+
+    This creates a `sequin.yaml` file you can commit to your repository.
+
+    <Info>
+      Consider having different YAML files for different environments. For example, `sequin.staging.yaml` and `sequin.production.yaml`.
+
+      Database names often differ between environments (e.g. `my_db_dev` vs `my_db_prod`).
+    </Info>
+
+    <Warning>
+      `sequin config export` is still early and experimental. See the warnings given when you run the command.
+    </Warning>
+  </Step>
+
+  <Step title="Apply to production">
+    Apply your configuration to production:
+
+    ```bash
+    sequin config apply sequin.yaml --context=production
+    ```
+
+    Replace `production` with the name of your production context.
+
+    Sequin will show you the changes it will apply to your production environment. If they look good, confirm by entering `yes`.
+  </Step>
+</Steps>

--- a/docs/how-to/maintain-caches.mdx
+++ b/docs/how-to/maintain-caches.mdx
@@ -4,334 +4,124 @@ sidebarTitle: "Maintain caches"
 description: "Keep your caches warm and up-to-date using Sequin"
 ---
 
-Sequin makes it easy to maintain caches that stay in sync with your database. Common use cases include:
+This guide shows you how to keep your caches synchronized with your Postgres database using Sequin for change data capture.
 
-- **Redis caching**: Keep frequently accessed data cached in Redis for fast retrieval
-- **In-memory caches**: Maintain application-level caches like Memcached or application memory
-- **Search indexes**: Keep search indexes like Elasticsearch up-to-date with your database
+By the end, you'll have a pipeline that streams database changes to your caching layer while handling common challenges like cache invalidation, race conditions, and recovery from failures.
 
-With Sequin, you can turn tables in your Postgres database into streams. Your application can pull rows from a stream using a Consumer Group or receive rows via a Webhook Subscription. Then, your application can update your cache with the latest data.
+## When to use this guide
 
-Sequin ensures ordered delivery and exactly-once processing, so you don't need to worry about race conditions or stale cache entries. This is especially important when maintaining caches that need to reflect the current state of your database.
-
-This guide shows you how to:
-
-- **Warm your cache**: Populate your cache with initial data
-- **Keep it fresh**: Maintain an up-to-date cache as source data changes
-- **Rebuild when needed**: Re-warm your cache if it gets flushed
+This approach works well when you need to:
+- Keep Redis, Memcached, or other caches in sync with your database
+- Maintain search indexes that reflect your current data
+- Update materialized views or derived data stores
+- Ensure cache consistency across multiple services
 
 ## Prerequisites
 
 This guide assumes you have:
 
-- Sequin installed and databases connected (if not, see the [quickstart guide](/quickstart))
-- A caching system ready (Redis, Memcached, etc.)
-- An application that can pull rows from a Consumer Group or receive rows via a Webhook Subscription
+1. [Already have Sequin installed](/quickstart/webhooks)
+2. [Have a database connected](/quickstart/connect-postgres)
+3. A caching system (Redis, Memcached, etc.) ready to receive updates
+4. A queue or stream that can receive messages (SQS, Kafka, Redis, etc.) or an HTTP endpoint that can receive webhooks
 
-## Overview
+## Architecture overview
 
-To maintain a cache with Sequin, you'll:
+Your cache maintenance pipeline will have these components:
 
-1. **[Create a stream](#create-a-stream)**: Stream changes from your source data
-2. Either **[Create a Consumer Group](#create-a-consumer-group)** or **[Create a Webhook Subscription](#consume-with-webhooks)**: Choose how to receive updates
-3. **[Write cache operations](#writing-cache-operations)**: Implement cache update logic
+1. **Source table(s)** in Postgres that contain the data you want to cache
+2. **Destination sink** (SQS, Kafka, Redis, or webhooks) that delivers changes to your processing system
+3. **Cache update processor** that receives changes and updates your cache
 
-### Cache invalidation
+## Setup your destination queue or stream
 
-Sequin streams the latest version of rows as they're created and updated in a table. Because Sequin streams rows from tables, and deleted rows are removed from tables, Sequin can't "see" deleted rows.
+It will be important for your system to process messages in order.
 
-When data is deleted from your source, you might want to remove it from your cache. You have several options:
+For Kafka, webhooks, and Sequin Stream sinks, you don't need to do anything special. During setup (below), you'll configure Sequin to write messages in order.
 
-1. **Soft delete tracking**: Use something like a `status` or `deleted_at` column in your source table. Then, when processing rows from your stream, you can remove the corresponding cache entry.
-2. **Change Capture Pipeline**: Use [Change Capture Pipelines](/capture-changes) to track explicit delete operations. Process these events to remove entries from your cache.
+For SQS, be sure to use a FIFO queue.
 
-### Development workflow
+For Redis, messages will be written to your Redis Stream in order. But there's risk you may have race conditions as you process them. See 
 
-Start by testing your cache maintenance pipeline locally. Later, we'll cover [production deployment](#deploying-to-production).
+DOCSTODO
 
-## Create a stream
+## Create a sink
 
-First, create a stream for each one of your source tables. This stream will let you backfill your cache with historical data, and provide real-time updates to keep your cache fresh:
+First, create a sink to the queue, stream, or webhook endpoint that you want to use to process changes:
 
 <Steps>
-  <Step title="Navigate to Streams">
-    In the Sequin web console, click on the "Streams" tab. Click "Create Stream".
-  </Step>
-
-  <Step title="Select your source table">
+  <Step title="Select the source">
     Select the table containing the data you want to cache.
 
-    Under "Sort and start", choose a sort column that reflects when data changes. `updated_at` works well for most cases since it captures both new and modified data.
-
-    <Info>
-      The sort column determines the order of updates to your cache when processing historical data. [Read more about sort columns](/how-sequin-works#streams).
-    </Info>
-
-    <Frame>
-      <img style={{maxWidth: '500px'}} src="/images/how-tos/replicating-tables/create-stream.png" alt="Stream configuration" />
-    </Frame>
+    Optionally add SQL filters to sync a subset of your source table to the destination.
   </Step>
 
-  <Step title="Create the stream">
-    Click "Create Stream".
+  <Step title="Select the message type">
+    Select "changes" as the message type.
+  </Step>
+
+  <Step title="Leave message grouping default">
+    If your sink supports message grouping, leave the default option selected for "Message grouping".
+    
+    This will ensure that messages are [grouped by primary key](/reference/ordering-and-grouping), helping eliminate race conditions as you write rows to your cache.
+  </Step>
+
+  <Step title="Specify backfill">
+    You can optionally backfill your cache with data currently in your source table.
+
+    Backfill messages are [change messages](/reference/messages#change-messages) where the `action` is `read`.
+  </Step>
+
+  <Step title="Specify batch size">
+    If both your sink and cache support batch operations, consider setting a batch size > `1`. Cache update operations are usually idempotent, so it's safe to process batches. A batch size of 100 is a good place to start.
+  </Step>
+
+  <Step title="Configure sink-specific settings">
+    Configure sink-specific settings and click "Create Sink".
   </Step>
 </Steps>
 
-## Create a Consumer Group
+## Implement cache updates
 
-You can use a Consumer Group to pull rows from your stream and write them to your cache. You'll need one Consumer Group per stream:
+Here's an example of how you might process changes to update a cache:
 
-<Steps>
-  <Step title="Create a Consumer Group">
-    Click on the "Consumer Groups" tab in the Sequin web console. Click "Create Consumer Group".
-  </Step>
-
-  <Step title="Configure the source">
-    Under "Source", select the stream you created.
-
-    For "Records to process", you can optionally add filters to sync a subset of your source table to the destination. For example, you can filter for `subscriptions` with a certain `status` or orders over a certain `total_amount`:
-
-    <Frame>
-      <img style={{maxWidth: '500px'}} src="/images/how-tos/replicating-tables/records-to-process.png" alt="Records to process" />
-    </Frame>
-
-    You can always change these filters later and [re-backfill your cache](#re-backfill-the-destination).
-
-    For "Where should the consumer group start?", you can indicate how far back in time you want to sync rows from the source table. Rows are ordered by the sort column you chose when you created the stream. So if you chose a field like `updated_at`, you can choose to sync rows from the beginning of the table, from the last few months, etc.
-
-    If you want your cache to contain all rows from the source, choose "At the beginning of the table." If you want to sync only new rows, choose "At the end of the table." Otherwise, choose a specific point in time according to your needs.
-  </Step>
-
-  <Step title="Configure message grouping">
-    Under "Message grouping", leave the default option selected.
-
-    <Info>
-      Sequin will group messages by primary key. This means that if a consumer pull or webhook push is outstanding for a row, Sequin will not deliver that row until the outstanding message is processed. This ensures there's no risk of a race condition as you write rows to your cache.
-    </Info>
-  </Step>
-
-  <Step title="Create and test the Consumer Group">
-    Click "Create Consumer Group".
-
-    To make sure things are working end-to-end, you can copy the example `curl` request on the Consumer Group's page and run it. The endpoint should return a batch of rows from your source table.
-  </Step>
-</Steps>
-
-### Setup your application
-
-In your application, you'll setup a worker that pulls messages from the Consumer Group and upserts them into your cache.
-
-For `MaxBatchSize`, because cache update operations are usually idempotent, it's usually safe to process batches ([see more below](#updating-your-cache)). A `MaxBatchSize` of 100 is a good place to start.
-
-Here's a basic example using Sequin's Go SDK:
-
-```go
-func main() {
-    client := sequin.NewClient(&sequin.ClientOptions{
-        Token: os.Getenv("SEQUIN_TOKEN"),
-    })
-
-    processor, err := sequin.NewProcessor(
-        client,
-        "my-consumer-group",
-        processRows,
-        sequin.ProcessorOptions{
-            MaxBatchSize: 100,  // Process up to 100 rows at once
-            MaxConcurrent: 10,
-        },
-    )
-    if err != nil {
-        log.Fatalf("Failed to create processor: %v", err)
-    }
-
-    if err := processor.Start(); err != nil {
-        log.Fatalf("Processor failed: %v", err)
-    }
-}
-
-func processRows(ctx context.Context, msgs []sequin.Message) error {
-    // See below for the logic to update your cache
-    res, err := updateCache(ctx, msgs)
-    if err != nil {
-        return err
-    }
-
-    log.Printf("Successfully processed %d rows", len(msgs))
-    return nil
-}
+```python
+def process_change(change):
+    # Extract key information
+    cache_key = f"{change.metadata.table_name}:{change.record['id']}"
+    
+    if change.action in ['insert', 'update', 'read']:
+        # Optional: Add version/timestamp
+        change.record['last_updated'] = change.metadata.commit_timestamp
+        
+        # Update cache
+        cache.set(
+            cache_key,
+            json.dumps(change.record),
+            ex=86400  # Consider your expiry needs
+        )
+    elif change.action == 'delete':
+        cache.delete(cache_key)
 ```
 
-<Info>
-  See the [Go SDK](https://github.com/sequinstream/sequin-go/tree/main/examples/audit_logging) for a complete example of consuming events from a Consumer Group with Go.
-</Info>
+### Consideration for Redis Streams
 
-### Rewind as needed
+If you're using Redis Streams, you'll need to be mindful of race conditions as you process messages.
 
-Remember, when you're in development, you can rewind your Consumer Group to any point in time. As you're tweaking your pipeline and cache update logic, you can rewind your Consumer Group in the Sequin web console.
+While Sequin will write messages pertaining to the same row to your stream in order, there's a risk that two separate workers could pull 
 
-## Consume with webhooks
+DOCSTODO: What's the recommendation? How can we give them an easiy `{commit_lsn, commit_seq}` to use?
 
-Instead of pulling rows with a Consumer Group, you can have Sequin push them to a webhook endpoint:
+## Verify your pipeline is working
 
-### Handle webhooks in your application
+If you specified a backfill, there should be messages in your stream ready for your system to process:
 
-Your webhook endpoint will receive POST requests with a [batch of one or more rows](/consume/webhooks).
+1. On the sink overview page, click the "Messages" tab. You should see messages flowing to your sink.
+2. Check the logs of your cache update processor to ensure it's processing messages as expected.
 
-Here's an example of handling webhooks with Node.js and Express:
+## Maintenance
 
-```javascript
-app.post('/webhooks/cache', async (req, res) => {
-  try {
-    // Webhook payload contains a data array of rows
-    const rows = req.body.data;
-    
-    await updateCache(rows);
-
-    // Return 200 to acknowledge successful processing
-    res.sendStatus(200);
-  } catch (error) {
-    console.error('Error processing webhook:', error);
-    // Return 500 to trigger a retry
-    res.sendStatus(500);
-  }
-});
-```
-
-If your endpoint returns a non-200 status code or fails to respond within the configured timeout, Sequin will retry the webhook indefinitely with an exponential backoff.
-
-### Setup your subscription
-
-With your webhook endpoint ready, you can create a subscription:
-
-<Steps>
-  <Step title="Navigate to Webhook Subscriptions">
-    In the Sequin web console, under destinations, navigate to the Webhook Subscriptions tab and click "Create Webhook Subscription".
-  </Step>
-
-  <Step title="Configure the source">
-    Under Source, select your stream.
-  </Step>
-
-  <Step title="Configure the webhook">
-    Under "Webhook configuration", enter your endpoint URL. This is where Sequin will send the webhook payloads.
-
-    For "Batch size", because cache update operations are usually idempotent, it's usually safe to process batches ([see more below](#updating-your-cache)). A batch size of 100 is a good place to start.
-
-    Remember, you'll want to insert all rows you receive in a webhook payload in a single statement.
-  </Step>
-
-  <Step title="Configure message grouping">
-    Under "Message grouping", leave the default option selected to ensure rows are processed in order.
-
-    <Info>
-      Sequin will group messages by primary key. This means that if a consumer pull or webhook push is outstanding for a row, Sequin will not deliver that row until the outstanding message is processed. This ensures there's no risk of a race condition as you write rows to your cache.
-    </Info>
-  </Step>
-
-  <Step title="Create the subscription">
-    Click "Create Webhook Subscription".
-  </Step>
-</Steps>
-
-### Rewind as needed
-
-Remember, when you're in development, you can rewind your Webhook Subscription to any point in time. As you're tweaking your pipeline and cache update logic, you can rewind your Webhook Subscription in the Sequin web console.
-
-You can also pause and resume your Webhook Subscription in the Sequin web console.
-
-## Writing to your cache
-
-Because cache update operations are usually idempotent, you can process batches of rows. If your worker dies mid-way through processing a batch, it's safe for another worker to re-process the same batch from the beginning.
-
-Here's an example using Redis:
-
-```javascript
-async function updateCache(rows) {
-  // Process one row at a time if your cache doesn't support batch operations
-  for (const row of rows) {
-    const { id, ...data } = row.record;
-    
-    // Use SET to update the cache
-    // The key is derived from the table's primary key
-    await redis.set(
-      `users:${id}`,
-      JSON.stringify(data),
-      // Optional: Set expiration
-      'EX', 
-      86400 // 24 hours
-    );
-  }
-}
-```
-
-For search indexes like Elasticsearch:
-
-```javascript
-async function updateCache(rows) {
-  for (const row of rows) {
-    const { id, ...data } = row.record;
-    
-    // Index/update document
-    await elasticsearch.index({
-      index: 'users',
-      id: id,
-      body: data,
-      // Refresh immediately for testing
-      refresh: true
-    });
-  }
-}
-```
-
-The key principles are:
-
-1. Use the primary key from the source table to generate cache keys
-2. Handle one row at a time if batching isn't supported
-3. Use operations that are idempotent (SET vs APPEND)
-
-## Deploying to production
-
-Once you've tested your cache maintenance pipeline locally, you can deploy it to production.
-
-You can use the Sequin CLI to export your local configuration and apply it to your production environment:
-
-<Steps>
-  <Step title="Perform migrations">
-    Ensure your production destination database has the tables you want to replicate to.
-    
-    We recommend deploying and migrating before proceeding.
-  </Step>
-
-  <Step title="Set your Sequin token">
-    If you're using a Consumer Group, ensure your Sequin token is configured in your production environment.
-  </Step>
-
-  <Step title="Export your configuration">
-    After [setting up the Sequin CLI](/cli), export your local configuration:
-
-    ```bash
-    sequin config export --context=local
-    ```
-
-    This creates a `sequin.yaml` file you can commit to your repository.
-
-    <Info>
-      Consider having different YAML files for different environments. For example, `sequin.staging.yaml` and `sequin.production.yaml`.
-
-      Database names often differ between environments (e.g. `my_db_dev` vs `my_db_prod`).
-    </Info>
-  </Step>
-
-  <Step title="Apply to production">
-    Apply your configuration to production:
-
-    ```bash
-    sequin config apply sequin.yaml --context=production
-    ```
-  </Step>
-</Steps>
-
-## Re-warming caches
+### Re-warming your cache
 
 You may need to re-warm your cache in these scenarios:
 
@@ -339,4 +129,8 @@ You may need to re-warm your cache in these scenarios:
 2. **Data model updates**: Schema or business logic changes
 3. **Cache eviction**: Unexpected cache flushes
 
-To re-warm your cache, go to your Consumer Group or Webhook Subscription. Click "Rewind". Indicate how far back in time you want to re-warm your cache. You can choose to replay the entire table in the stream, or just rows from the last few days, etc.
+You can use a [backfill](/reference/backfills) to play `read` operations from your table into your stream.
+
+## Next steps
+
+See "[Deploy to production](/how-to/deploy-to-production)" for guidance on copying your local sink configuration to your production environment.

--- a/docs/how-to/replicate-tables.mdx
+++ b/docs/how-to/replicate-tables.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Replicate tables"
 description: "Replicate tables between databases"
 ---
 
+DOCTODO: Make generic.
+
 Sequin makes it easy to replicate tables between databases. Common use cases include:
 
 - **Analytics & reporting**: Maintain a dedicated analytics database with transformed data optimized for complex queries and reporting

--- a/docs/how-to/stream-postgres-to-a-webhook-endpoint.mdx
+++ b/docs/how-to/stream-postgres-to-a-webhook-endpoint.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Stream to a webhook endpoint"
 description: "Receive Postgres changes as webhooks in real-time"
 ---
 
-This guide shows you how to use Sequin to set up real-time streaming of database changes from Postgres to your webhook endpoints.
+This guide shows you how to set up Postgres change data capture (CDC) and stream changes to a webhook endpoint using Sequin.
 
 With Postgres data streaming to your application, you can trigger workflows, keep services in sync, [build audit logs](/how-to/create-audit-logs), [maintain caches](/how-to/maintain-caches), and more.
 
@@ -51,7 +51,7 @@ Here's how to generate a secure token with `openssl`:
 openssl rand -base64 32
 ```
 
-### (Optional) Create a Change Capture Pipeline
+### (Optional) Enable retention for changes
 
 You can send either [changes or rows](/reference/messages) to your webhook endpoint.
 

--- a/docs/how-to/stream-postgres-to-kafka.mdx
+++ b/docs/how-to/stream-postgres-to-kafka.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Stream to Kafka"
 description: "Receive Postgres changes in Kafka topics in real-time"
 ---
 
-This guide shows you how to use Sequin to set up real-time streaming of database changes from Postgres to Kafka.
+This guide shows you how to set up Postgres change data capture (CDC) and stream changes to Kafka using Sequin.
 
 With Postgres data streaming to Kafka, you can trigger workflows, keep services in sync, [build audit logs](/how-to/create-audit-logs), [maintain caches](/how-to/maintain-caches), and more.
 
@@ -22,7 +22,7 @@ This guide assumes you:
 
 ### Prepare your Kafka cluster
 
-TODO.
+DOCTODO.
 
 ## Create Kafka sink
 
@@ -54,7 +54,7 @@ Navigate to the "Sinks" tab, click "Create Sink", and select "Kafka Sink".
   </Step>
 
   <Step title="Specify message grouping">
-    TODO: Do we let them specify a message key?
+    DOCTODO: Do we let them specify a message key?
 
     Under "Message grouping", you'll most likely want to leave the default option selected to ensure events for the same row are sent to [Kafka in order](reference/kafka#message-grouping).
   </Step>

--- a/docs/how-to/stream-postgres-to-redis.mdx
+++ b/docs/how-to/stream-postgres-to-redis.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Stream to Redis"
 description: "Receive Postgres changes in Redis Streams in real-time"
 ---
 
-This guide shows you how to use Sequin to set up real-time streaming of database changes from Postgres to Redis.
+This guide shows you how to set up Postgres change data capture (CDC) and stream changes to Redis using Sequin.
 
 With Postgres data streaming to Redis, you can trigger workflows, keep services in sync, [build audit logs](/how-to/create-audit-logs), [maintain caches](/how-to/maintain-caches), and more.
 

--- a/docs/how-to/stream-postgres-to-sequin-stream.mdx
+++ b/docs/how-to/stream-postgres-to-sequin-stream.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Stream to Sequin Stream"
 description: "Pull Postgres changes directly from Sequin with exactly-once processing"
 ---
 
-This guide shows you how to use Sequin to set up real-time streaming of database changes from Postgres to Sequin Stream, Sequin's native HTTP pull interface.
+This guide shows you how to set up Postgres change data capture (CDC) and stream changes to Sequin Stream using Sequin.
 
 With Sequin Stream, you can pull database changes directly from Sequin without setting up additional infrastructure like Kafka or SQS. Sequin Stream provides exactly-once processing guarantees and supports multiple consumers working together as a consumer group.
 
@@ -19,7 +19,7 @@ This guide assumes you:
 
 ## Basic setup
 
-### (Optional) Create a Change Capture Pipeline
+### (Optional) Enable retention for changes
 
 You can send either [changes or rows](/reference/messages) to Sequin Stream.
 

--- a/docs/how-to/stream-postgres-to-sqs.mdx
+++ b/docs/how-to/stream-postgres-to-sqs.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Stream to SQS"
 description: "Receive Postgres changes in Amazon SQS in real-time"
 ---
 
-This guide shows you how to use Sequin to set up real-time streaming of database changes from Postgres to Amazon SQS.
+This guide shows you how to set up Postgres change data capture (CDC) and stream changes to SQS using Sequin.
 
 With Postgres data streaming to SQS, you can trigger workflows, keep services in sync, [build audit logs](/how-to/create-audit-logs), [maintain caches](/how-to/maintain-caches), and more.
 
@@ -54,7 +54,7 @@ Replace `<your-queue-arn>` with your actual queue ARN.
 
 After creating the user, save the Access Key ID and Secret Access Key - you'll need these when configuring the SQS sink in Sequin.
 
-### (Optional) Create a Change Capture Pipeline
+### (Optional) Enable retention for changes
 
 You can send either [changes or rows](/reference/messages) to SQS.
 


### PR DESCRIPTION
Added documentation for deploying Sequin to production and improved the cache maintenance guide. Key changes:

- Added new guide explaining how to export local Sequin configuration and apply it to production environments using the CLI
- Restructured cache maintenance guide to focus on change data capture patterns
- Added architecture overview and detailed implementation examples for cache updates
- Improved guidance around message ordering and handling race conditions
- Added sections on maintenance tasks like cache re-warming
- Added placeholders for additional Redis Streams documentation and Kafka configuration details

The deploy guide includes step-by-step instructions for exporting configurations and safely applying them to production, with warnings about environment-specific considerations.