### PR TITLE
Add verbiage in Contributions page for needed pguser 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,12 @@ Thank you for your interest in contributing to Sequin! This document outlines th
     ```bash
     docker compose up -d
     ```
+
+    If you encounter an error about the default PostgreSQL user "postgres" not existing, you can create the user with:
+    ```bash
+    createuser -s postgres
+    ```
+
 3. Run the setup script
     ```bash
     mix setup


### PR DESCRIPTION
This PR addresses an issue first-time contributors of the project might come across.  One caveat was that I was not able to run the `make signoff` call because it was failing locally. 


I was going through the Contribution page. When running `mix setup`, you may encounter an error if the default PostgreSQL user "postgres" does not exist. This can be resolved by running `createuser -s postgres`. This step is only required once.


```
[error] Postgrex.Protocol (#PID<0.561.0>) failed to connect: ** (Postgrex.Error) FATAL 28000 (invalid_authorization_specification) role "postgres" does not exist
```

