### PR TITLE
:bug: Restart replication after sink_consumer update

### DIFF
--- a/lib/sequin/databases/connection_cache.ex
+++ b/lib/sequin/databases/connection_cache.ex
@@ -212,7 +212,9 @@ defmodule Sequin.Databases.ConnectionCache do
 
     defp default_stop(conn) do
       Task.Supervisor.async_nolink(Sequin.TaskSupervisor, fn ->
-        GenServer.stop(conn)
+        if Process.alive?(conn) do
+          GenServer.stop(conn)
+        end
       end)
 
       :ok

--- a/lib/sequin/runtime/database_lifecycle_event_worker.ex
+++ b/lib/sequin/runtime/database_lifecycle_event_worker.ex
@@ -47,7 +47,7 @@ defmodule Sequin.Runtime.DatabaseLifecycleEventWorker do
       "update" ->
         with {:ok, %PostgresDatabase{} = db} <- Databases.get_db(id) do
           db = Repo.preload(db, [:replication_slot])
-          Runtime.Supervisor.restart_replication(db.replication_slot.id)
+          Runtime.Supervisor.restart_replication(db.replication_slot)
         end
 
       "delete" ->

--- a/lib/sequin/runtime/slot_supervisor.ex
+++ b/lib/sequin/runtime/slot_supervisor.ex
@@ -60,6 +60,11 @@ defmodule Sequin.Runtime.SlotSupervisor do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
+  def stop_slot_processor(id) do
+    sup_via = via_tuple(id)
+    Sequin.DynamicSupervisor.stop_child(sup_via, SlotProcessor.via_tuple(id))
+  end
+
   def start_children(%PostgresReplicationSlot{} = pg_replication, opts) do
     pg_replication =
       Repo.preload(pg_replication, [

--- a/lib/sequin/runtime/supervisor.ex
+++ b/lib/sequin/runtime/supervisor.ex
@@ -119,7 +119,7 @@ defmodule Sequin.Runtime.Supervisor do
     start_table_reader(supervisor, consumer, opts)
   end
 
-  def start_replication(supervisor \\ slot_supervisor(), pg_replication_or_id, opts \\ [])
+  def start_replication(supervisor \\ slot_supervisor(), pg_replication, opts \\ [])
 
   def start_replication(_supervisor, %PostgresReplicationSlot{status: :disabled} = pg_replication, _opts) do
     Logger.info("PostgresReplicationSlot #{pg_replication.id} is disabled, skipping start")
@@ -179,12 +179,13 @@ defmodule Sequin.Runtime.Supervisor do
 
   def stop_replication(supervisor, id) do
     Logger.info("[Runtime.Supervisor] Stopping replication #{id}")
+    SlotSupervisor.stop_slot_processor(id)
     Sequin.DynamicSupervisor.stop_child(supervisor, SlotSupervisor.via_tuple(id))
   end
 
-  def restart_replication(supervisor \\ slot_supervisor(), pg_replication_or_id) do
-    stop_replication(supervisor, pg_replication_or_id)
-    start_replication(supervisor, pg_replication_or_id)
+  def restart_replication(supervisor \\ slot_supervisor(), %PostgresReplicationSlot{} = pg_replication) do
+    stop_replication(supervisor, pg_replication)
+    start_replication(supervisor, pg_replication)
   end
 
   def start_wal_pipeline_servers(supervisor \\ wal_event_supervisor(), pg_replication) do


### PR DESCRIPTION
After a sink_consumer is updated, we need to restart the ConsumerProducer/Pipeline. In order to do that, we need to restart the SMS+CP pair, and therefore need to restart the SlotProcessor.