### PR TITLE
Add `Consumers.max_memory_mb`

### DIFF
--- a/lib/sequin/consumers_runtime/lifecycle_event_worker.ex
+++ b/lib/sequin/consumers_runtime/lifecycle_event_worker.ex
@@ -48,6 +48,8 @@ defmodule Sequin.ConsumersRuntime.LifecycleEventWorker do
   end
 
   defp handle_consumer_event(event, id, data) do
+    :syn.publish(:consumers, :consumers_changed, :consumers_changed)
+
     case event do
       "create" ->
         with {:ok, consumer} <- Consumers.get_consumer(id) do

--- a/lib/sequin/size.ex
+++ b/lib/sequin/size.ex
@@ -1,0 +1,22 @@
+defmodule Sequin.Size do
+  @moduledoc """
+  Helpers for working with sizes in bytes.
+
+  Like `:timer.minutes/1` etc for bytes.
+  """
+
+  @spec bytes(bytes :: non_neg_integer()) :: bytes :: non_neg_integer()
+  def bytes(n), do: n
+
+  @spec kb(kilobytes :: non_neg_integer()) :: bytes :: non_neg_integer()
+  def kb(n), do: n * 1024
+
+  @spec mb(megabytes :: non_neg_integer()) :: bytes :: non_neg_integer()
+  def mb(n), do: n * 1024 * 1024
+
+  @spec gb(gigabytes :: non_neg_integer()) :: bytes :: non_neg_integer()
+  def gb(n), do: n * 1024 * 1024 * 1024
+
+  @spec tb(terabytes :: non_neg_integer()) :: bytes :: non_neg_integer()
+  def tb(n), do: n * 1024 * 1024 * 1024 * 1024
+end

--- a/lib/sequin_web/live/components/consumer_form.ex
+++ b/lib/sequin_web/live/components/consumer_form.ex
@@ -59,6 +59,7 @@ defmodule SequinWeb.Components.ConsumerForm do
       |> assign(:encoded_databases, Enum.map(assigns.databases, &encode_database/1))
       |> assign(:encoded_http_endpoints, Enum.map(assigns.http_endpoints, &encode_http_endpoint/1))
       |> assign(:consumer_title, consumer_title(assigns.consumer))
