### PR TITLE
⚡️ [TableReaderServer] If a batch is missed, discard it

### DIFF
--- a/lib/sequin/databases_runtime/message_handler.ex
+++ b/lib/sequin/databases_runtime/message_handler.ex
@@ -211,7 +211,8 @@ defmodule Sequin.DatabasesRuntime.SlotProcessor.MessageHandler do
         matching_msgs = Enum.filter(messages, &(&1.table_oid == batch.table_oid))
 
         # Create a MapSet of all ids from matching messages and union with existing values
-        incoming_pks = MapSet.new(matching_msgs, & &1.ids)
+
+        incoming_pks = MapSet.new(matching_msgs, fn msg -> Enum.map(msg.ids, &to_string/1) end)
         new_pks = MapSet.union(batch.primary_key_values, incoming_pks)
 
         if MapSet.size(new_pks) > ctx.max_pks_per_batch do

--- a/lib/sequin/databases_runtime/message_handler.ex
+++ b/lib/sequin/databases_runtime/message_handler.ex
@@ -170,8 +170,8 @@ defmodule Sequin.DatabasesRuntime.SlotProcessor.MessageHandler do
 
     case Enum.find(ctx.table_reader_batches, &(&1.batch_id == batch_id)) do
       nil ->
-        # TODO: Reset the table reader?
         Logger.error("[MessageHandler] Batch #{batch_id} not found in table reader batches")
+        TableReaderServer.discard_batch(TableReaderServer.via_tuple(backfill_id), batch_id)
         ctx
 
       batch ->

--- a/lib/sequin/databases_runtime/table_reader_server.ex
+++ b/lib/sequin/databases_runtime/table_reader_server.ex
@@ -367,6 +367,8 @@ defmodule Sequin.DatabasesRuntime.TableReaderServer do
     batch_by_pk =
       Map.new(state.batch, fn row ->
         pks = Enum.map(pk_columns, &Map.fetch!(row, &1))
+        # Important - PKs are passed around as a list of strings
+        pks = Enum.map(pks, &to_string/1)
         {pks, row}
       end)
 

--- a/lib/sequin/databases_runtime/table_reader_server.ex
+++ b/lib/sequin/databases_runtime/table_reader_server.ex
@@ -32,6 +32,10 @@ defmodule Sequin.DatabasesRuntime.TableReaderServer do
     GenStateMachine.call(pid, {:flush_batch, batch_info})
   end
 
+  def discard_batch(pid, batch_id) do
+    GenStateMachine.call(pid, {:discard_batch, batch_id})
+  end
+
   # Convenience function
   def via_tuple(%_{} = consumer) do
     consumer = Repo.preload(consumer, :active_backfill)
@@ -295,6 +299,23 @@ defmodule Sequin.DatabasesRuntime.TableReaderServer do
 
   def handle_event({:call, from}, {:flush_batch, batch_info}, _state_name, _state) do
     Logger.warning("[TableReaderServer] Received flush_batch call for unknown batch #{batch_info.batch_id}")
+    {:keep_state_and_data, [{:reply, from, :ok}]}
+  end
+
+  # Add call handler
+  @impl GenStateMachine
+  def handle_event({:call, from}, {:discard_batch, batch_id}, :await_flush, %State{batch_id: batch_id} = state) do
+    Logger.warning("[TableReaderServer] Discarding batch #{state.batch_id} by request")
+
+    state = %{state | batch: nil, batch_id: nil, next_cursor: nil}
+    {:next_state, :fetch_batch, state, [{:reply, from, :ok}]}
+  end
+
+  def handle_event({:call, from}, {:discard_batch, batch_id}, _state_name, %State{} = state) do
+    Logger.info(
+      "[TableReaderServer] Ignoring call to discard batch, batch not found: #{batch_id} (current batch: #{state.batch_id})"
+    )
+
     {:keep_state_and_data, [{:reply, from, :ok}]}
   end
 

--- a/test/sequin/message_handler_test.exs
+++ b/test/sequin/message_handler_test.exs
@@ -383,7 +383,7 @@ defmodule Sequin.MessageHandlerTest do
         backfill_id: "backfill1",
         seq: 1,
         # Some existing PKs
-        primary_key_values: MapSet.new([[1], [2]])
+        primary_key_values: MapSet.new([["1"], ["2"]])
       }
 
       batch2 = %MessageHandler.BatchState{
@@ -401,7 +401,7 @@ defmodule Sequin.MessageHandlerTest do
         backfill_id: "backfill2",
         seq: 3,
         # One existing PK
-        primary_key_values: MapSet.new([[10]])
+        primary_key_values: MapSet.new([["10"]])
       }
 
       context = %MessageHandler.Context{
@@ -436,19 +436,19 @@ defmodule Sequin.MessageHandlerTest do
       # Verify batch1 has original PKs plus new ones (without duplicates)
       assert MapSet.equal?(
                updated_batch1.primary_key_values,
-               MapSet.new([[1], [2], [3], [4], [5]])
+               MapSet.new([["1"], ["2"], ["3"], ["4"], ["5"]])
              )
 
       # Verify batch2 has only the new PKs
       assert MapSet.equal?(
                updated_batch2.primary_key_values,
-               MapSet.new([[100], [101]])
+               MapSet.new([["100"], ["101"]])
              )
 
       # Verify batch3 is unchanged
       assert MapSet.equal?(
                updated_batch3.primary_key_values,
-               MapSet.new([[10]])
+               MapSet.new([["10"]])
              )
     end
   end
@@ -461,7 +461,7 @@ defmodule Sequin.MessageHandlerTest do
         table_oid: 789,
         backfill_id: "existing-backfill",
         seq: 42,
-        primary_key_values: MapSet.new([[1], [2]])
+        primary_key_values: MapSet.new([["1"], ["2"]])
       }
 
       context = %MessageHandler.Context{
@@ -546,10 +546,10 @@ defmodule Sequin.MessageHandlerTest do
         table_oid: 123,
         backfill_id: "test-backfill",
         seq: 42,
-        primary_key_values: MapSet.new([[1], [2], [3]])
+        primary_key_values: MapSet.new([["1"], ["2"], ["3"]])
       }
 
