### PR TITLE
Add GitHub OAuth redirect URI to environment configuration

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -249,7 +249,7 @@ if config_env() == :prod do
 
   config :sequin, SequinWeb.UserSessionController,
     github: [
-      redirect_uri: "https://console.sequinstream.com/auth/github/callback",
+      redirect_uri: get_env.("GITHUB_CLIENT_REDIRECT_URI", "https://console.sequinstream.com/auth/github/callback"),
       client_id: get_env.("GITHUB_CLIENT_ID"),
       client_secret: get_env.("GITHUB_CLIENT_SECRET")
     ]

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -136,6 +136,7 @@ To use GitHub OAuth as a sign-in/sign-up method, provide the following environme
 
 - `GITHUB_CLIENT_ID`: GitHub OAuth client ID
 - `GITHUB_CLIENT_SECRET`: GitHub OAuth client secret
+- `GITHUB_CLIENT_REDIRECT_URI`: GitHub OAuth callback URL
 
 ### Monitoring/stats configuration
 


### PR DESCRIPTION
**Description:**  
This pull request updates the GitHub OAuth configuration by moving the hardcoded `redirect_uri` value to an environment variable (`GITHUB_CLIENT_REDIRECT_URI`).

**Changes included:**  
- Updated `config/runtime.exs` to use `get_env("GITHUB_CLIENT_REDIRECT_URI")` with a fallback to the previous URI.  
- Updated `docs/reference/configuration.mdx` to include `GITHUB_CLIENT_REDIRECT_URI` as a required environment variable for GitHub OAuth.

Let me know if any further adjustments are needed!