### PR TITLE
:recycle: Prepare for async message handler by adding before_handle_messages

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -9,6 +9,7 @@ alias Sequin.Databases.PostgresDatabase
 alias Sequin.DatabasesRuntime.SlotMessageStore
 alias Sequin.DatabasesRuntime.SlotProcessor
 alias Sequin.DatabasesRuntime.SlotSupervisor
+alias Sequin.DatabasesRuntime.TableReaderServer
 alias Sequin.Health
 alias Sequin.Postgres
 alias Sequin.Replication

--- a/lib/sequin/databases_runtime/message_handler_behaviour.ex
+++ b/lib/sequin/databases_runtime/message_handler_behaviour.ex
@@ -7,6 +7,21 @@ defmodule Sequin.DatabasesRuntime.SlotProcessor.MessageHandlerBehaviour do
   alias Sequin.DatabasesRuntime.SlotProcessor.Message
 
   @doc """
+  Callback invoked before handling a batch of replication messages.
+
+  ## Parameters
+
+    * `context` - Any context passed by the caller to SlotProcessor.
+    * `messages` - A list of Record types (InsertedRecord, UpdatedRecord, or DeletedRecord) that SlotProcessor handles.
+
+  ## Returns
+
+    The return value is :ok or {:error, reason}.
+  """
+  @callback before_handle_messages(context :: any(), messages :: [Message.t()]) ::
+              :ok | {:error, reason :: any()}
+
+  @doc """
   Callback invoked to handle a batch of replication messages.
 
   ## Parameters

--- a/lib/sequin/databases_runtime/slot_processor.ex
+++ b/lib/sequin/databases_runtime/slot_processor.ex
@@ -1047,6 +1047,8 @@ defmodule Sequin.DatabasesRuntime.SlotProcessor do
       incr_counter(:messages_processed_since_last_log, count)
 
       # Flush accumulated messages
+      # Temp: Do this here, as handle_messages call is going to become async
+      state.message_handler_module.before_handle_messages(state.message_handler_ctx, messages)
       {time, res} = :timer.tc(fn -> state.message_handler_module.handle_messages(state.message_handler_ctx, messages) end)
 
       state.backfill_watermark_messages

--- a/lib/sequin/databases_runtime/table_reader_server.ex
+++ b/lib/sequin/databases_runtime/table_reader_server.ex
@@ -31,6 +31,10 @@ defmodule Sequin.DatabasesRuntime.TableReaderServer do
 
   @callback flush_batch(String.t() | pid(), map()) :: :ok
 
+  @callback pks_seen(String.t(), [any()]) :: :ok
+
+  @callback running_for_consumer?(String.t()) :: boolean()
+
   @max_backoff_ms :timer.seconds(1)
   @max_backoff_time :timer.minutes(1)
 
@@ -74,6 +78,24 @@ defmodule Sequin.DatabasesRuntime.TableReaderServer do
     :exit, _ ->
       Logger.warning("[TableReaderServer] Table reader for backfill #{backfill_id} not running, skipping drop_pks")
       :ok
+  end
+
+  @doc """
+  Checks if a table reader server is running for a given consumer ID.
+
+  ## Parameters
+    * `consumer_id` - The ID of the consumer to check
+
+  ## Returns
+    * `true` - If the table reader server is running
+    * `false` - If the table reader server is not running
+  """
+  @spec running_for_consumer?(String.t()) :: boolean()
+  def running_for_consumer?(consumer_id) when is_binary(consumer_id) do
+    case :ets.whereis(multiset_name(consumer_id)) do
+      :undefined -> false
+      _table -> true
+    end
   end
 
   @doc """

--- a/test/sequin/postgres_replication_test.exs
+++ b/test/sequin/postgres_replication_test.exs
@@ -714,6 +714,8 @@ defmodule Sequin.PostgresReplicationTest do
 
       test_pid = self()
 
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
+
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         send(test_pid, {:change, msgs})
         {:ok, length(msgs)}
@@ -732,6 +734,8 @@ defmodule Sequin.PostgresReplicationTest do
 
     test "changes in a transaction are buffered then delivered to message handler in order" do
       test_pid = self()
+
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
 
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         send(test_pid, {:changes, msgs})
@@ -780,6 +784,8 @@ defmodule Sequin.PostgresReplicationTest do
       test_pid = self()
 
       # simulate a message mis-handle/crash
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
+
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         send(test_pid, {:change, msgs})
         raise "Simulated crash"
@@ -797,6 +803,8 @@ defmodule Sequin.PostgresReplicationTest do
 
       stop_replication!()
 
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
+
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         send(test_pid, {:change, msgs})
         {:ok, length(msgs)}
@@ -813,6 +821,8 @@ defmodule Sequin.PostgresReplicationTest do
 
     test "creates, updates, and deletes are captured" do
       test_pid = self()
+
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
 
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         send(test_pid, {:change, msgs})
@@ -861,6 +871,8 @@ defmodule Sequin.PostgresReplicationTest do
 
     test "messages are processed exactly once, even after crash and reboot" do
       test_pid = self()
+
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
 
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         send(test_pid, {:changes, msgs})
@@ -922,6 +934,8 @@ defmodule Sequin.PostgresReplicationTest do
       # Attempt to start replication with the non-existent slot
       start_replication!(heartbeat_interval: 5)
 
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
+
       stub(MessageHandlerMock, :handle_messages, fn _ctx, [] ->
         {:ok, 0}
       end)
@@ -945,6 +959,8 @@ defmodule Sequin.PostgresReplicationTest do
       check_memory_fn = fn ->
         :atomics.get(memory_counter, 1)
       end
+
+      stub(MessageHandlerMock, :before_handle_messages, fn _ctx, _msgs -> :ok end)
 
       stub(MessageHandlerMock, :handle_messages, fn _ctx, msgs ->
         {:ok, length(msgs)}


### PR DESCRIPTION
We need to call `pks_seen` synchronously, before flushing a TableReaderServer batch. This solution (temp) moves the call out of soon-to-be-async handle_messages and into another callback.