### PR TITLE
Transaction annotations: Add dismissable health event when we receive an invalid annotation

### DIFF
--- a/lib/sequin/health/event.ex
+++ b/lib/sequin/health/event.ex
@@ -46,7 +46,9 @@ defmodule Sequin.Health.Event do
     :alert_toast_columns_detected_dismissed,
     :toast_columns_detected,
     :backfill_fetch_batch,
-    :backfill_finished
+    :backfill_finished,
+    :invalid_transaction_annotation_received,
+    :invalid_transaction_annotation_received_dismissed
   ]
 
   @http_endpoint_event_slugs [


### PR DESCRIPTION
When we receive a bad annotation (unparseable JSON), log a health event. Propagate up to frontend. When the user dismisses it, wait 24h before showing it again (in the case that we're still receiving unparseable JSON).