### PR TITLE
✨ Improve logs with metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,10 +14,10 @@ config :esbuild, :version, "0.17.11"
 
 # Configures Elixir's Logger
 config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  level: :info,
+  format: {Sequin.ConsoleLogger, :format},
+  metadata: :all
 
-# Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
 config :sentry,
@@ -43,6 +43,8 @@ config :sequin, Oban,
        {"*/2 * * * *", Sequin.Health.SnapshotHealthWorker}
      ]}
   ]
+
+config :sequin, Sequin.ConsoleLogger, drop_metadata_keys: [:file, :domain, :application]
 
 # Configures the mailer
 #

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,11 +10,6 @@ config :libcluster,
     ]
   ]
 
-config :logger, :console,
-  format: "[$level] [$time] $metadata$message\n",
-  time_format: "%H:%M:%S.%f",
-  metadata: [:pid]
-
 config :mix_test_interactive,
   clear: true
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,8 +9,7 @@ import Config
 self_hosted = System.get_env("SELF_HOSTED", "0") in ~w(1 true)
 
 if self_hosted do
-  config :logger,
-    level: :info
+  config :sequin, Sequin.ConsoleLogger, drop_metadata_keys: [:mfa]
 else
   config :logger,
     level: :info,

--- a/lib/console_logger.ex
+++ b/lib/console_logger.ex
@@ -1,0 +1,29 @@
+defmodule Sequin.ConsoleLogger do
+  @moduledoc false
+  @drop_metadata_keys Application.compile_env(:sequin, [__MODULE__, :drop_metadata_keys], [])
+  @format_pattern Logger.Formatter.compile("[$level] [$time] $message $metadata\n")
+
+  # Example binding. Note some keys are dropped by Elixir's default formatter:
+  # [
+  #   level: :info,
+  #   message: "Running in passive mode, another instance is holding active mutex.",
+  #   metadata: [
+  #     line: 94,
+  #     pid: #PID<0.942.0>,
+  #     time: 1735861762188779,
+  #     file: ~c"lib/sequin/mutex_owner.ex",
+  #     gl: #PID<0.470.0>,
+  #     domain: [:elixir],
+  #     application: :sequin,
+  #     mfa: {Sequin.MutexOwner, :handle_event, 4},
+  #     mutex_key: "sequin:mutexed_supervisor:dev:Elixir.Sequin.Runtime.MutexedSupervisor"
+  #   ],
+  #   timestamp: {{2025, 1, 2}, {15, 49, 22, 188}}
+  # ]
+  def format(level, message, timestamp, metadata) do
+    # Drop metadata keys we don't care about
+    metadata = Keyword.drop(metadata, @drop_metadata_keys)
+
+    Logger.Formatter.format(@format_pattern, level, message, timestamp, metadata)
+  end
+end


### PR DESCRIPTION
Before, we weren't including metadata in log output (in dev or self-hosted prod!) This commit includes all metadata in our log output. We display metadata as `key=value` after the message.

To do so, we're particular about what keys we display. In dev, we don't need keys like `:domain` or `:application` - just noise. But in prod, it's useful to include those, as users will likely use to discriminate Sequin logs from other logs piping into their system.

For a list of the default metadata keys, see the comment in `lib/console_logger.ex`.