### PR TITLE
🐛 [TableReaderServer] Tag watermarks with replication_id

### DIFF
--- a/lib/sequin/databases_runtime/table_reader.ex
+++ b/lib/sequin/databases_runtime/table_reader.ex
@@ -85,12 +85,13 @@ defmodule Sequin.DatabasesRuntime.TableReader do
 
   # Queries
   @emit_logical_message_sql "select pg_logical_emit_message(true, $1, $2)"
-  def with_watermark(%PostgresDatabase{} = db, backfill_id, current_batch_id, table_oid, fun) do
+  def with_watermark(%PostgresDatabase{} = db, replication_slot_id, backfill_id, current_batch_id, table_oid, fun) do
     payload =
       Jason.encode!(%{
         table_oid: table_oid,
         batch_id: current_batch_id,
-        backfill_id: backfill_id
+        backfill_id: backfill_id,
+        replication_slot_id: replication_slot_id
       })
 
     with {:ok, conn} <- ConnectionCache.connection(db),

--- a/test/sequin/table_reader_test.exs
+++ b/test/sequin/table_reader_test.exs
@@ -97,7 +97,7 @@ defmodule Sequin.TableReaderTest do
       # This does not test that watermark messages are emitted, we will do this in a separate test
 
       {:ok, result, _lsn} =
-        TableReader.with_watermark(db, UUID.uuid4(), batch_id, table_oid, fn conn ->
+        TableReader.with_watermark(db, UUID.uuid4(), UUID.uuid4(), batch_id, table_oid, fn conn ->
           Postgrex.query(conn, "select 1", [])
         end)
 

--- a/test/support/factory/character_factory.ex
+++ b/test/support/factory/character_factory.ex
@@ -112,7 +112,7 @@ defmodule Sequin.Factory.CharacterFactory do
         name: Factory.name(),
         status: Factory.one_of([:active, :inactive, :retired]),
         power_level: Factory.non_neg_integer(),
-        age: Factory.integer(),
+        age: Factory.non_neg_integer(),
         height: Factory.float(min: 1, max: 3),
         is_hero: Factory.boolean(),
         biography: Faker.Lorem.paragraph(),

--- a/test/support/factory/factory.ex
+++ b/test/support/factory/factory.ex
@@ -31,7 +31,7 @@ defmodule Sequin.Factory do
   def http_method, do: one_of([:get, :post, :put, :patch, :delete])
   def index, do: Faker.random_between(1, 250_000)
   def integer, do: Faker.random_between(1, 100_000)
-  def non_neg_integer, do: Faker.random_between(0, 100_000)
+  def non_neg_integer, do: Faker.random_between(1, 100_000)
   def iso_timestamp, do: DateTime.to_iso8601(timestamp())
   def last_name, do: Faker.Person.last_name()
   def milliseconds, do: Faker.random_between(1, 300_000)


### PR DESCRIPTION
- Support multiple replication slots on one database by tagging each watermark with a replication_id
- More assertive handling of situation where we receive a flush_batch after already having flushed the batch