+      |> assign(:self_hosted, self_hosted?())
 
     ~H"""
     <div id={@id}>
@@ -73,7 +74,8 @@ defmodule SequinWeb.Components.ConsumerForm do
             submitError: @submit_error,
             parent: @id,
             databases: @encoded_databases,
-            httpEndpoints: @encoded_http_endpoints
+            httpEndpoints: @encoded_http_endpoints,
+            isSelfHosted: @self_hosted
           }
         }
         socket={@socket}
@@ -431,6 +433,7 @@ defmodule SequinWeb.Components.ConsumerForm do
         "sink" => decode_sink(socket.assigns.consumer.type, form["sink"]),
         "max_ack_pending" => form["maxAckPending"],
         "max_waiting" => form["maxWaiting"],
+        "max_memory_mb" => form["maxMemoryMb"],
         "message_kind" => form["messageKind"],
         "name" => form["name"],
         "postgres_database_id" => form["postgresDatabaseId"],
@@ -590,6 +593,7 @@ defmodule SequinWeb.Components.ConsumerForm do
       "name" => consumer.name || Name.generate(999),
       "ack_wait_ms" => consumer.ack_wait_ms,
       "batch_size" => Map.get(consumer, :batch_size),
+      "max_memory_mb" => consumer.max_memory_mb,
       "group_column_attnums" => source_table && source_table.group_column_attnums,
       "max_ack_pending" => consumer.max_ack_pending,
       "max_deliver" => consumer.max_deliver,
@@ -1024,5 +1028,10 @@ defmodule SequinWeb.Components.ConsumerForm do
       table = Sequin.Enum.find!(db.tables, &(&1.oid == table_oid))
       %{table | sort_column_attnum: sort_column_attnum}
     end
+  end
+
+  defp self_hosted? do
+    Application.get_env(:sequin, :env) != :prod or
+      Application.get_env(:sequin, :self_hosted)
   end
 end

--- a/priv/repo/migrations/20250213215937_add_max_memory_mb_to_sink_consumers.exs
+++ b/priv/repo/migrations/20250213215937_add_max_memory_mb_to_sink_consumers.exs
@@ -1,0 +1,11 @@
+defmodule Sequin.Repo.Migrations.AddMaxMemoryMbToSinkConsumers do
+  use Ecto.Migration
+
+  @config_schema Application.compile_env(:sequin, [Sequin.Repo, :config_schema_prefix])
+
+  def change do
+    alter table(:sink_consumers, prefix: @config_schema) do
+      add :max_memory_mb, :integer, default: 1024, null: false
+    end
+  end
+end

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -19,6 +19,7 @@ defmodule Sequin.ConsumersTest do
   alias Sequin.Factory.ConsumersFactory
   alias Sequin.Factory.DatabasesFactory
   alias Sequin.Factory.ReplicationFactory
+  alias Sequin.Size
 
   describe "ack_messages/2" do
     setup do
@@ -2264,6 +2265,33 @@ defmodule Sequin.ConsumersTest do
 
       assert [updated_msg] = Consumers.list_consumer_messages_for_consumer(consumer)
       refute updated_msg.not_visible_until == existing_msg.not_visible_until
+    end
+  end
+
+  describe "max_system_memory_bytes_for_consumer/3" do
+    test "returns minimum between consumer's and system's per-consumer max memory" do
+      # Set up a consumer with 1000MB max memory
+      consumer = ConsumersFactory.sink_consumer(max_memory_mb: 1000)
+
+      # Mock system having 2000MB total memory
+      system_max_bytes = Size.mb(2000)
+
+      # With single consumer, returns consumer's max_bytes since it's lower
+      expected_consumer_max_bytes = round(Size.mb(1000) * 0.8)
+      assert Consumers.max_system_memory_bytes_for_consumer(consumer, 1, system_max_bytes) == expected_consumer_max_bytes
+
+      # With 5 consumers sharing system memory
+      expected_shared_max_bytes = round(system_max_bytes / 5 * 0.8)
+
+      # Each consumer (even with different memory limits) gets equal share of system memory
+      consumers =
+        for _ <- 1..4 do
+          ConsumersFactory.sink_consumer(max_memory_mb: Enum.random(1000..10_000))
+        end
+
+      Enum.each(consumers, fn consumer ->
+        assert Consumers.max_system_memory_bytes_for_consumer(consumer, 5, system_max_bytes) == expected_shared_max_bytes
+      end)
     end
   end
 end

--- a/test/sequin/slot_message_store_state_test.exs
+++ b/test/sequin/slot_message_store_state_test.exs
@@ -7,6 +7,7 @@ defmodule Sequin.DatabasesRuntime.SlotMessageStoreStateTest do
   alias Sequin.Factory
   alias Sequin.Factory.ConsumersFactory
   alias Sequin.Multiset
+  alias Sequin.Size
 
   setup do
     state = %State{consumer: %SinkConsumer{seq: Factory.unique_integer()}}
@@ -56,11 +57,11 @@ defmodule Sequin.DatabasesRuntime.SlotMessageStoreStateTest do
     end
 
     test "returns error when exceeding setting_max_accumulated_payload_bytes", %{state: state} do
-      state = %{state | setting_max_accumulated_payload_bytes: 150}
+      state = %{state | max_memory_bytes: Size.mb(100)}
 
-      msg1 = ConsumersFactory.consumer_message(payload_size_bytes: 100)
+      msg1 = ConsumersFactory.consumer_message(payload_size_bytes: Size.mb(100))
 
-      msg2 = ConsumersFactory.consumer_message(payload_size_bytes: 100)
+      msg2 = ConsumersFactory.consumer_message(payload_size_bytes: Size.mb(100))
 
       assert {:error, %Error.InvariantError{}} = State.put_messages(state, [msg1, msg2])
     end

--- a/test/support/factory/consumers_factory.ex
+++ b/test/support/factory/consumers_factory.ex
@@ -83,6 +83,7 @@ defmodule Sequin.Factory.ConsumersFactory do
         max_ack_pending: 10_000,
         max_deliver: Enum.random(1..100),
         max_waiting: 20,
+        max_memory_mb: Enum.random(200..2048),
         message_kind: message_kind,
         name: Factory.unique_word(),
         replication_slot_id: replication_slot_id,


### PR DESCRIPTION
Allows for configuring a max_memory_mb per consumer in self-hosted environments. Sequin will set a soft memory limit on a consumer based on a consumer's max_memory_mb and the system's configured MAX_MEMORY_MB (whichever is lesser).

![CleanShot 2025-02-13 at 14 20 30@2x](https://github.com/user-attachments/assets/b75393fd-0804-42e1-8ebb-e0e23a38eb98)
![CleanShot 2025-02-13 at 14 21 38@2x](https://github.com/user-attachments/assets/4d0cb05a-23d7-41c5-bffa-6db1035a8f30)
