### PR TITLE
[Docs] Fix example configuration

### DIFF
--- a/docs/reference/sequin-yaml.mdx
+++ b/docs/reference/sequin-yaml.mdx
@@ -288,7 +288,7 @@ sinks:
     database: "production-db"
     table: "users"
     destination:
-      type: "http_push"
+      type: "webhook"
       http_endpoint: "webhook-endpoint"
 
 change_retentions:


### PR DESCRIPTION
Docker container stops when using the example configuration from the docs due to the incorrect destination type

```
** (FunctionClauseError) no function clause matching in Sequin.YamlLoader.parse_sink/2 
```