### PR TITLE
:lipstick: Improve WalPipeline health/recovery

### DIFF
--- a/lib/sequin/health/event.ex
+++ b/lib/sequin/health/event.ex
@@ -52,6 +52,8 @@ defmodule Sequin.Health.Event do
   @wal_pipeline_event_slugs [
     :messages_filtered,
     :messages_ingested,
+    :messages_fetch,
+    :messages_delete,
     :destination_insert
   ]
 


### PR DESCRIPTION
Previously in WALPipeline we only tracked health events around inserting to the destination. In this PR we now track health events around fetching from our database and deleting from our database period. This will ensure that ephemeral fetch errors won't stick on the health of a WALPipeline indefinitely. they will clear the next time a successful fetch happens.