### PR TITLE
Bring back Kernel.to_string

### DIFF
--- a/lib/sequin/transforms/minielixir/validator.ex
+++ b/lib/sequin/transforms/minielixir/validator.ex
@@ -142,6 +142,7 @@ defmodule Sequin.Transforms.MiniElixir.Validator do
     trunc
     tuple_size
     update_in
+    to_string
   ]a
 
   def check(ast) do

--- a/test/sequin/minielixir_test.exs
+++ b/test/sequin/minielixir_test.exs
@@ -194,5 +194,9 @@ defmodule Sequin.MiniElixirTest do
       # In if condition
       assert :ok = Validator.check(quote do: if(match?(x when x > 0, 1), do: :ok, else: :error))
     end
+
+    test "interpolation" do
+      assert :ok = Validator.check(quote do: "#{1}")
+    end
   end
 end


### PR DESCRIPTION
When we added the additional allows for Kernel functions, we forgot to include to_string!