### PR TITLE
Make it easier to see selected table

### DIFF
--- a/assets/svelte/components/TableSelector.svelte
+++ b/assets/svelte/components/TableSelector.svelte
@@ -409,7 +409,9 @@ where parent_table = '${destinationSchemaName}.${destinationTableName}';
                       : 'hover:bg-gray-100'}"
                   >
                     <TableCell class="flex items-center space-x-2">
-                      {#if onlyEventTables}
+                      {#if table.oid === selectedTableOid}
+                        <CheckIcon class="h-4 w-4 text-green-500" />
+                      {:else if onlyEventTables}
                         <Logs class="h-4 w-4 text-gray-400" />
                       {:else}
                         <TableIcon class="h-4 w-4 text-gray-400" />


### PR DESCRIPTION
### TL;DR

Added a check icon to indicate the currently selected table in the TableSelector component.

![CleanShot 2025-04-07 at 15.20.57@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ps7MKmCULkGcazvFyiEe/ac5d3a78-ae21-46c6-90c8-b1d1dd593bae.png)

### What changed?

Added a conditional rendering block that displays a green check icon when a table is selected in the TableSelector component. The check icon appears only for the table that matches the `selectedTableOid`.

### How to test?

1. Navigate to a page that uses the TableSelector component
2. Select a table from the list
3. Verify that the selected table now displays a green check icon instead of the default table icon

### Why make this change?

This change improves the user experience by providing a clear visual indicator of which table is currently selected in the interface, making it easier for users to identify their selection at a glance.