### PR TITLE
Add time units to timer.tc calls

### DIFF
--- a/lib/sequin/bench/bench.ex
+++ b/lib/sequin/bench/bench.ex
@@ -196,8 +196,8 @@ defmodule Sequin.Bench do
   end
 
   defp exec_fun(scenario_fun, input_args) do
-    {execution_time, _result} = :timer.tc(fn -> apply(scenario_fun, input_args) end)
-    execution_time / 1000
+    {execution_time, _result} = :timer.tc(fn -> apply(scenario_fun, input_args) end, :millisecond)
+    execution_time
   end
 
   defp format_stats(test_name, stats) do

--- a/lib/sequin/postgres/replication_connection.ex
+++ b/lib/sequin/postgres/replication_connection.ex
@@ -630,9 +630,8 @@ defmodule Sequin.Postgres.ReplicationConnection do
   end
 
   defp execute_timed(name, fun) do
-    {time, result} = :timer.tc(fun)
-    # Convert microseconds to milliseconds
-    incr_counter(:"#{name}_total_ms", time / 1000)
+    {time, result} = :timer.tc(fun, :millisecond)
+    incr_counter(:"#{name}_total_ms", time)
     incr_counter(:"#{name}_count")
     result
   end

--- a/lib/sequin/redis.ex
+++ b/lib/sequin/redis.ex
@@ -148,10 +148,9 @@ defmodule Sequin.Redis do
   defp maybe_time([command_kind | _commands], query_name, fun) do
     command_kind = if is_list(command_kind), do: "pipeline-#{List.first(command_kind)}", else: command_kind
     query_name = query_name || "unnamed_query"
-    {time_us, result} = :timer.tc(fun)
+    {time_ms, result} = :timer.tc(fun, :millisecond)
 
     if Enum.random(0..99) < @sample_rate do
-      time_ms = time_us / 1000
       Statsd.timing("sequin.redis", time_ms, tags: %{query: query_name, command_kind: command_kind})
     end
 

--- a/lib/sequin/runtime/message_handler.ex
+++ b/lib/sequin/runtime/message_handler.ex
@@ -509,9 +509,8 @@ defmodule Sequin.Runtime.MessageHandler do
   end
 
   defp execute_timed(name, fun) do
-    {time, result} = :timer.tc(fun)
-    # Convert microseconds to milliseconds
-    incr_counter(:"#{name}_total_ms", time / 1000)
+    {time, result} = :timer.tc(fun, :millisecond)
+    incr_counter(:"#{name}_total_ms", time)
     incr_counter(:"#{name}_count")
     result
   end

--- a/lib/sequin/runtime/table_reader_server.ex
+++ b/lib/sequin/runtime/table_reader_server.ex
@@ -1060,9 +1060,8 @@ defmodule Sequin.Runtime.TableReaderServer do
   # Private helper functions for timing metrics
 
   defp execute_timed(name, fun) do
-    {time, result} = :timer.tc(fun)
-    # Convert microseconds to milliseconds
-    incr_counter(:"#{name}_total_ms", div(time, 1000))
+    {time, result} = :timer.tc(fun, :millisecond)
+    incr_counter(:"#{name}_total_ms", time)
     result
   end
 

--- a/lib/sequin/sinks/redis/client.ex
+++ b/lib/sequin/sinks/redis/client.ex
@@ -44,8 +44,7 @@ defmodule Sequin.Sinks.Redis.Client do
             ]
         end)
 
-      {time, res} = :timer.tc(fn -> qp(connection, commands) end)
-      time = round(time / 1000)
+      {time, res} = :timer.tc(fn -> qp(connection, commands) end, :millisecond)
 
       if time > 200 do
         Logger.warning("[Sequin.Sinks.Redis] Slow command execution", duration_ms: time)

--- a/lib/sequin/statsd.ex
+++ b/lib/sequin/statsd.ex
@@ -16,8 +16,8 @@ defmodule Sequin.Statsd do
   @spec measure(key(), fun()) :: on_send() | term()
   @spec measure(key(), options(), fun()) :: on_send() | term()
   def measure(key, options \\ [], fun) when is_function(fun, 0) do
-    {elapsed, result} = :timer.tc(fun)
-    timing(key, div(elapsed, 1000), options)
+    {elapsed, result} = :timer.tc(fun, :millisecond)
+    timing(key, elapsed, options)
     result
   end
 

--- a/lib/sequin_web/controllers/pull_controller.ex
+++ b/lib/sequin_web/controllers/pull_controller.ex
@@ -115,7 +115,7 @@ defmodule SequinWeb.PullController do
   defp maybe_wait(_params, _consumer), do: :ok
 
   defp wait(consumer, wait_for) do
-    {duration_us, res} = :timer.tc(fn -> SlotMessageStore.count_messages(consumer) end)
+    {duration, res} = :timer.tc(fn -> SlotMessageStore.count_messages(consumer) end, :millisecond)
 
     count =
       case res do
@@ -123,7 +123,6 @@ defmodule SequinWeb.PullController do
         {:error, _} -> 0
       end
 
-    duration = round(duration_us / 1000)
     wait_for = Enum.max([wait_for - duration, 0])
 
     cond do

--- a/test/sequin_web/controllers/pull_controller_test.exs
+++ b/test/sequin_web/controllers/pull_controller_test.exs
@@ -289,15 +289,13 @@ defmodule SequinWeb.PullControllerTest do
   end
 
   defp assert_elapsed_under(elapsed, fun, fun_desc \\ "function") do
-    {time_us, value} = :timer.tc(fun)
-    time = time_us / 1000
+    {time, value} = :timer.tc(fun, :millisecond)
     assert time < elapsed, "Expected #{fun_desc} to complete in #{elapsed}ms, but it took #{time}ms"
     value
   end
 
   defp assert_elapsed_at_least(elapsed, fun, fun_desc \\ "function") do
-    {time_us, value} = :timer.tc(fun)
-    time = time_us / 1000
+    {time, value} = :timer.tc(fun, :millisecond)
     assert time >= elapsed, "Expected #{fun_desc} to complete in at least #{elapsed}ms, but it took #{time}ms"
     value
   end


### PR DESCRIPTION
The `timer.tc` function has [supported time units](https://github.com/erlang/otp/blob/05737d130706c7189a8e6750d9c2252d2cc7987e/lib/stdlib/src/timer.erl#L578) since Erlang 26. 

Because the [`.tool-versions` file](https://github.com/sequinstream/sequin/blob/f3cf9b2772aaa954d4eaa66f9377338d9c9c02e9/.tool-versions#L2) requires Erlang 27.2.1, using `timer.tc` with the `:millisecond` argument is safe and eliminates the need for unnecessary conversions.