### PR TITLE
Fix picking context names that contain spaces

### DIFF
--- a/cli/cli/context_command.go
+++ b/cli/cli/context_command.go
@@ -266,7 +266,7 @@ func (c *ctxCommand) pickContext(message string) error {
 		return err
 	}
 
-	c.name = strings.SplitN(choice, " ", 2)[0]
+	c.name = choice
 	return nil
 }
 


### PR DESCRIPTION
Currently, the CLI context picker splits the selected context name on white spaces, grabbing only the first part. The consequence of this is that when, for example, a context is picked for removal and its name contains spaces, the CLI will try to delete a file that doesn't exist or, even worse, an existing file that was not meant to be deleted.

For example, considering a context created with the name "local test", when attempting to remove it via the selector list will result in the CLI trying to remove the file `/home/$HOME/.sequin/contexts/local.json` instead of `/home/$HOME/.sequin/contexts/local test.json`

I don't see why, as the choice variable that contains the context name doesn't contain anything else. Perhaps it's a leftover from a previous iteration when choice had more than just the context name? 

This PR removes the splitting so that the full name is returned.

PS - my Elixir setup is currently broken, so I couldn't run `make signoff`, as it needs the `mix` command.