### PR TITLE
Removed unused const and type

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -12,5 +12,3 @@ var (
 type Config struct {
 	ContextName string
 }
-
-const LogFilePath = "sequin.log"

--- a/cli/cli/table.go
+++ b/cli/cli/table.go
@@ -2,16 +2,12 @@ package cli
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
 type TableType int
-
-type tickMsg time.Time
 
 const (
 	PrintableTable TableType = iota


### PR DESCRIPTION
Going through the code and removed unused const and type.  No logic changes. 

Note, I was not able to run `make signoff` because it failed locally with the following error:


[error] [06:42:10.042] Postgrex.Protocol (#PID<0.5759.0>) failed to connect: ** (Postgrex.Error) FATAL 53300 (too_many_connections) sorry, too many clients already line=107 pid=<0.5759.0> mfa=DBConnection.Connection.handle_event/4 

I _was_ able to run `make build` and the CLI built fine after the changes.