### PR TITLE
SlotProcessor clean-up

### DIFF
--- a/lib/sequin/health/check_postgres_replication_slot_worker.ex
+++ b/lib/sequin/health/check_postgres_replication_slot_worker.ex
@@ -17,6 +17,7 @@ defmodule Sequin.Health.CheckPostgresReplicationSlotWorker do
   alias Sequin.NetworkUtils
   alias Sequin.Replication
   alias Sequin.Repo
+  alias Sequin.Statsd
 
   require Logger
 
@@ -111,6 +112,10 @@ defmodule Sequin.Health.CheckPostgresReplicationSlotWorker do
         if lag_bytes > Replication.lag_bytes_alert_threshold(slot) do
           Logger.warning("Replication lag is #{lag_mb}MB")
         else
+          Statsd.gauge("sequin.db.replication_lag_mb", lag_mb,
+            tags: %{replication_slot_id: slot.id, account_id: slot.account_id}
+          )
+
           Logger.info("Replication lag is #{lag_mb}MB")
         end
 

--- a/lib/sequin/load_generator.ex
+++ b/lib/sequin/load_generator.ex
@@ -61,8 +61,8 @@ defmodule Sequin.LoadGenerator do
     workload = Keyword.get(opts, :workload, [:inserts, :updates, :deletes])
 
     # Calculate timing
-    batches_per_second = div(throughput_per_second, batch_size)
-    total_batches = batches_per_second * div(duration_ms, 1000)
+    batches_per_second = throughput_per_second / batch_size
+    total_batches = max(1, round(batches_per_second * (duration_ms / 1000)))
 
     now = System.system_time(:millisecond)
     interval = 1000 / batches_per_second

--- a/lib/sequin/postgres/postgres.ex
+++ b/lib/sequin/postgres/postgres.ex
@@ -553,8 +553,14 @@ defmodule Sequin.Postgres do
 
   def fetch_table_oid(conn, schema, table) do
     case query(conn, "SELECT '#{quote_name(schema)}.#{quote_name(table)}'::regclass::oid") do
-      {:ok, %{rows: [[oid]]}} -> oid
-      _ -> nil
+      {:ok, %{rows: [[oid]]}} ->
+        {:ok, oid}
+
+      {:error, %Postgrex.Error{postgres: %{code: :undefined_table}}} ->
+        {:error, Error.not_found(entity: :table_oid, params: %{schema: schema, table: table})}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/sequin/runtime/postgres_adapter/decoder.ex
+++ b/lib/sequin/runtime/postgres_adapter/decoder.ex
@@ -243,6 +243,17 @@ defmodule Sequin.Runtime.PostgresAdapter.Decoder do
   end
 
   @pg_epoch DateTime.from_iso8601("2000-01-01T00:00:00Z")
