### PR TITLE
:sparkles: Add `seq` to consumer messages tables

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -64,6 +64,7 @@ config :sequin, Sequin.Repo,
     read_after_writes: true,
     default: {:fragment, "uuid_generate_v4()"}
   ],
+  migration_lock: :pg_advisory_lock,
   log: false
 
 # Configures the endpoint

--- a/lib/sequin/consumers/consumer_event.ex
+++ b/lib/sequin/consumers/consumer_event.ex
@@ -25,6 +25,7 @@ defmodule Sequin.Consumers.ConsumerEvent do
     field :consumer_id, Ecto.UUID, primary_key: true
     field :id, :integer, primary_key: true, read_after_writes: true
     field :commit_lsn, :integer
+    field :seq, :integer
     field :record_pks, {:array, :string}
     field :table_oid, :integer
 
@@ -46,6 +47,7 @@ defmodule Sequin.Consumers.ConsumerEvent do
     |> cast(attrs, [
       :consumer_id,
       :commit_lsn,
+      :seq,
       :record_pks,
       :table_oid,
       :not_visible_until,
@@ -57,6 +59,7 @@ defmodule Sequin.Consumers.ConsumerEvent do
     |> validate_required([
       :consumer_id,
       :commit_lsn,
+      :seq,
       :record_pks,
       :table_oid,
       :deliver_count,

--- a/lib/sequin/consumers/consumer_record.ex
+++ b/lib/sequin/consumers/consumer_record.ex
@@ -23,6 +23,7 @@ defmodule Sequin.Consumers.ConsumerRecord do
     field :consumer_id, Ecto.UUID, primary_key: true
     field :id, :integer, primary_key: true, read_after_writes: true
     field :commit_lsn, :integer
+    field :seq, :integer
     field :record_pks, {:array, :string}
     field :group_id, :string
     field :table_oid, :integer
@@ -46,6 +47,7 @@ defmodule Sequin.Consumers.ConsumerRecord do
     |> cast(attrs, [
       :consumer_id,
       :commit_lsn,
+      :seq,
       :record_pks,
       :group_id,
       :state,
@@ -57,6 +59,8 @@ defmodule Sequin.Consumers.ConsumerRecord do
     ])
     |> validate_required([
       :consumer_id,
+      :commit_lsn,
+      :seq,
       :record_pks,
       :group_id,
       :table_oid,

--- a/lib/sequin/replication/message.ex
+++ b/lib/sequin/replication/message.ex
@@ -24,8 +24,10 @@ defmodule Sequin.Replication.Message do
   typedstruct do
     field :action, :insert | :update | :delete
     field :columns, list(map())
+    field :commit_lsn, integer()
+    field :commit_idx, integer()
     field :commit_timestamp, DateTime.t()
-    field :commit_seq, integer()
+    field :seq, integer()
     field :errors, any()
     field :ids, list()
     field :table_schema, String.t()

--- a/lib/sequin/replication/message_handler.ex
+++ b/lib/sequin/replication/message_handler.ex
@@ -125,7 +125,8 @@ defmodule Sequin.Replication.MessageHandler do
   defp consumer_event(consumer, message) do
     %ConsumerEvent{
       consumer_id: consumer.id,
-      commit_lsn: DateTime.to_unix(message.commit_timestamp, :microsecond),
+      commit_lsn: message.commit_lsn,
+      seq: message.seq,
       record_pks: Enum.map(message.ids, &to_string/1),
       table_oid: message.table_oid,
       deliver_count: 0,
@@ -137,7 +138,8 @@ defmodule Sequin.Replication.MessageHandler do
   defp consumer_record(consumer, message) do
     %ConsumerRecord{
       consumer_id: consumer.id,
-      commit_lsn: DateTime.to_unix(message.commit_timestamp, :microsecond),
+      commit_lsn: message.commit_lsn,
+      seq: message.seq,
       record_pks: Enum.map(message.ids, &to_string/1),
       group_id: generate_group_id(consumer, message),
       table_oid: message.table_oid,
@@ -250,7 +252,8 @@ defmodule Sequin.Replication.MessageHandler do
   defp wal_event(pipeline, message) do
     %WalEvent{
       wal_pipeline_id: pipeline.id,
-      commit_lsn: DateTime.to_unix(message.commit_timestamp, :microsecond),
+      commit_lsn: message.commit_lsn,
+      seq: message.seq,
       record_pks: Enum.map(message.ids, &to_string/1),
       record: fields_to_map(get_fields(message)),
       changes: get_changes(message),

--- a/lib/sequin/replication/wal_event.ex
+++ b/lib/sequin/replication/wal_event.ex
@@ -12,6 +12,7 @@ defmodule Sequin.Replication.WalEvent do
              :id,
              :wal_pipeline_id,
              :commit_lsn,
+             :seq,
              :record_pks,
              :record,
              :changes,
@@ -23,6 +24,7 @@ defmodule Sequin.Replication.WalEvent do
     field :action, Ecto.Enum, values: [:insert, :update, :delete]
     field :changes, :map
     field :commit_lsn, :integer
+    field :seq, :integer
     field :committed_at, :utc_datetime_usec
     field :record_pks, {:array, :string}
     field :record, :map
@@ -43,6 +45,7 @@ defmodule Sequin.Replication.WalEvent do
     |> cast(attrs, [
       :wal_pipeline_id,
       :commit_lsn,
+      :seq,
       :record_pks,
       :replication_message_trace_id,
       :source_table_oid,
@@ -56,6 +59,7 @@ defmodule Sequin.Replication.WalEvent do
     |> validate_required([
       :wal_pipeline_id,
       :commit_lsn,
+      :seq,
       :record_pks,
       :replication_message_trace_id,
       :source_table_oid,

--- a/priv/repo/migrations/20241205004309_add_seq_to_consumer_stream_tables.exs
+++ b/priv/repo/migrations/20241205004309_add_seq_to_consumer_stream_tables.exs
@@ -1,0 +1,24 @@
+defmodule Sequin.Repo.Migrations.AddSeqToConsumerStreamTables do
+  use Ecto.Migration
+  @stream_schema Application.compile_env(:sequin, [Sequin.Repo, :stream_schema_prefix])
+
+  def change do
+    alter table(:consumer_events, prefix: @stream_schema) do
+      add :seq, :bigint
+    end
+
+    create unique_index(:consumer_events, [:consumer_id, :seq], prefix: @stream_schema)
+
+    alter table(:consumer_records, prefix: @stream_schema) do
+      add :seq, :bigint
+    end
+
+    create unique_index(:consumer_records, [:consumer_id, :seq], prefix: @stream_schema)
+
+    alter table(:wal_events, prefix: @stream_schema) do
+      add :seq, :bigint
+    end
+
+    create unique_index(:wal_events, [:wal_pipeline_id, :seq], prefix: @stream_schema)
+  end
+end

--- a/test/support/factory/consumers_factory.ex
+++ b/test/support/factory/consumers_factory.ex
@@ -335,6 +335,7 @@ defmodule Sequin.Factory.ConsumersFactory do
       %ConsumerEvent{
         consumer_id: Factory.uuid(),
         commit_lsn: Enum.random(1..1_000_000),
+        seq: Factory.unique_integer(),
         record_pks: record_pks,
         table_oid: Enum.random(1..100_000),
         ack_id: Factory.uuid(),
@@ -415,6 +416,7 @@ defmodule Sequin.Factory.ConsumersFactory do
       %ConsumerRecord{
         consumer_id: Factory.uuid(),
         commit_lsn: Enum.random(1..1_000_000),
+        seq: Factory.unique_integer(),
         record_pks: record_pks,
         group_id: Enum.join(record_pks, ","),
         table_oid: Enum.random(1..100_000),

--- a/test/support/factory/replication_factory.ex
+++ b/test/support/factory/replication_factory.ex
@@ -80,6 +80,9 @@ defmodule Sequin.Factory.ReplicationFactory do
       %Message{
         action: :insert,
         commit_timestamp: Factory.timestamp(),
+        commit_lsn: Factory.unique_integer(),
+        commit_idx: Enum.random(1..100),
+        seq: Factory.unique_integer(),
         errors: nil,
         ids: [Factory.unique_integer()],
         table_schema: "__postgres_replication_test_schema__",
@@ -104,6 +107,9 @@ defmodule Sequin.Factory.ReplicationFactory do
       %Message{
         action: :update,
         commit_timestamp: Factory.timestamp(),
+        commit_lsn: Factory.unique_integer(),
+        commit_idx: Enum.random(1..100),
+        seq: Factory.unique_integer(),
         errors: nil,
         ids: [Factory.unique_integer()],
         table_schema: Factory.postgres_object(),
@@ -131,6 +137,9 @@ defmodule Sequin.Factory.ReplicationFactory do
       %Message{
         action: :delete,
         commit_timestamp: Factory.timestamp(),
+        commit_lsn: Factory.unique_integer(),
+        commit_idx: Enum.random(1..100),
+        seq: Factory.unique_integer(),
         errors: nil,
         ids: [Factory.unique_integer()],
         table_schema: Factory.postgres_object(),
@@ -253,6 +262,7 @@ defmodule Sequin.Factory.ReplicationFactory do
       %WalEvent{
         wal_pipeline_id: Factory.uuid(),
         commit_lsn: Factory.unique_integer(),
+        seq: Factory.unique_integer(),
         record_pks: record_pks,
         record: %{"column" => Factory.word()},
         changes: if(action == :update, do: %{"column" => Factory.word()}),


### PR DESCRIPTION
We're propagating `seq` through the pipeline, which is a unique, monotonically increasing integer for each message.