### PR TITLE
Clean up UX in nav, sink select, db create

### DIFF
--- a/assets/svelte/components/Sidenav.svelte
+++ b/assets/svelte/components/Sidenav.svelte
@@ -21,6 +21,7 @@
     Logs,
     ChevronsLeftRightEllipsis,
     ArrowUpCircle,
+    UserCog,
   } from "lucide-svelte";
   import * as Tooltip from "$lib/components/ui/tooltip";
 
@@ -313,7 +314,7 @@
                 data-phx-link-state="push"
               >
                 <Command.Item class="cursor-pointer">
-                  <Cog class="mr-2 h-4 w-4" />
+                  <UserCog class="mr-2 h-4 w-4" />
                   <span>Manage user</span>
                 </Command.Item>
               </a>

--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -261,21 +261,35 @@ where parent_table = '${destinationSchemaName}.${destinationTableName}';
         {/each}
       </SelectContent>
     </Select>
-    <Button
-      variant="outline"
-      size="sm"
-      on:click={refreshDatabases}
-      disabled={databaseRefreshState === "refreshing"}
-    >
-      {#if databaseRefreshState === "refreshing"}
-        <RotateCwIcon class="h-4 w-4 mr-2 animate-spin" />
-      {:else if databaseRefreshState === "done"}
-        <CheckIcon class="h-4 w-4 mr-2 text-green-500" />
-      {:else}
-        <RotateCwIcon class="h-4 w-4 mr-2" />
-      {/if}
-      Refresh
-    </Button>
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <Button
+          variant="outline"
+          size="sm"
+          on:click={refreshDatabases}
+          disabled={databaseRefreshState === "refreshing"}
+          class="p-2"
+          aria-label="Refresh Databases"
+        >
+          {#if databaseRefreshState === "refreshing"}
+            <RotateCwIcon class="h-5 w-5 animate-spin" />
+          {:else if databaseRefreshState === "done"}
+            <CheckIcon class="h-5 w-5 text-green-500" />
+          {:else}
+            <RotateCwIcon class="h-5 w-5" />
+          {/if}
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>
+        <p class="text-xs">Refresh databases</p>
+      </Tooltip.Content>
+    </Tooltip.Root>
+    <a href="/databases/new" target="_blank">
+      <Button variant="outline" size="sm">
+        <Plus class="h-4 w-4 mr-2" />
+        Connect new database
+      </Button>
+    </a>
   </div>
 
   {#if selectedDatabaseId}
@@ -299,21 +313,29 @@ where parent_table = '${destinationSchemaName}.${destinationTableName}';
               bind:value={searchQuery}
             />
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            on:click={refreshTables}
-            disabled={tableRefreshState === "refreshing"}
-          >
-            {#if tableRefreshState === "refreshing"}
-              <RotateCwIcon class="h-4 w-4 mr-2 animate-spin" />
-            {:else if tableRefreshState === "done"}
-              <CheckIcon class="h-4 w-4 mr-2 text-green-500" />
-            {:else}
-              <RotateCwIcon class="h-4 w-4 mr-2" />
-            {/if}
-            Refresh
-          </Button>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <Button
+                variant="outline"
+                size="sm"
+                on:click={refreshTables}
+                disabled={tableRefreshState === "refreshing"}
+                class="p-2"
+                aria-label="Refresh Tables"
+              >
+                {#if tableRefreshState === "refreshing"}
+                  <RotateCwIcon class="h-5 w-5 animate-spin" />
+                {:else if tableRefreshState === "done"}
+                  <CheckIcon class="h-5 w-5 text-green-500" />
+                {:else}
+                  <RotateCwIcon class="h-5 w-5" />
+                {/if}
+              </Button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              <p class="text-xs">Refresh tables</p>
+            </Tooltip.Content>
+          </Tooltip.Root>
         </div>
       </div>
 

--- a/assets/svelte/consumers/SinkHttpPushForm.svelte
+++ b/assets/svelte/consumers/SinkHttpPushForm.svelte
@@ -38,6 +38,7 @@
     DropdownMenuContent,
     DropdownMenuItem,
   } from "$lib/components/ui/dropdown-menu";
+  import * as Tooltip from "$lib/components/ui/tooltip";
 
   export let live;
   export let form;
@@ -223,22 +224,29 @@
         </SelectContent>
       </Select>
       <div class="flex items-center">
-        <Button
-          variant="outline"
-          size="sm"
-          on:click={refreshHttpEndpoints}
-          disabled={httpEndpointsRefreshState === "refreshing"}
-          class="p-2"
-          aria-label="Refresh HTTP Endpoints"
-        >
-          {#if httpEndpointsRefreshState === "refreshing"}
-            <RotateCwIcon class="h-5 w-5 animate-spin" />
-          {:else if httpEndpointsRefreshState === "done"}
-            <CheckIcon class="h-5 w-5 text-green-500" />
-          {:else}
-            <RotateCwIcon class="h-5 w-5" />
-          {/if}
-        </Button>
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <Button
+              variant="outline"
+              size="sm"
+              on:click={refreshHttpEndpoints}
+              disabled={httpEndpointsRefreshState === "refreshing"}
+              class="p-2"
+              aria-label="Refresh HTTP Endpoints"
+            >
+              {#if httpEndpointsRefreshState === "refreshing"}
+                <RotateCwIcon class="h-5 w-5 animate-spin" />
+              {:else if httpEndpointsRefreshState === "done"}
+                <CheckIcon class="h-5 w-5 text-green-500" />
+              {:else}
+                <RotateCwIcon class="h-5 w-5" />
+              {/if}
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <p class="text-xs">Refresh HTTP endpoints</p>
+          </Tooltip.Content>
+        </Tooltip.Root>
         <DropdownMenu>
           <DropdownMenuTrigger asChild let:builder>
             <Button

--- a/assets/svelte/consumers/SinkIndex.svelte
+++ b/assets/svelte/consumers/SinkIndex.svelte
@@ -333,29 +333,31 @@
 </div>
 
 <Dialog bind:open={dialogOpen}>
-  <DialogContent class="sm:max-w-[425px]">
+  <DialogContent class="sm:max-w-[800px] flex flex-col">
     <DialogHeader>
       <DialogTitle>Choose Sink Type</DialogTitle>
       <DialogDescription>
         Where do you want to stream Postgres to?
       </DialogDescription>
     </DialogHeader>
-    <RadioGroup
-      bind:value={selectedDestination}
-      class="grid grid-cols-2 gap-4 py-4"
-    >
-      {#each sinks as dest}
-        <Label
-          for={dest.id}
-          class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary text-center leading-tight cursor-pointer"
-        >
-          <RadioGroupItem value={dest.id} id={dest.id} class="sr-only" />
-          <svelte:component this={dest.icon} class="mb-3 h-12 w-12" />
-          {dest.name}
-        </Label>
-      {/each}
-    </RadioGroup>
-    <DialogFooter>
+    <div class="flex-1 overflow-y-auto">
+      <RadioGroup
+        bind:value={selectedDestination}
+        class="grid grid-cols-3 gap-4 py-4"
+      >
+        {#each sinks as dest}
+          <Label
+            for={dest.id}
+            class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary text-center leading-tight cursor-pointer"
+          >
+            <RadioGroupItem value={dest.id} id={dest.id} class="sr-only" />
+            <svelte:component this={dest.icon} class="mb-3 h-12 w-12" />
+            {dest.name}
+          </Label>
+        {/each}
+      </RadioGroup>
+    </div>
+    <DialogFooter class="mt-4">
       {#if selectedDestination}
         <LinkPatchNavigate
           class="w-full"


### PR DESCRIPTION
# UI Improvements for Navigation and Sink Selection

## Changes

- Changed the "Manage user" icon from `Cog` to `UserCog` in the sidenav for better semantic representation

![CleanShot 2025-03-27 at 14.19.19@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/368d3718-0f6b-4658-90bd-9d3d4ce3a901.png)

- Enhanced the database refresh button in TableSelector:
  - Simplified Refresh to an icon-only button with proper aria-label
  - Added a "Connect new database" button with link to /databases/new

![CleanShot 2025-03-27 at 14.19.27@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/258e07fd-c2ee-45e5-9c1d-62d77fc8f6f2.png)

- Improved the sink selection dialog to support more options on a smaller screen

![CleanShot 2025-03-27 at 14.19.12@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/dbfbfbcb-c484-488c-bbcd-547ec320d96c.png)



These changes improve usability and provide clearer visual cues for common actions.