### PR TITLE
⚡️ [SlotProcessorServer] Disconnect, don't stop, if at system mem limit

### DIFF
--- a/test/sequin/postgres_replication_test.exs
+++ b/test/sequin/postgres_replication_test.exs
@@ -1165,7 +1165,7 @@ defmodule Sequin.PostgresReplicationTest do
           CharacterFactory.insert_character!([], repo: UnboxedRepo)
 
           # Process should shut down due to memory limit
-          assert_receive {:stop_replication, _}, 1000
+          assert_receive {SlotProcessorServer, :disconnected}, 1000
 
           stop_replication!()
         end)


### PR DESCRIPTION
First, there was an if statement that was returning a tuple that was actually unused.

Second, when we've hit system memory limits, we should undergo the same behavior as when payload limit is exceeded: we should disconnect instead of crashing. Disconnecting is less dramatic, as we preserve our `last_flushed_lsn`, which means we can skip messages rapidly on reconnection.