-      batch_info = %{batch_id: "matching-batch", seq: 42, drop_pks: MapSet.new([[1], [2], [3]])}
+      batch_info = %{batch_id: "matching-batch", seq: 42, drop_pks: MapSet.new([["1"], ["2"], ["3"]])}
 
       context = %MessageHandler.Context{
         table_reader_batches: [

--- a/test/sequin/table_reader_server_test.exs
+++ b/test/sequin/table_reader_server_test.exs
@@ -161,7 +161,7 @@ defmodule Sequin.DatabasesRuntime.TableReaderServerTest do
       for n <- 1..2 do
         assert_receive {TableReaderServer, {:batch_fetched, batch_id}}, 1000
 
-        assert :ok = TableReaderServer.flush_batch(pid, %{batch_id: batch_id, seq: n, drop_pks: []})
+        assert :ok = TableReaderServer.flush_batch(pid, %{batch_id: batch_id, seq: n, drop_pks: MapSet.new()})
       end
 
       # Fetch ConsumerRecords from the database
@@ -206,7 +206,7 @@ defmodule Sequin.DatabasesRuntime.TableReaderServerTest do
 
       {dropped_characters, kept_characters} = characters |> Enum.shuffle() |> Enum.split(3)
 
-      dropped_pks = Enum.map(dropped_characters, fn character -> %{"id" => character.id} end)
+      dropped_pks = MapSet.new(dropped_characters, fn character -> [character.id] end)
 
       for n <- 1..3 do
         assert_receive {TableReaderServer, {:batch_fetched, batch_id}}, 1000
@@ -442,7 +442,7 @@ defmodule Sequin.DatabasesRuntime.TableReaderServerTest do
 
     receive do
       {TableReaderServer, {:batch_fetched, batch_id}} = msg ->
-        assert :ok = TableReaderServer.flush_batch(pid, %{batch_id: batch_id, seq: seq, drop_pks: []})
+        assert :ok = TableReaderServer.flush_batch(pid, %{batch_id: batch_id, seq: seq, drop_pks: MapSet.new()})
 
         flush_batches(pid, seq + 1, [msg | message_history])
 

--- a/test/sequin/table_reader_server_test.exs
+++ b/test/sequin/table_reader_server_test.exs
@@ -206,7 +206,7 @@ defmodule Sequin.DatabasesRuntime.TableReaderServerTest do
 
       {dropped_characters, kept_characters} = characters |> Enum.shuffle() |> Enum.split(3)
 
-      dropped_pks = MapSet.new(dropped_characters, fn character -> [character.id] end)
+      dropped_pks = MapSet.new(dropped_characters, fn character -> [to_string(character.id)] end)
 
       for n <- 1..3 do
         assert_receive {TableReaderServer, {:batch_fetched, batch_id}}, 1000

--- a/test/sequin/table_reader_test.exs
+++ b/test/sequin/table_reader_test.exs
@@ -94,7 +94,7 @@ defmodule Sequin.TableReaderTest do
 
       # This does not test that watermark messages are emitted, we will do this in a separate test
 
-      {:ok, result} =
+      {:ok, result, _lsn} =
         TableReader.with_watermark(db, UUID.uuid4(), batch_id, table_oid, fn conn ->
           Postgrex.query(conn, "select 1", [])
         end)

--- a/test/support/factory/replication_factory.ex
+++ b/test/support/factory/replication_factory.ex
@@ -2,6 +2,7 @@ defmodule Sequin.Factory.ReplicationFactory do
   @moduledoc false
   import Sequin.Factory.Support
 
+  alias Sequin.DatabasesRuntime.PostgresAdapter.Decoder.Messages.LogicalMessage
   alias Sequin.DatabasesRuntime.PostgresAdapter.Decoder.Messages.Relation
   alias Sequin.DatabasesRuntime.SlotProcessor.Message
   alias Sequin.Factory
@@ -152,6 +153,23 @@ defmodule Sequin.Factory.ReplicationFactory do
           field(column_name: "house", value: nil),
           field(column_name: "planet", value: nil)
         ]
+      },
+      attrs
+    )
+  end
+
+  def postgres_logical_message(attrs \\ []) do
+    attrs = Map.new(attrs)
+
+    merge_attributes(
+      %LogicalMessage{
+        prefix: Factory.word(),
+        content:
+          Jason.encode!(%{
+            "batch_id" => "batch_#{Factory.sequence()}",
+            "table_oid" => Factory.unique_integer(),
+            "backfill_id" => "backfill_#{Factory.sequence()}"
+          })
       },
       attrs
     )

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -9,3 +9,7 @@ Mox.defmock(Sequin.Mocks.NatsMock,
 Mox.defmock(Sequin.Mocks.RabbitMqMock,
   for: Sequin.Sinks.RabbitMq
 )
+
+Mox.defmock(Sequin.Mocks.TableReaderServerMock,
+  for: Sequin.DatabasesRuntime.TableReaderServer
+)


### PR DESCRIPTION
For ultimate safety: the TableReaderServer will now check on occasion to see if it's waiting for a batch to flush, but that batch's LSN is behind the slot's current LSN. i.e. - it's waiting for a batch that will never be flushed, as it already missed.

You'll see in the next PR that we also try to have SlotProcessor discard the batch if it sees the high watermark but didn't see the corresponding low watermark.