### PR TITLE
🔨 Start replication/table readers with catch

### DIFF
--- a/lib/sequin/databases_runtime/slot_message_store.ex
+++ b/lib/sequin/databases_runtime/slot_message_store.ex
@@ -435,6 +435,8 @@ defmodule Sequin.DatabasesRuntime.SlotMessageStore do
     consumer = opts[:consumer]
     consumer_id = if consumer, do: consumer.id, else: Keyword.fetch!(opts, :consumer_id)
 
+    Logger.metadata(consumer_id: consumer_id)
+
     state = %State{
       consumer: consumer,
       consumer_id: consumer_id,


### PR DESCRIPTION
* This prevents a bug where a single failing replication slot prevents
  other replication slots / table readers from starting up