### PR TITLE
🐛 In change retention, don't coalesce wal events for same record

### DIFF
--- a/lib/sequin/runtime/wal_pipeline_server.ex
+++ b/lib/sequin/runtime/wal_pipeline_server.ex
@@ -478,7 +478,7 @@ defmodule Sequin.Runtime.WalPipelineServer do
       |> Enum.map(fn wal_event ->
         values =
           [
-            wal_event.commit_lsn,
+            wal_event.commit_lsn + wal_event.commit_idx,
             Sequin.String.string_to_binary!(state.replication_slot.postgres_database_id),
             wal_event.source_table_oid,
             wal_event.source_table_schema,

--- a/test/sequin/wal_pipeline_server_test.exs
+++ b/test/sequin/wal_pipeline_server_test.exs
@@ -99,7 +99,7 @@ defmodule Sequin.Runtime.WalPipelineServerTest do
       as_logs =
         Enum.map(wal_events, fn wal_event ->
           %{
-            seq: wal_event.commit_lsn,
+            seq: wal_event.commit_lsn + wal_event.commit_idx,
             source_table_oid: wal_event.source_table_oid,
             source_table_schema: wal_event.source_table_schema,
             source_table_name: wal_event.source_table_name,
@@ -222,7 +222,7 @@ defmodule Sequin.Runtime.WalPipelineServerTest do
       log = hd(logs)
 
       # Verify basic fields match
-      assert log.seq == wal_event.commit_lsn
+      assert log.seq == wal_event.commit_lsn + wal_event.commit_idx
       assert log.record_pk == hd(wal_event.record_pks)
       assert log.action == to_string(wal_event.action)
     end


### PR DESCRIPTION
In Change Retentions, we would coalesce events that impacted the same PK inside of a transaction. Now, we generate a unique `seq` by combining the LSN and the commit idx - no longer coalescing.