### PR TITLE
Load logger level from LOG_LEVEL for all environments and adjust defaults

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,6 @@ config :esbuild, :version, "0.17.11"
 
 # Configures Elixir's Logger
 config :logger, :console,
-  level: :info,
   format: {Sequin.ConsoleLogger, :format},
   metadata: :all
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,6 @@ if self_hosted do
   config :sequin, Sequin.ConsoleLogger, drop_metadata_keys: [:mfa]
 else
   config :logger,
-    level: :info,
     default_handler: [formatter: {LoggerJSON.Formatters.Datadog, metadata: :all}]
 end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,6 +39,12 @@ if System.get_env("PHX_HOST") do
   Logger.warning("PHX_HOST environment variable is deprecated. Please use SERVER_HOST instead.")
 end
 
+if config_env() == :test do
+  config :logger, level: ConfigParser.log_level(env_vars, :warning)
+else
+  config :logger, level: ConfigParser.log_level(env_vars, :info)
+end
+
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
 # system starts, so it is typically used to load production configuration
@@ -119,8 +125,6 @@ if config_env() == :prod and self_hosted do
       "0" -> false
       other -> raise("Invalid SERVER_CHECK_ORIGIN: #{other}, must be true or false or 1 or 0")
     end
-
-  config :logger, level: ConfigParser.log_level(env_vars)
 
   config :sequin, Sequin.Posthog,
     req_opts: [base_url: "https://us.i.posthog.com"],

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,7 +21,6 @@ config :libcluster,
 # The MIX_TEST_PARTITION environment variable can be used
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
-config :logger, level: :warning
 
 config :phoenix, :plug_init_mode, :runtime
 

--- a/lib/sequin/config_parser.ex
+++ b/lib/sequin/config_parser.ex
@@ -9,20 +9,20 @@ defmodule Sequin.ConfigParser do
     |> put_redis_opts_ipv6(env)
   end
 
-  def log_level(env) do
+  @valid_log_levels [:error, :warning, :notice, :info, :debug]
+  def log_level(env, default_level) when default_level in @valid_log_levels do
     env
-    |> Map.get("LOG_LEVEL", "info")
+    |> Map.get("LOG_LEVEL", default_level |> to_string())
     |> String.downcase()
     |> String.to_atom()
-    |> validate_log_level()
+    |> validate_log_level(default_level)
   end
 
-  @valid_log_levels [:error, :warning, :notice, :info, :debug]
-  defp validate_log_level(level) when level in @valid_log_levels, do: level
+  defp validate_log_level(level, _default_level) when level in @valid_log_levels, do: level
 
-  defp validate_log_level(level) do
-    Logger.warning("[ConfigParser] Invalid log level: #{inspect(level)}. Using default :info level.")
-    :info
+  defp validate_log_level(level, default_level) do
+    Logger.warning("[ConfigParser] Invalid log level: #{inspect(level)}. Using default #{inspect(default_level)} level.")
+    default_level
   end
 
   defp put_redis_url(opts, %{"REDIS_URL" => url}) do

--- a/lib/sequin/config_parser.ex
+++ b/lib/sequin/config_parser.ex
@@ -12,7 +12,7 @@ defmodule Sequin.ConfigParser do
   @valid_log_levels [:error, :warning, :notice, :info, :debug]
   def log_level(env, default_level) when default_level in @valid_log_levels do
     env
-    |> Map.get("LOG_LEVEL", default_level |> to_string())
+    |> Map.get("LOG_LEVEL", to_string(default_level))
     |> String.downcase()
     |> String.to_atom()
     |> validate_log_level(default_level)

--- a/test/sequin/config_parser_test.exs
+++ b/test/sequin/config_parser_test.exs
@@ -55,31 +55,35 @@ defmodule Sequin.ConfigParserTest do
     end
   end
 
-  describe "log_level/1" do
-    test "returns default :info when LOG_LEVEL is not set" do
-      assert ConfigParser.log_level(%{}) == :info
+  describe "log_level/2" do
+    test "returns default provided level when LOG_LEVEL is not set" do
+      assert ConfigParser.log_level(%{}, :info) == :info
+      assert ConfigParser.log_level(%{}, :debug) == :debug
+      assert ConfigParser.log_level(%{}, :warning) == :warning
     end
 
     test "returns atom level when valid LOG_LEVEL is set" do
       for level <- ["error", "warning", "notice", "info", "debug"] do
         env = %{"LOG_LEVEL" => level}
         expected_atom = String.to_atom(level)
-        assert ConfigParser.log_level(env) == expected_atom
+        assert ConfigParser.log_level(env, :info) == expected_atom
       end
     end
 
-    test "returns uppercase variants" do
+    test "returns lowercase atom variants" do
       env = %{"LOG_LEVEL" => "ERROR"}
-      assert ConfigParser.log_level(env) == :error
+      assert ConfigParser.log_level(env, :info) == :error
 
       env = %{"LOG_LEVEL" => "Debug"}
-      assert ConfigParser.log_level(env) == :debug
+      assert ConfigParser.log_level(env, :info) == :debug
     end
 
     @tag capture_log: true
-    test "returns default :info for invalid LOG_LEVEL" do
+    test "returns provided default level for invalid LOG_LEVEL" do
       env = %{"LOG_LEVEL" => "invalid"}
-      assert ConfigParser.log_level(env) == :info
+      assert ConfigParser.log_level(env, :info) == :info
+      assert ConfigParser.log_level(env, :debug) == :debug
+      assert ConfigParser.log_level(env, :warning) == :warning
     end
   end
 


### PR DESCRIPTION
Load logger level from env var `LOG_LEVEL` for all environments except test

Some notes:
- We keep the default `:info` level within [`ConfigParser.log_level/1`](https://github.com/sequinstream/sequin/blob/main/lib/sequin/config_parser.ex#L12-L18)
- We keep a hardcoded `:warn` log level for tests to reduce verbosity