### PR TITLE
Move sort_column_attnum to backfills

### DIFF
--- a/assets/svelte/components/BackfillForm.svelte
+++ b/assets/svelte/components/BackfillForm.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { RadioGroup, RadioGroupItem } from "$lib/components/ui/radio-group";
+  import { Label } from "$lib/components/ui/label";
+  import { Input } from "$lib/components/ui/input";
+  import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+  } from "$lib/components/ui/select";
+  import { ExternalLinkIcon } from "lucide-svelte";
+  import type { Table } from "$lib/databases/types";
+  import Datetime from "./Datetime.svelte";
+  import { conditionalClass } from "$lib/utils";
+
+  export let form: {
+    startPosition: "beginning" | "specific";
+    sortColumnAttnum: number | null;
+    initialSortColumnValue: any | null;
+  };
+  export let formErrors: Record<string, string>;
+  export let table: Table;
+
+  $: {
+    if (!form.sortColumnAttnum) {
+      const defaultName = defaultSortColumnNames.find((col) =>
+        table.columns.find((c) => c.name.toLowerCase() === col.toLowerCase()),
+      );
+      if (defaultName) {
+        const column = table.columns.find(
+          (col) => col.name.toLowerCase() === defaultName.toLowerCase(),
+        );
+        form.sortColumnAttnum = column.attnum;
+      }
+    }
+  }
+
+  // Default sort column names to look for
+  const defaultSortColumnNames = [
+    // Updated/Modified columns
+    "updated_at",
+    "UpdatedAt",
+    "updatedAt",
+    "last_modified",
+    "LastModified",
+    "lastModified",
+    "last_modified_at",
+    "LastModifiedAt",
+    "lastModifiedAt",
+    "last_updated",
+    "lastUpdated",
+    "last_updated_at",
+    "lastUpdatedAt",
+    "modified_at",
+    "ModifiedAt",
+    "modifiedAt",
+    "modified_date",
+    "modifiedDate",
+    "modified_on",
+    "modifiedOn",
+    "update_time",
+    "updateTime",
+    "modification_date",
+    "modificationDate",
+    "dateModified",
+    "dateUpdated",
+
+    // Created/Inserted columns
+    "created_at",
+    "CreatedAt",
+    "createdAt",
+    "inserted_at",
+    "InsertedAt",
+    "insertedAt",
+    "creation_date",
+    "CreationDate",
+    "creationDate",
+    "creation_time",
+    "create_time",
+    "createTime",
+    "created_date",
+    "created_on",
+    "DateCreated",
+    "dateCreated",
+    "insert_date",
+    "insert_time",
+    "insertTime",
+    "timestamp",
+  ];
+
+  $: selectedColumnName =
+    table.columns.find((column) => column.attnum === form.sortColumnAttnum)
+      ?.name || "Select a sort column";
+
+  $: sortColumn = table.columns.find(
+    (column) => column.attnum === form.sortColumnAttnum,
+  );
+</script>
+
+<div class="space-y-4">
+  <RadioGroup bind:value={form.startPosition}>
+    <div class="flex items-center space-x-2">
+      <RadioGroupItem value="beginning" id="beginning" />
+      <Label for="beginning">Backfill from the beginning</Label>
+    </div>
+    <div class="flex items-center space-x-2">
+      <RadioGroupItem value="specific" id="specific" />
+      <Label for="specific">Backfill from a specific point</Label>
+    </div>
+  </RadioGroup>
+
+  {#if form.startPosition === "specific"}
+    <div class="space-y-4">
+      <!-- Integrated SortColumnSelector functionality -->
+      <div class="space-y-2">
+        <Label for="sort_column_attnum">Sort column</Label>
+        <p class="text-sm text-muted-foreground mt-1 mb-2">
+          Select a sort column for the backfill. A good example of a sort column
+          is <code>updated_at</code>.
+          <a
+            href="https://sequinstream.com/docs/reference/backfills#backfill-ordering"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center text-link hover:underline"
+          >
+            Learn more
+            <ExternalLinkIcon class="w-3 h-3 ml-1" />
+          </a>
+        </p>
+        <Select
+          selected={{
+            value: form.sortColumnAttnum,
+            label: selectedColumnName,
+          }}
+          onSelectedChange={(event) => {
+            form.sortColumnAttnum = event.value;
+          }}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select a sort column" />
+          </SelectTrigger>
+          <SelectContent>
+            {#each table.columns as column}
+              <SelectItem value={column.attnum}>{column.name}</SelectItem>
+            {/each}
+          </SelectContent>
+        </Select>
+      </div>
+      {#if sortColumn}
+        <div class="grid grid-cols-[auto_1fr] gap-4 content-center mt-4">
+          <div
+            class="flex items-center space-x-2 text-sm font-mono {conditionalClass(
+              sortColumn.type.startsWith('timestamp'),
+              'pt-8',
+            )}"
+          >
+            <span class="bg-secondary-2xSubtle px-2 py-1 rounded"
+              >{sortColumn.name}</span
+            >
+            <span class="bg-secondary-2xSubtle px-2 py-1 rounded">&gt;=</span>
+          </div>
+
+          {#if sortColumn.type.startsWith("timestamp")}
+            <Datetime bind:value={form.initialSortColumnValue} />
+            {#if formErrors?.initialSortColumnValue}
+              <p class="text-sm text-red-500 mt-2">
+                {formErrors.initialSortColumnValue}
+              </p>
+            {/if}
+          {:else if ["integer", "bigint", "smallint", "serial"].includes(sortColumn.type)}
+            <Input type="number" bind:value={form.initialSortColumnValue} />
+          {:else}
+            <Input type="text" bind:value={form.initialSortColumnValue} />
+          {/if}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/assets/svelte/components/SinkCardHttpPush.svelte
+++ b/assets/svelte/components/SinkCardHttpPush.svelte
@@ -3,7 +3,7 @@
   import { Card, CardContent } from "$lib/components/ui/card";
   import { concatenateUrl } from "../databases/utils";
   import { Button } from "$lib/components/ui/button";
-  import type { HttpPushConsumer } from "../types/consumer";
+  import type { HttpPushConsumer } from "../consumers/types";
 
   export let consumer: HttpPushConsumer;
 

--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -39,9 +39,6 @@
     schema: string;
     name: string;
     isEventTable?: boolean;
-    sort_column?: {
-      name: string;
-    };
   };
 
   export let databases: Array<{
@@ -62,7 +59,6 @@
   export let selectedTableOid: number | null;
   export let onlyEventTables: boolean = false;
   export let excludeEventTables: boolean = false;
-  export let showSortColumn: boolean = false;
 
   let selectedDatabase;
   let autoRefreshedDatabaseTables = [];
@@ -367,9 +363,6 @@ where parent_table = '${destinationSchemaName}.${destinationTableName}';
                     Tables
                   {/if}
                 </TableHead>
-                {#if showSortColumn}
-                  <TableHead>Sort Column</TableHead>
-                {/if}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -400,13 +393,6 @@ where parent_table = '${destinationSchemaName}.${destinationTableName}';
                       {/if}
                       <span>{table.schema}.{table.name}</span>
                     </TableCell>
-                    {#if showSortColumn}
-                      <TableCell>
-                        {#if table.sort_column}
-                          {table.sort_column.name}
-                        {/if}
-                      </TableCell>
-                    {/if}
                   </TableRow>
                 {/each}
                 {#if onlyEventTables}

--- a/assets/svelte/consumers/types.ts
+++ b/assets/svelte/consumers/types.ts
@@ -1,3 +1,5 @@
+import type { Table } from "../databases/types";
+
 // Base consumer type with shared properties
 export type BaseConsumer = {
   id: string;
@@ -12,7 +14,7 @@ export type BaseConsumer = {
     | "rabbitmq";
   name: string;
   annotations: Record<string, boolean>;
-  status: string;
+  status: "active" | "paused" | "disabled";
   message_kind: string;
   ack_wait_ms: number;
   max_ack_pending: number;
@@ -31,6 +33,7 @@ export type BaseConsumer = {
       jsonb_path: string;
     }>;
   };
+  table: Table;
   postgres_database: {
     id: string;
     name: string;

--- a/assets/svelte/databases/types.ts
+++ b/assets/svelte/databases/types.ts
@@ -1,0 +1,18 @@
+type Column = {
+  attnum: number;
+  isPk?: boolean;
+  name: string;
+  type: string;
+  filterType?: string;
+};
+
+type Table = {
+  oid: number;
+  schema: string;
+  name: string;
+  columns: Column[];
+  defaultGroupColumns: number[];
+  isEventTable: boolean;
+};
+
+export type { Column, Table };

--- a/assets/svelte/sinks/azure_event_hub/AzureEventHubSinkCard.svelte
+++ b/assets/svelte/sinks/azure_event_hub/AzureEventHubSinkCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Card, CardContent } from "$lib/components/ui/card";
-  import type { AzureEventHubConsumer } from "../../types/consumer";
+  import type { AzureEventHubConsumer } from "../../consumers/types";
 
   export let consumer: AzureEventHubConsumer;
 </script>

--- a/assets/svelte/sinks/azure_event_hub/AzureEventHubSinkForm.svelte
+++ b/assets/svelte/sinks/azure_event_hub/AzureEventHubSinkForm.svelte
@@ -7,7 +7,7 @@
     CardTitle,
   } from "$lib/components/ui/card";
   import { Label } from "$lib/components/ui/label";
-  import type { AzureEventHubConsumer } from "$lib/types/consumer";
+  import type { AzureEventHubConsumer } from "$lib/consumers/types";
   import FormItem from "$lib/components/ui/form-item.svelte";
   import FormErrorMessage from "$lib/components/ui/form-error-message.svelte";
   import FormToggleVisibilityButton from "$lib/components/ui/form-toggle-visibility-button.svelte";

--- a/assets/svelte/sinks/gcp_pubsub/GcpPubsubSinkCard.svelte
+++ b/assets/svelte/sinks/gcp_pubsub/GcpPubsubSinkCard.svelte
@@ -2,7 +2,7 @@
   import { ExternalLink } from "lucide-svelte";
   import { Card, CardContent } from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
-  import type { GcpPubsubConsumer } from "../../types/consumer";
+  import type { GcpPubsubConsumer } from "../../consumers/types";
 
   export let consumer: GcpPubsubConsumer;
 

--- a/assets/svelte/sinks/kafka/KafkaSinkCard.svelte
+++ b/assets/svelte/sinks/kafka/KafkaSinkCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Card, CardContent } from "$lib/components/ui/card";
-  import type { KafkaConsumer } from "../../types/consumer";
+  import type { KafkaConsumer } from "../../consumers/types";
 
   export let consumer: KafkaConsumer;
 </script>

--- a/assets/svelte/sinks/nats/NatsSinkCard.svelte
+++ b/assets/svelte/sinks/nats/NatsSinkCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Card, CardContent } from "$lib/components/ui/card";
-  import type { NatsConsumer } from "../../types/consumer";
+  import type { NatsConsumer } from "../../consumers/types";
 
   export let consumer: NatsConsumer;
 </script>

--- a/assets/svelte/sinks/nats/NatsSinkForm.svelte
+++ b/assets/svelte/sinks/nats/NatsSinkForm.svelte
@@ -8,7 +8,7 @@
   } from "$lib/components/ui/card";
   import { Label } from "$lib/components/ui/label";
   import { EyeIcon, EyeOffIcon } from "lucide-svelte";
-  import type { NatsConsumer } from "$lib/types/consumer";
+  import type { NatsConsumer } from "$lib/consumers/types";
   import FormItem from "$lib/components/ui/form-item.svelte";
   import FormErrorMessage from "$lib/components/ui/form-error-message.svelte";
   import FormToggleVisibilityButton from "$lib/components/ui/form-toggle-visibility-button.svelte";

--- a/assets/svelte/sinks/rabbitmq/RabbitMqSinkCard.svelte
+++ b/assets/svelte/sinks/rabbitmq/RabbitMqSinkCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Card, CardContent } from "$lib/components/ui/card";
-  import type { RabbitMqConsumer } from "../../types/consumer";
+  import type { RabbitMqConsumer } from "../../consumers/types";
 
   export let consumer: RabbitMqConsumer;
 </script>

--- a/assets/svelte/sinks/redis/RedisSinkCard.svelte
+++ b/assets/svelte/sinks/redis/RedisSinkCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Card, CardContent } from "$lib/components/ui/card";
-  import type { RedisConsumer } from "../../types/consumer";
+  import type { RedisConsumer } from "../../consumers/types";
 
   export let consumer: RedisConsumer;
 </script>

--- a/assets/svelte/sinks/sequin_stream/SequinStreamSinkCard.svelte
+++ b/assets/svelte/sinks/sequin_stream/SequinStreamSinkCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Card, CardContent } from "$lib/components/ui/card";
   import CodeWithSecret from "../../components/CodeWithSecret.svelte";
-  import type { SequinStreamConsumer } from "../../types/consumer";
+  import type { SequinStreamConsumer } from "../../consumers/types";
 
   export let consumer: SequinStreamConsumer;
   export let apiBaseUrl: string;

--- a/assets/svelte/sinks/sqs/SqsSinkCard.svelte
+++ b/assets/svelte/sinks/sqs/SqsSinkCard.svelte
@@ -2,7 +2,7 @@
   import { ExternalLink } from "lucide-svelte";
   import { Card, CardContent } from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
-  import type { SqsConsumer } from "../../types/consumer";
+  import type { SqsConsumer } from "../../consumers/types";
 
   export let consumer: SqsConsumer;
 </script>

--- a/assets/svelte/utils.ts
+++ b/assets/svelte/utils.ts
@@ -131,3 +131,18 @@ export function formatNumberWithCommas(number: number | null): string {
   }
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
+
+/**
+ * Conditionally applies a style class based on a condition
+ * @param condition Boolean condition to evaluate
+ * @param trueClass Class to apply if condition is true
+ * @param falseClass Optional class to apply if condition is false
+ * @returns The class to apply based on the condition
+ */
+export function conditionalClass(
+  condition: boolean,
+  trueClass: string,
+  falseClass: string = "",
+): string {
+  return condition ? trueClass : falseClass;
+}

--- a/docs/reference/sequin-yaml.mdx
+++ b/docs/reference/sequin-yaml.mdx
@@ -47,7 +47,6 @@ databases:
     tables:                     # Optional, list of tables to track
       - table_name: "users"     # Required
         table_schema: "public"  # Default: public
-        sort_column_name: "updated_at" # Required
 ```
 
 ### HTTP endpoint configuration
@@ -274,7 +273,6 @@ databases:
     publication_name: "sequin_pub"
     tables:
       - table_name: "users"
-        sort_column_name: "updated_at"
 
 http_endpoints:
   - name: "webhook-endpoint"

--- a/lib/sequin/consumers/backfill.ex
+++ b/lib/sequin/consumers/backfill.ex
@@ -21,7 +21,8 @@ defmodule Sequin.Consumers.Backfill do
              :completed_at,
              :canceled_at,
              :inserted_at,
-             :updated_at
+             :updated_at,
+             :sort_column_attnum
            ]}
   typed_schema "backfills" do
     belongs_to :account, Account
@@ -38,6 +39,7 @@ defmodule Sequin.Consumers.Backfill do
     field :rows_ingested_count, :integer, default: 0
     field :completed_at, :utc_datetime_usec, read_after_writes: true
     field :canceled_at, :utc_datetime_usec, read_after_writes: true
+    field :sort_column_attnum, :integer
 
     timestamps()
   end
@@ -49,7 +51,8 @@ defmodule Sequin.Consumers.Backfill do
       :sink_consumer_id,
       :state,
       :rows_initial_count,
-      :initial_min_cursor
+      :initial_min_cursor,
+      :sort_column_attnum
     ])
     |> validate_required([:account_id, :sink_consumer_id, :state, :initial_min_cursor])
     |> foreign_key_constraint(:sink_consumer_id)

--- a/lib/sequin/consumers/source_table.ex
+++ b/lib/sequin/consumers/source_table.ex
@@ -41,9 +41,7 @@ defmodule Sequin.Consumers.SourceTable do
   end
 
   def record_changeset(source_table, attrs) do
-    source_table
-    |> changeset(attrs)
-    |> validate_required([:sort_column_attnum])
+    changeset(source_table, attrs)
   end
 
   def event_changeset(source_table, attrs) do

--- a/lib/sequin/databases/databases.ex
+++ b/lib/sequin/databases/databases.ex
@@ -258,21 +258,16 @@ defmodule Sequin.Databases do
   def update_sequence_from_db(%Sequence{} = sequence, %PostgresDatabase{} = db) do
     with {:ok, tables} <- tables(db) do
       table = Enum.find(tables, fn t -> t.oid == sequence.table_oid end)
-      column = table && Enum.find(table.columns, fn c -> c.attnum == sequence.sort_column_attnum end)
 
-      case {table, column} do
-        {nil, _} ->
+      case table do
+        nil ->
           {:error, Error.not_found(entity: :table, params: %{oid: sequence.table_oid})}
 
-        {_, nil} ->
-          {:error, Error.not_found(entity: :column, params: %{attnum: sequence.sort_column_attnum})}
-
-        {table, column} ->
+        table ->
           sequence
           |> Sequence.changeset(%{
             table_schema: table.schema,
-            table_name: table.name,
-            sort_column_name: column.name
+            table_name: table.name
           })
           |> Repo.update()
       end

--- a/lib/sequin/databases/sequence.ex
+++ b/lib/sequin/databases/sequence.ex
@@ -40,7 +40,6 @@ defmodule Sequin.Databases.Sequence do
     |> validate_required([
       :name,
       :table_oid,
-      :sort_column_attnum,
       :postgres_database_id
     ])
     |> unique_constraint([:account_id, :name], error_key: :name)

--- a/lib/sequin/runtime/consumer_lifecycle_event_worker.ex
+++ b/lib/sequin/runtime/consumer_lifecycle_event_worker.ex
@@ -60,6 +60,7 @@ defmodule Sequin.Runtime.ConsumerLifecycleEventWorker do
           CheckSinkConfigurationWorker.enqueue(consumer.id, unique: false)
           RuntimeSupervisor.start_for_sink_consumer(consumer)
           :ok = RuntimeSupervisor.refresh_message_handler_ctx(consumer.replication_slot_id)
+          RuntimeSupervisor.maybe_start_table_reader(consumer)
           :ok
         end
 

--- a/lib/sequin/runtime/init_backfill_stats_worker.ex
+++ b/lib/sequin/runtime/init_backfill_stats_worker.ex
@@ -24,7 +24,7 @@ defmodule Sequin.Runtime.InitBackfillStatsWorker do
       table =
         database.tables
         |> Sequin.Enum.find!(&(&1.oid == backfill.sink_consumer.sequence.table_oid))
-        |> Map.put(:sort_column_attnum, backfill.sink_consumer.sequence.sort_column_attnum)
+        |> Map.put(:sort_column_attnum, backfill.sort_column_attnum)
 
       case TableReader.fast_count_estimate(database, table, backfill.initial_min_cursor, timeout: :infinity) do
         {:ok, count} ->

--- a/lib/sequin/runtime/supervisor.ex
+++ b/lib/sequin/runtime/supervisor.ex
@@ -54,6 +54,16 @@ defmodule Sequin.Runtime.Supervisor do
     SlotSupervisor.stop_stores_and_pipeline(replication_slot_id, id)
   end
 
+  def maybe_start_table_reader(supervisor \\ table_reader_supervisor(), %SinkConsumer{} = consumer, opts \\ []) do
+    consumer = Repo.preload(consumer, [:active_backfill, :sequence])
+
+    if is_nil(consumer.active_backfill) do
+      :ok
+    else
+      start_table_reader(supervisor, consumer, opts)
+    end
+  end
+
   def start_table_reader(supervisor \\ table_reader_supervisor(), %SinkConsumer{} = consumer, opts \\ []) do
     consumer = Repo.preload(consumer, [:active_backfill, :sequence])
 

--- a/lib/sequin/runtime/table_reader_server.ex
+++ b/lib/sequin/runtime/table_reader_server.ex
@@ -4,6 +4,7 @@ defmodule Sequin.Runtime.TableReaderServer do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Sequin.Consumers
+  alias Sequin.Consumers.Backfill
   alias Sequin.Consumers.ConsumerEvent
   alias Sequin.Consumers.ConsumerRecord
   alias Sequin.Consumers.SinkConsumer
@@ -968,13 +969,12 @@ defmodule Sequin.Runtime.TableReaderServer do
   defp table_oid(%{sequence: %Sequence{table_oid: table_oid}}), do: table_oid
   defp table_oid(%{source_tables: [source_table | _]}), do: source_table.table_oid
 
-  defp sort_column_attnum(%{sequence: %Sequence{sort_column_attnum: sort_column_attnum}}), do: sort_column_attnum
-  defp sort_column_attnum(%{source_tables: [source_table | _]}), do: source_table.sort_column_attnum
-
   defp table(%State{} = state) do
     database = database(state)
+    %{backfill: %Backfill{} = backfill} = state
+
     db_table = Sequin.Enum.find!(database.tables, &(&1.oid == state.table_oid))
-    %{db_table | sort_column_attnum: sort_column_attnum(state.consumer)}
+    %{db_table | sort_column_attnum: backfill.sort_column_attnum}
   end
 
   defp push_messages_with_retry(

--- a/lib/sequin/yaml_loader.ex
+++ b/lib/sequin/yaml_loader.ex
@@ -430,7 +430,7 @@ defmodule Sequin.YamlLoader do
   end
 
   defp sort_column_attnum_for_sequence(_, %{}) do
-    {:error, Error.bad_request(message: "`sort_column_name` is required for each stream")}
+    {:ok, nil}
   end
 
   ##############################

--- a/priv/repo/migrations/20250314182521_add_sort_column_attnum_to_backfills.exs
+++ b/priv/repo/migrations/20250314182521_add_sort_column_attnum_to_backfills.exs
@@ -1,0 +1,27 @@
+defmodule Sequin.Repo.Migrations.AddSortColumnAttnumToBackfills do
+  use Ecto.Migration
+
+  @config_schema Application.compile_env(:sequin, [Sequin.Repo, :config_schema_prefix])
+
+  def change do
+    alter table(:backfills, prefix: @config_schema) do
+      add :sort_column_attnum, :integer
+    end
+
+    # Remove NOT NULL constraint from sort_column_attnum in sequences table
+    alter table(:sequences, prefix: @config_schema) do
+      modify :sort_column_attnum, :integer, null: true
+    end
+
+    # Populate sort_column_attnum for existing backfills
+    # Traverse from backfills -> sink_consumer_id -> sequences to get sort_column_attnum
+    execute """
+            update #{@config_schema}.backfills b
+            set sort_column_attnum = s.sort_column_attnum
+            from #{@config_schema}.sink_consumers sc
+            join #{@config_schema}.sequences s on sc.sequence_id = s.id
+            where b.sink_consumer_id = sc.id
+            """,
+            "select 1"
+  end
+end

--- a/test/sequin/table_reader_test.exs
+++ b/test/sequin/table_reader_test.exs
@@ -213,6 +213,30 @@ defmodule Sequin.TableReaderTest do
       assert next_cursor[table.sort_column_attnum] == char3.updated_at
     end
 
+    test "works with nil sort column", %{
+      db: db,
+      characters_table: table,
+      character_consumer: consumer
+    } do
+      # Create a table with nil sort_column_attnum
+      table_with_nil_sort = %{table | sort_column_attnum: nil}
+
+      now = NaiveDateTime.utc_now()
+      char1 = CharacterFactory.insert_character!(updated_at: NaiveDateTime.add(now, -3, :second))
+      char2 = CharacterFactory.insert_character!(updated_at: NaiveDateTime.add(now, -2, :second))
+      char3 = CharacterFactory.insert_character!(updated_at: NaiveDateTime.add(now, -1, :second))
+
+      {:ok, _first_row, initial_cursor} = TableReader.fetch_first_row(db, table_with_nil_sort)
+
+      {:ok, %{messages: messages, next_cursor: next_cursor}} =
+        TableReader.fetch_batch(db, consumer, table_with_nil_sort, initial_cursor, include_min: true)
+
+      assert length(messages) == 3
+
+      # Verify next cursor only contains primary key columns
+      refute Map.has_key?(next_cursor, table.sort_column_attnum)
+    end
+
     test "correctly handles nil and populated UUID, UUID[] and bytea fields", %{
       db: db,
       characters_detailed_table: table,
@@ -338,6 +362,29 @@ defmodule Sequin.TableReaderTest do
       assert length(primary_keys) == 2
       assert primary_keys == [[to_string(char2.id)], [to_string(char3.id)]]
       assert next_cursor[table.sort_column_attnum] == char3.updated_at
+    end
+
+    test "works with nil sort column", %{
+      db: db,
+      characters_table: table
+    } do
+      # Create a table with nil sort_column_attnum
+      table_with_nil_sort = %{table | sort_column_attnum: nil}
+
+      char1 = CharacterFactory.insert_character!()
+      char2 = CharacterFactory.insert_character!()
+      char3 = CharacterFactory.insert_character!()
+
+      {:ok, _first_row, initial_cursor} = TableReader.fetch_first_row(db, table_with_nil_sort)
+
+      # Fetch primary keys
+      {:ok, %{pks: primary_keys, next_cursor: next_cursor}} =
+        TableReader.fetch_batch_pks(db, table_with_nil_sort, initial_cursor, include_min: true)
+
+      assert length(primary_keys) == 3
+
+      # Verify next cursor only contains primary key columns
+      refute Map.has_key?(next_cursor, table.sort_column_attnum)
     end
 
     test "fetches primary keys for multi PK table", %{


### PR DESCRIPTION
`sequences` in general are a legacy hold-over. The last important bit on them was `sort_column_attnum`, which dictated the sort column used for backfills. But the problem is that sequences are hidden in the UI, and so the sort column can't be changed after create. Also, because sort columns are *only* related to backfills, it makes sense to tie them directly to the backfill (vs bind them to the table).

This commit moves sort_column_attnum over. It does not do clean-up of the sort_column_attnum on sequences. However, new sequences can now be created without sort_column_attnum populated. We can drop these columns in the future/at any time.