### PR TITLE
Add vector extension to docker image so mix test can pass

### DIFF
--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,17 @@
+FROM postgres:17
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    postgresql-server-dev-17 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone and install pgvector
+RUN git clone --branch v0.5.1 https://github.com/pgvector/pgvector.git \
+    && cd pgvector \
+    && make \
+    && make install
+
+# Cleanup
+RUN rm -rf pgvector

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,9 @@ name: sequin-dev
 
 services:
   postgres:
-    image: "postgres:17"
+    build: 
+      context: .
+      dockerfile: Dockerfile.postgres
     command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200 -c pg_stat_statements.max=10000 -c track_activity_query_size=2048 -c wal_level=logical
     ports:
       - "127.0.0.1:5432:5432"


### PR DESCRIPTION
Before: `mix test` was failing because docker image did not have the vector extension. This PR builds a pg container with vector and uses that image. 

After: `mix test` passes. 

To test: 

docker compose down
docker compose build
docker compose up

run `mix test`

