### PR TITLE
🐛 Clean up Metrics for acked messages

### DIFF
--- a/lib/sequin/tracer/server.ex
+++ b/lib/sequin/tracer/server.ex
@@ -52,7 +52,7 @@ defmodule Sequin.Tracer.Server do
 
   def messages_acked(_consumer, []), do: :ok
 
-  def messages_acked(consumer, ack_ids) do
+  def messages_acked(consumer, ack_ids) when is_list(ack_ids) do
     GenServer.cast(via_tuple(consumer.account_id), {:acked, consumer, ack_ids})
   end
 

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -95,7 +95,11 @@ defmodule Sequin.ConsumersTest do
       record1 = ConsumersFactory.insert_consumer_record!(consumer_id: consumer.id, state: :delivered)
       record2 = ConsumersFactory.insert_consumer_record!(consumer_id: consumer.id, state: :delivered)
 
+      record1 = %ConsumerRecord{record1 | payload_size_bytes: Size.bytes(100)}
+      record2 = %ConsumerRecord{record2 | payload_size_bytes: Size.bytes(200)}
+
       assert {:ok, 2} = Consumers.ack_messages(consumer, [record1.ack_id, record2.ack_id])
+      assert {:ok, 2} = Consumers.after_messages_acked(consumer, [record1, record2])
 
       assert {:ok, messages} = AcknowledgedMessages.fetch_messages(consumer.id)
       assert length(messages) == 2


### PR DESCRIPTION
* This resolves a bug where the Posthog Telemetry Reporter detaches due
  to `key :bytes_processed not found`
* This also resolves a bug where messages stored in Postgres are counted
  twice towards message throughput / count