### PR TITLE
✏️ Fix typo: a Sinks -> a Sink

### DIFF
--- a/assets/svelte/consumers/SinkIndex.svelte
+++ b/assets/svelte/consumers/SinkIndex.svelte
@@ -108,7 +108,7 @@
 </script>
 
 <div class="container mx-auto py-10">
-  <DatabaseConnectionAlert show={!hasDatabases} entityName="Sinks" />
+  <DatabaseConnectionAlert show={!hasDatabases} entityName="Sink" />
 
   <div class="flex justify-between items-center mb-4">
     <div class="flex items-center">


### PR DESCRIPTION
👋 

This PR improves wording on the first page shown after registration.

<img width="1582" alt="Screenshot 2025-01-11 at 02 54 42" src="https://github.com/user-attachments/assets/97b2dae8-770d-479d-9b33-bf4d09aec691" />

The component always uses "a" so the easiest fix was to use a singular entity name.