### PR TITLE
✨ Add replication lag health checks, console gauge

### DIFF
--- a/assets/svelte/databases/Show.svelte
+++ b/assets/svelte/databases/Show.svelte
@@ -8,6 +8,7 @@
     ArrowRightToLine,
     ArrowLeftFromLine,
     Loader2,
+    CircleGauge,
   } from "lucide-svelte";
   import { Button } from "$lib/components/ui/button";
   import { Card, CardContent } from "$lib/components/ui/card";
@@ -17,6 +18,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import { writable } from "svelte/store";
   import { formatRelativeTimestamp } from "$lib/utils";
+  import HealthAlerts from "$lib/health/HealthAlerts.svelte";
 
   interface Table {
     schema_name: string;
@@ -57,6 +59,7 @@
   export let parent: string;
   export let metrics: {
     avg_latency: number;
+    replication_lag_bytes: number;
   };
 
   let refreshingTables = writable(false);
@@ -110,20 +113,40 @@
       <Card>
         <CardContent class="p-6">
           <div class="flex justify-between items-center mb-4">
-            <span class="text-sm font-medium text-gray-500">Avg. Latency</span>
-            <Clock class="h-5 w-5 text-blue-500" />
+            <span class="text-sm font-medium text-gray-500">Performance</span>
+            <CircleGauge class="h-5 w-5 text-blue-500" />
           </div>
-          {#if metrics.avg_latency}
-            <div class="text-4xl font-bold">{metrics.avg_latency} ms</div>
-          {:else}
-            <div class="flex items-center">
-              <Loader2 class="h-8 w-8 text-gray-400 animate-spin mr-2" />
-              <span class="text-4xl font-bold text-gray-500">ms</span>
+          <div class="space-y-4">
+            <div>
+              <div class="text-sm text-gray-500 mb-1">Avg. Latency</div>
+              {#if metrics.avg_latency}
+                <div class="text-l font-bold">{metrics.avg_latency} ms</div>
+              {:else}
+                <div class="flex items-center">
+                  <Loader2 class="h-8 w-8 text-gray-400 animate-spin mr-2" />
+                  <span class="text-l font-bold text-gray-500">ms</span>
+                </div>
+              {/if}
             </div>
-          {/if}
+            <div>
+              <div class="text-sm text-gray-500 mb-1">Replication Lag</div>
+              {#if metrics.replication_lag_bytes !== null}
+                <div class="text-l font-bold">
+                  {Math.round(metrics.replication_lag_bytes / 1024 / 1024)} mb
+                </div>
+              {:else}
+                <div class="flex items-center">
+                  <Loader2 class="h-8 w-8 text-gray-400 animate-spin mr-2" />
+                  <span class="text-l font-bold text-gray-500">mb</span>
+                </div>
+              {/if}
+            </div>
+          </div>
         </CardContent>
       </Card>
     </div>
+
+    <HealthAlerts checks={database.health.checks} {pushEvent} />
 
     <Card class="mb-6">
       <CardContent class="p-6">

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -405,14 +405,6 @@ defmodule Sequin.Databases do
     end)
   end
 
-  def replication_lag_bytes(%PostgresDatabase{} = database) do
-    database = Repo.preload(database, :replication_slot)
-
-    with_connection(database, fn conn ->
-      Postgres.replication_lag_bytes(conn, database.replication_slot.slot_name)
-    end)
-  end
-
   defp create_replication_slot(conn, slot_name) do
     # First, check if the slot already exists
     check_query = "SELECT 1 FROM pg_replication_slots WHERE slot_name = $1"

--- a/lib/sequin/health/check.ex
+++ b/lib/sequin/health/check.ex
@@ -41,12 +41,13 @@ defmodule Sequin.Health.Check do
 
   def to_external(%Check{} = check) do
     error_code = if check.error && Map.has_key?(check.error, :code), do: check.error.code
+    error_details = if check.error && Map.has_key?(check.error, :details), do: check.error.details
 
     %{
       slug: check.slug,
       name: check_name(check),
       status: if(check.status == :waiting, do: :initializing, else: check.status),
-      error: if(check.error, do: %{message: Exception.message(check.error), code: error_code}),
+      error: if(check.error, do: %{message: Exception.message(check.error), code: error_code, details: error_details}),
       error_slug: check.error_slug
     }
   end

--- a/lib/sequin/health/event.ex
+++ b/lib/sequin/health/event.ex
@@ -31,7 +31,8 @@ defmodule Sequin.Health.Event do
     :replication_connected,
     :replication_message_processed,
     :replication_heartbeat_received,
-    :replication_memory_limit_exceeded
+    :replication_memory_limit_exceeded,
+    :replication_lag_checked
   ]
 
   @sink_consumer_event_slugs [

--- a/lib/sequin/metrics/metrics.ex
+++ b/lib/sequin/metrics/metrics.ex
@@ -8,6 +8,7 @@ defmodule Sequin.Metrics do
   alias Sequin.Consumers.HttpEndpoint
   alias Sequin.Databases.PostgresDatabase
   alias Sequin.Metrics.Store
+  alias Sequin.Replication.PostgresReplicationSlot
 
   # Consumer Messages Processed
   def incr_consumer_messages_processed_count(%{id: id}, count \\ 1) do
@@ -55,5 +56,13 @@ defmodule Sequin.Metrics do
 
   def get_http_endpoint_avg_latency(%HttpEndpoint{id: id}) do
     Store.get_latency("http_endpoint_avg_latency:#{id}")
+  end
+
+  def measure_postgres_replication_slot_lag(%PostgresReplicationSlot{id: id}, lag_bytes) do
+    Store.measure_gauge("postgres_replication_slot_lag:#{id}", lag_bytes)
+  end
+
+  def get_postgres_replication_slot_lag(%PostgresReplicationSlot{id: id}) do
+    Store.get_gauge("postgres_replication_slot_lag:#{id}")
   end
 end

--- a/lib/sequin/metrics/store.ex
+++ b/lib/sequin/metrics/store.ex
@@ -112,4 +112,19 @@ defmodule Sequin.Metrics.Store do
         {:error, error}
     end
   end
+
+  def measure_gauge(key, value) do
+    case Redis.command(["SET", "metrics:gauge:#{key}", value]) do
+      {:ok, _} -> :ok
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def get_gauge(key) do
+    case Redis.command(["GET", "metrics:gauge:#{key}"]) do
+      {:ok, nil} -> {:ok, nil}
+      {:ok, value} -> {:ok, String.to_integer(value)}
+      {:error, error} -> {:error, error}
+    end
+  end
 end

--- a/test/sequin/replication_test.exs
+++ b/test/sequin/replication_test.exs
@@ -1,7 +1,10 @@
 defmodule Sequin.ReplicationTest do
   use Sequin.DataCase, async: true
 
+  alias Sequin.Factory.DatabasesFactory
   alias Sequin.Factory.ReplicationFactory
+  alias Sequin.Health
+  alias Sequin.Metrics
   alias Sequin.Replication
 
   describe "list_wal_events/2" do
@@ -119,6 +122,48 @@ defmodule Sequin.ReplicationTest do
     test "returns ok with 0 count when no events match the given ids" do
       {:ok, deleted_count} = Replication.delete_wal_events([Ecto.UUID.generate(), Ecto.UUID.generate()])
       assert deleted_count == 0
+    end
+  end
+
+  describe "measure_replication_lag/2" do
+    setup do
+      replication_slot =
+        ReplicationFactory.postgres_replication(
+          inserted_at: Sequin.utc_now(),
+          status: :active,
+          postgres_database: DatabasesFactory.postgres_database()
+        )
+
+      {:ok, slot: replication_slot}
+    end
+
+    test "records metrics and health events when lag is below threshold", %{slot: slot} do
+      lag_bytes = 100_000
+
+      measure_fn = fn _slot -> {:ok, lag_bytes} end
+
+      assert {:ok, ^lag_bytes} = Replication.measure_replication_lag(slot, measure_fn)
+
+      # Verify metrics were recorded
+      assert {:ok, ^lag_bytes} = Metrics.get_postgres_replication_slot_lag(slot)
+    end
+
+    test "records warning health event when lag exceeds threshold", %{slot: slot} do
+      # Set lag above the threshold
+      lag_bytes = 10 * 1024 * 1024 * 1024
+
+      measure_fn = fn _slot -> {:ok, lag_bytes} end
+
+      Replication.measure_replication_lag(slot, measure_fn)
+
+      # Verify metrics were recorded
+      assert {:ok, ^lag_bytes} = Metrics.get_postgres_replication_slot_lag(slot)
+
+      # Verify health event was recorded with warning status
+      assert {:ok, event} = Health.get_event(slot.id, :replication_lag_checked)
+      assert event.status == :warning
+      assert {:ok, health} = Health.health(slot)
+      assert health.status == :warning
     end
   end
 end


### PR DESCRIPTION
We show the warning at **2GB**

Copy-pasta from how we augment alerts in SinkConsumer. Figured we could get away with it for a _little_ longer.

We'll need some design help to figure out how to organize these alerts and gauges on the console.

**NOTE**: I down-cased `MB` -> `mb` in the console to match `ms` after these screenshots:

![CleanShot 2025-02-06 at 19 52 30@2x](https://github.com/user-attachments/assets/65a99e88-18c2-4707-b4b8-f14b2e42e944)
![CleanShot 2025-02-06 at 19 49 58@2x](https://github.com/user-attachments/assets/f54f78e4-cdb3-408a-90c5-e6ebfa3c936b)