+  @type message ::
+          Messages.Relation.t()
+          | Messages.Commit.t()
+          | Messages.Origin.t()
+          | Messages.Insert.t()
+          | Messages.Update.t()
+          | Messages.Delete.t()
+          | Messages.Truncate.t()
+          | Messages.Type.t()
+          | Messages.LogicalMessage.t()
+          | Messages.Unsupported.t()
 
   @doc """
   Parses logical replication messages from Postgres

--- a/lib/sequin/runtime/slot_processor.ex
+++ b/lib/sequin/runtime/slot_processor.ex
@@ -1,0 +1,301 @@
+defmodule Sequin.Runtime.SlotProcessor do
+  @moduledoc false
+  alias Sequin.Databases.ConnectionCache
+  alias Sequin.Databases.PostgresDatabase
+  alias Sequin.Error
+  alias Sequin.Health
+  alias Sequin.Postgres
+  alias Sequin.Replication
+  alias Sequin.Runtime.PostgresAdapter.Decoder
+  alias Sequin.Runtime.PostgresAdapter.Decoder.Messages.Relation
+
+  require Logger
+
+  @type reply :: String.t()
+
+  defmodule State do
+    @moduledoc false
+    use TypedStruct
+
+    alias Sequin.Consumers.SinkConsumer
+    alias Sequin.Replication.PostgresReplicationSlot
+    alias Sequin.Runtime.PostgresAdapter.Decoder.Messages.LogicalMessage
+
+    typedstruct do
+      # Replication slot info
+      field :connection, map()
+      field :id, String.t()
+      field :postgres_database, PostgresDatabase.t()
+      field :publication, String.t()
+      field :replication_slot, PostgresReplicationSlot.t()
+      field :schemas, %{}, default: %{}
+      field :slot_name, String.t()
+      field :test_pid, pid()
+
+      # Current state tracking
+      field :connect_attempts, non_neg_integer(), default: 0
+      field :current_commit_idx, nil | integer()
+      field :current_commit_ts, nil | integer()
+      field :current_xaction_lsn, nil | integer()
+      field :current_xid, nil | integer()
+      field :last_commit_lsn, integer()
+      field :step, :disconnected | :streaming
+
+      # Wal cursors
+      field :low_watermark_wal_cursor, Replication.wal_cursor()
+      field :safe_wal_cursor_fn, (State.t() -> Replication.wal_cursor())
+
+      # Buffers
+      field :accumulated_msg_binaries, %{count: non_neg_integer(), bytes: non_neg_integer(), binaries: [binary()]},
+        default: %{count: 0, bytes: 0, binaries: []}
+
+      field :backfill_watermark_messages, [LogicalMessage.t()], default: []
+      field :flush_timer, nil | reference()
+
+      # Message handlers
+      field :message_handler_ctx, any()
+      field :message_handler_module, atom()
+      field :message_store_refs, %{SinkConsumer.id() => reference()}, default: %{}
+
+      # Health and monitoring
+      field :bytes_received_since_last_limit_check, non_neg_integer(), default: 0
+      field :check_memory_fn, nil | (-> non_neg_integer())
+      field :dirty, boolean(), default: false
+      field :heartbeat_timer, nil | reference()
+
+      # Settings
+      field :bytes_between_limit_checks, non_neg_integer()
+      field :heartbeat_interval, non_neg_integer()
+      field :max_memory_bytes, non_neg_integer()
+    end
+  end
+
+  @eager_decode_msg_kinds [
+    # Relation
+    ?R
+  ]
+
+  @spec handle_data(binary() | Decoder.message(), State.t()) :: {:ok, [reply()], State.t()} | {:error, Error.t()}
+  def handle_data(<<?w, _header::192, msg_kind::8, _::binary>> = bin, %State{} = state)
+      when msg_kind in @eager_decode_msg_kinds do
+    <<?w, _header::192, msg::binary>> = bin
+    msg = Decoder.decode_message(msg)
+    handle_data(msg, state)
+  end
+
+  def handle_data(<<?w, _header::192, msg::binary>>, %State{} = state) do
+    raw_bytes_received = byte_size(msg)
+    incr_counter(:raw_bytes_received, raw_bytes_received)
+    incr_counter(:raw_bytes_received_since_last_log, raw_bytes_received)
+
+    state =
+      Map.update!(state, :accumulated_msg_binaries, fn acc ->
+        %{acc | count: acc.count + 1, bytes: acc.bytes + raw_bytes_received, binaries: [msg | acc.binaries]}
+      end)
+
+    # Update bytes processed and check limits
+    with {:ok, state} <- check_limit(state, raw_bytes_received) do
+      {:ok, [], state}
+    end
+  end
+
+  # Primary keepalive message from server:
+  # https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-PRIMARY-KEEPALIVE-MESSAGE
+  #
+  # Byte1('k')      - Identifies message as a sender keepalive
+  # Int64           - Current end of WAL on the server
+  # Int64           - Server's system clock (microseconds since 2000-01-01 midnight)
+  # Byte1           - 1 if reply requested immediately to avoid timeout, 0 otherwise
+  # The server is not asking for a reply
+  def handle_data(<<?k, _wal_end::64, _clock::64, 0>>, %State{} = state) do
+    # Because these are <14 Postgres databases, they will not receive heartbeat messages
+    # temporarily mark them as healthy if we receive a keepalive message
+    if state.id in ["59d70fc1-e6a2-4c0e-9f4d-c5ced151cec1", "dcfba45f-d503-4fef-bb11-9221b9efa70a"] do
+      Health.put_event(
+        state.replication_slot,
+        %Health.Event{slug: :replication_heartbeat_received, status: :success}
+      )
+    end
+
+    {:ok, [], state}
+  end
+
+  # The server is asking for a reply
+  def handle_data(<<?k, wal_end::64, _clock::64, 1>>, %State{} = state) do
+    execute_timed(:handle_data_keepalive, fn ->
+      commit_lsn =
+        if is_nil(state.last_commit_lsn) do
+          # If we don't have a last_commit_lsn, we're still processing the first xaction
+          # we received on boot. This can happen if we're processing a very large xaction.
+          # It is therefore safe to send an ack with the last LSN we processed.
+          {:ok, low_watermark} = Replication.low_watermark_wal_cursor(state.id)
+
+          if low_watermark.commit_lsn > wal_end do
+            Logger.warning("Server LSN #{wal_end} is behind our LSN #{low_watermark.commit_lsn}")
+          end
+
+          low_watermark.commit_lsn
+        else
+          # With our current LSN increment strategy, we'll always replay the last record on boot. It seems
+          # safe to increment the last_commit_lsn by 1 (Commit also contains the next LSN)
+          wal_cursor = state.safe_wal_cursor_fn.(state)
+          Logger.info("Acking LSN #{inspect(wal_cursor)} (current server LSN: #{wal_end})")
+
+          Replication.put_low_watermark_wal_cursor!(state.id, wal_cursor)
+
+          if wal_cursor.commit_lsn > wal_end do
+            Logger.warning("Server LSN #{wal_end} is behind our LSN #{wal_cursor.commit_lsn}")
+          end
+
+          wal_cursor.commit_lsn
+        end
+
+      reply = ack_message(commit_lsn)
+
+      {:ok, [reply], state}
+    end)
+  end
+
+  def handle_data(%Relation{} = relation, %State{} = state) do
+    state = put_relation_message(relation, state)
+    {:ok, [], state}
+  end
+
+  def handle_data(data, %State{} = state) do
+    Logger.error("Unknown data: #{inspect(data)}")
+    {:ok, [], state}
+  end
+
+  # The receiving process can send replies back to the sender at any time, using one of the following message formats (also in the payload of a CopyData message):
+  # https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-STANDBY-STATUS-UPDATE
+  #
+  # Byte1('r')      - Identifies message as receiver status update
+  # Int64           - Last WAL byte + 1 received and written to disk
+  # Int64           - Last WAL byte + 1 flushed to disk
+  # Int64           - Last WAL byte + 1 applied in standby
+  # Int64           - Client timestamp
+  # Byte1           - 1 if reply requested immediately, 0 otherwise
+  defp ack_message(lsn) when is_integer(lsn) do
+    <<?r, lsn::64, lsn::64, lsn::64, current_time()::64, 0>>
+  end
+
+  @spec put_relation_message(Relation.t(), State.t()) :: State.t()
+  defp put_relation_message(%Relation{id: id, columns: columns, namespace: schema, name: table}, %State{} = state) do
+    conn = get_cached_conn(state)
+
+    # First, determine if this is a partition and get its parent table info
+    partition_query = """
+    SELECT
+      p.inhparent as parent_id,
+      pn.nspname as parent_schema,
+      pc.relname as parent_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_inherits p ON p.inhrelid = c.oid
+    JOIN pg_class pc ON pc.oid = p.inhparent
+    JOIN pg_namespace pn ON pn.oid = pc.relnamespace
+    WHERE c.oid = $1;
+    """
+
+    parent_info =
+      case Postgres.query(conn, partition_query, [id]) do
+        {:ok, %{rows: [[parent_id, parent_schema, parent_name]]}} ->
+          # It's a partition, use the parent info
+          %{id: parent_id, schema: parent_schema, name: parent_name}
+
+        {:ok, %{rows: []}} ->
+          # Not a partition, use its own info
+          %{id: id, schema: schema, name: table}
+      end
+
+    # Get attnums for the actual table
+    attnum_query = """
+    with pk_columns as (
+      select a.attname
+      from pg_index i
+      join pg_attribute a on a.attrelid = i.indrelid and a.attnum = any(i.indkey)
+      where i.indrelid = $1
+      and i.indisprimary
+    ),
+    column_info as (
+      select a.attname, a.attnum,
+             (select typname
+              from pg_type
+              where oid = case when t.typtype = 'd'
+                              then t.typbasetype
+                              else t.oid
+                         end) as base_type
+      from pg_attribute a
+      join pg_type t on t.oid = a.atttypid
+      where a.attrelid = $1
+      and a.attnum > 0
+      and not a.attisdropped
+    )
+    select c.attname, c.attnum, c.base_type, (pk.attname is not null) as is_pk
+    from column_info c
+    left join pk_columns pk on pk.attname = c.attname;
+    """
+
+    {:ok, %{rows: attnum_rows}} = Postgres.query(conn, attnum_query, [parent_info.id])
+
+    # Enrich columns with primary key information and attnums
+    enriched_columns =
+      Enum.map(columns, fn %{name: name} = column ->
+        case Enum.find(attnum_rows, fn [col_name, _, _, _] -> col_name == name end) do
+          [_, attnum, base_type, is_pk] ->
+            %{column | pk?: is_pk, attnum: attnum, type: base_type}
+
+          nil ->
+            column
+        end
+      end)
+
+    # Store using the actual relation_id but with parent table info
+    updated_schemas =
+      Map.put(state.schemas, id, %{
+        columns: enriched_columns,
+        schema: parent_info.schema,
+        table: parent_info.name,
+        parent_table_id: parent_info.id
+      })
+
+    %{state | schemas: updated_schemas}
+  end
+
+  defp check_limit(%State{} = state, raw_bytes_received) do
+    # Check if it's been a while since we last checked the limit
+    if state.bytes_received_since_last_limit_check + raw_bytes_received >= state.bytes_between_limit_checks do
+      current_memory = state.check_memory_fn.()
+
+      if current_memory >= state.max_memory_bytes do
+        {:error, Error.invariant(message: "Memory limit exceeded", code: :over_system_memory_limit)}
+      else
+        {:ok, %{state | bytes_received_since_last_limit_check: 0}}
+      end
+    else
+      new_bytes = state.bytes_received_since_last_limit_check + raw_bytes_received
+      {:ok, %{state | bytes_received_since_last_limit_check: new_bytes}}
+    end
+  end
+
+  defp get_cached_conn(%State{} = state) do
+    {:ok, conn} = ConnectionCache.connection(state.postgres_database)
+    conn
+  end
+
+  defp incr_counter(name, amount \\ 1) do
+    current = Process.get(name, 0)
+    Process.put(name, current + amount)
+  end
+
+  @epoch DateTime.to_unix(~U[2000-01-01 00:00:00Z], :microsecond)
+  defp current_time, do: System.os_time(:microsecond) - @epoch
+
+  defp execute_timed(name, fun) do
+    {time, result} = :timer.tc(fun)
+    # Convert microseconds to milliseconds
+    incr_counter(:"#{name}_total_ms", time / 1000)
+    incr_counter(:"#{name}_count")
+    result
+  end
+end

--- a/test/sequin/slot_processor_test.exs
+++ b/test/sequin/slot_processor_test.exs
@@ -1,0 +1,268 @@
+defmodule Sequin.Runtime.SlotProcessorTest do
+  use Sequin.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Sequin.Databases.ConnectionCache
+  alias Sequin.Error
+  alias Sequin.Factory
+  alias Sequin.Factory.DatabasesFactory
+  alias Sequin.Postgres
+  alias Sequin.Replication
+  alias Sequin.Runtime.PostgresAdapter.Decoder.Messages.Relation
+  alias Sequin.Runtime.SlotProcessor
+  alias Sequin.Runtime.SlotProcessor.State
+  alias Sequin.TestSupport.Models.Character
+
+  setup do
+    %{state: build_test_state()}
+  end
+
+  describe "handle_data/2 with relation messages" do
+    test "properly enriches and stores relation schema information", %{state: state} do
+      # Create a relation message for the Characters table from our test schema
+      relation = %Relation{
+        id: Character.table_oid(),
+        namespace: "public",
+        name: "Characters",
+        replica_identity: :default,
+        columns: [
+          %Relation.Column{name: "id", flags: [:key], type: "int8", type_modifier: 0},
+          %Relation.Column{name: "name", flags: [], type: "text", type_modifier: 0},
+          %Relation.Column{name: "house", flags: [], type: "text", type_modifier: 0},
+          %Relation.Column{name: "planet", flags: [], type: "text", type_modifier: 0}
+        ]
+      }
+
+      # Process the relation message
+      {:ok, [], updated_state} = SlotProcessor.handle_data(relation, state)
+
+      # Verify that the schema was stored correctly
+      assert Map.has_key?(updated_state.schemas, relation.id)
+      stored_schema = updated_state.schemas[relation.id]
+
+      # Check schema and table names
+      assert stored_schema.schema == "public"
+      assert stored_schema.table == "Characters"
+
+      # Check that columns were enriched with primary key info and attnums
+      assert length(stored_schema.columns) == length(relation.columns)
+
+      # Find the id column and verify it's marked as a primary key
+      id_column = Enum.find(stored_schema.columns, fn col -> col.name == "id" end)
+      assert id_column.pk?
+      assert is_integer(id_column.attnum)
+    end
+
+    test "handles partition tables by using parent table info", %{state: state} do
+      {:ok, table_oid} = Postgres.fetch_table_oid(Sequin.Repo, "public", "test_event_logs_partitioned_default")
+      # Create a relation message for a partition table
+      relation = %Relation{
+        id: table_oid,
+        namespace: "public",
+        name: "test_event_logs_partitioned_default",
+        replica_identity: :default,
+        columns: [
+          %Relation.Column{name: "id", flags: [:key], type: "int8", type_modifier: 0},
+          %Relation.Column{name: "seq", flags: [], type: "int8", type_modifier: 0},
+          %Relation.Column{name: "committed_at", flags: [:key], type: "timestamptz", type_modifier: 0}
+        ]
+      }
+
+      # Process the relation message
+      {:ok, [], updated_state} = SlotProcessor.handle_data(relation, state)
+
+      # Verify that the schema was stored with parent table info
+      assert Map.has_key?(updated_state.schemas, relation.id)
+      stored_schema = updated_state.schemas[relation.id]
+
+      # The schema should have the parent table name, not the partition name
+      assert stored_schema.table == "test_event_logs_partitioned"
+      assert is_integer(stored_schema.parent_table_id)
+    end
+  end
+
+  describe "handle_data/2 with binary messages" do
+    test "accumulates binary messages correctly", %{state: state} do
+      # Create a binary message with insert action
+      content = "test message content"
+      binary_msg = message(content, :insert)
+      msg_kind = <<?I>>
+
+      # Process the binary message
+      {:ok, [], updated_state} = SlotProcessor.handle_data(binary_msg, state)
+
+      # Verify that the message was accumulated correctly
+      assert updated_state.accumulated_msg_binaries.count == 1
+      assert updated_state.accumulated_msg_binaries.bytes == byte_size(msg_kind <> content)
+      assert length(updated_state.accumulated_msg_binaries.binaries) == 1
+      assert hd(updated_state.accumulated_msg_binaries.binaries) == msg_kind <> content
+    end
+
+    test "accumulates multiple binary messages", %{state: state} do
+      # Create two messages with different actions
+      content1 = "test message content 1"
+      content2 = "test message content 2"
+      binary_msg1 = message(content1, :insert)
+      binary_msg2 = message(content2, :update)
+
+      msg_kind1 = <<?I>>
+      msg_kind2 = <<?U>>
+
+      # Process the messages
+      {:ok, [], state_after_first} = SlotProcessor.handle_data(binary_msg1, state)
+      {:ok, [], state_after_second} = SlotProcessor.handle_data(binary_msg2, state_after_first)
+
+      # Verify that both messages were accumulated correctly
+      assert state_after_second.accumulated_msg_binaries.count == 2
+
+      assert state_after_second.accumulated_msg_binaries.bytes ==
+               byte_size(msg_kind1 <> content1) + byte_size(msg_kind2 <> content2)
+
+      assert length(state_after_second.accumulated_msg_binaries.binaries) == 2
+
+      # The binaries are stored in reverse order (newest first)
+      [second, first] = state_after_second.accumulated_msg_binaries.binaries
+      assert first == msg_kind1 <> content1
+      assert second == msg_kind2 <> content2
+    end
+
+    test "checks memory limit on an interval, returns error when memory limit is exceeded" do
+      # Create a state with a memory check function that always fails
+      # but with bytes_between_limit_checks set high enough to require multiple messages
+      state =
+        build_test_state(%{
+          max_memory_bytes: 100,
+          # Set higher than our first message
+          bytes_between_limit_checks: 20,
+          # Always returns over the limit
+          check_memory_fn: fn -> 1000 end
+        })
+
+      # Create two messages of different sizes
+      small_content = "small"
+      large_content = "this is a larger message"
+      binary_msg1 = message(small_content, :insert)
+      binary_msg2 = message(large_content, :insert)
+
+      # First message should succeed because we don't check the limit yet
+      # (bytes received < bytes_between_limit_checks)
+      {:ok, [], updated_state} = SlotProcessor.handle_data(binary_msg1, state)
+
+      # Second message should trigger the check and fail
+      # (bytes received > bytes_between_limit_checks)
+      result = SlotProcessor.handle_data(binary_msg2, updated_state)
+      assert {:error, %Error.InvariantError{code: :over_system_memory_limit}} = result
+    end
+  end
+
+  describe "handle_data/2 with keepalive messages" do
+    @describetag capture_log: true
+    setup %{state: state} do
+      # Set up the low watermark in Redis
+      Replication.put_low_watermark_wal_cursor!(state.id, %{commit_lsn: 789, commit_idx: 101})
+
+      :ok
+    end
+
+    test "handles keepalive with reply=0 correctly", %{state: state} do
+      # Create a keepalive message with reply=0
+      keepalive_msg = keepalive_message(0)
+
+      # Process the keepalive message
+      {:ok, [], updated_state} = SlotProcessor.handle_data(keepalive_msg, state)
+
+      # Verify that no reply was generated and state is unchanged
+      assert updated_state == state
+    end
+
+    test "handles keepalive with reply=1 and nil last_commit_lsn", %{state: state} do
+      # Create a keepalive message with reply=1
+      keepalive_msg = keepalive_message(1)
+
+      # Process the keepalive message
+      {:ok, [reply], _updated_state} = SlotProcessor.handle_data(keepalive_msg, state)
+
+      # Extract the LSN values from the reply
+      <<114, lsn1::64, lsn2::64, lsn3::64, _timestamp::64, 0>> = reply
+
+      # Verify that all three LSN values in the reply are the same
+      assert lsn1 == lsn2
+      assert lsn2 == lsn3
+
+      # Get the low watermark value that was set in the setup
+      {:ok, low_watermark} = Replication.low_watermark_wal_cursor(state.id)
+
+      # Verify that the LSN in the reply matches the low watermark
+      assert lsn1 == low_watermark.commit_lsn
+    end
+
+    test "handles keepalive with reply=1 and existing last_commit_lsn", %{state: state} do
+      expected_lsn = 555
+      safe_wal_cursor_fn = fn _state -> %{commit_lsn: expected_lsn, commit_idx: 42} end
+      state = %{state | safe_wal_cursor_fn: safe_wal_cursor_fn, last_commit_lsn: 456}
+
+      # Create a keepalive message with reply=1
+      keepalive_msg = keepalive_message(1)
+
+      # Process the keepalive message
+      {:ok, [reply], _updated_state} = SlotProcessor.handle_data(keepalive_msg, state)
+
+      # Verify that a reply was generated with the LSN from safe_wal_cursor_fn
+      assert <<?r, ^expected_lsn::64, ^expected_lsn::64, ^expected_lsn::64, _timestamp::64, 0>> = reply
+    end
+  end
+
+  describe "handle_data/2 with logical messages" do
+    test "handles unknown binary data gracefully", %{state: state} do
+      # Create an unknown binary message
+      unknown_msg = <<1, 2, 3, 4, 5>>
+
+      assert capture_log(fn ->
+               {:ok, [], ^state} = SlotProcessor.handle_data(unknown_msg, state)
+             end) =~ "Unknown data"
+    end
+  end
+
+  # Private helper functions
+
+  defp build_test_state(overrides \\ []) do
+    overrides = Map.new(overrides)
+    db = Map.get_lazy(overrides, :db, fn -> DatabasesFactory.insert_configured_postgres_database!() end)
+    ConnectionCache.cache_connection(db, Sequin.Repo)
+
+    base_state = %State{
+      postgres_database: db,
+      schemas: %{},
+      id: "test-slot-id-#{Factory.uuid()}",
+      check_memory_fn: fn -> 0 end,
+      bytes_between_limit_checks: Factory.integer(),
+      max_memory_bytes: Factory.integer(),
+      safe_wal_cursor_fn: fn _state -> %{commit_lsn: Factory.integer(), commit_idx: Factory.integer()} end,
+      accumulated_msg_binaries: %{count: 0, bytes: 0, binaries: []},
+      low_watermark_wal_cursor: %{commit_lsn: Factory.integer(), commit_idx: Factory.integer()},
+      current_xaction_lsn: Factory.integer(),
+      current_commit_idx: Factory.integer()
+    }
+
+    Map.merge(base_state, overrides)
+  end
+
+  # Message factory functions
+  defp message(content, action) do
+    msg_kind =
+      case action do
+        :insert -> <<?I>>
+        :update -> <<?U>>
+        :delete -> <<?D>>
+      end
+
+    <<?w, 0::192>> <> msg_kind <> content
+  end
+
+  defp keepalive_message(reply) do
+    wal_end = 1000
+    clock = 1_234_567_890
+    <<?k, wal_end::64, clock::64, reply>>
+  end
+end


### PR DESCRIPTION
Speed up SlotProcessor by only updating Health during flushes

Note we already do the message_processed update event inside flush_messages, the other one in process_messages was unnecessary.

While we debounce health updates with an ETS lookup, even debounced updates appear to have a cost. By moving the update events into flush_messages, we call them far less frequently on high-throughput slots. This resulted in a 10-15% speed-up.

We could perhaps further optimize in the future by using Process k/v for debouncing, or keeping some "flush messages" generation/idx to debounce more.

♻️ Reorganize/tidy SlotProcessorServer.State

♻️ [SlotProcessorServer] Tidy process_message function

♻️ Add Statsd to CheckPostgresReplicationSlotWorker

🐛 [SlotProcessorServer] Use parent table_name and schema when change happens in partition table

♻️ [SlotProcessorServer] Clean up keepalive handler by splitting handlers for no-reply/reply

♻️ [SlotProcessorServer] Move some functionality to SlotProcessor