### PR TITLE
Sort tables by schema and name on "Create * Sink" page

### DIFF
--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -74,12 +74,17 @@
     if (selectedDatabaseId) {
       selectedDatabase = databases.find((db) => db.id === selectedDatabaseId);
     }
-    filteredTables =
+    filteredTables = (
       selectedDatabase?.tables.filter((table) =>
         `${table.schema}.${table.name}`
           .toLowerCase()
           .includes((searchQuery || "").toLowerCase()),
-      ) || [];
+      ) || []
+    ).sort((a: any, b: any) =>
+      a.schema === b.schema
+        ? a.name.localeCompare(b.name)
+        : a.schema.localeCompare(b.schema),
+    );
 
     if (onlyEventTables) {
       filteredTables = filteredTables.filter((table) => table.isEventTable);


### PR DESCRIPTION
This small change improves the UI by sorting the `filteredTables` variable by schema and name. The update ensures a more organized and predictable table display for better user experience.

before:
<img width="450" src="https://github.com/user-attachments/assets/172a4126-84d0-48ef-a762-7955e6b1620d" />

after:
<img width="450" src="https://github.com/user-attachments/assets/e5acb9dd-719f-4b06-8a43-73903e79d165" />
