### PR TITLE
minielixir: don't explode when we see an error we've never seen before

### DIFF
--- a/lib/sequin/transforms/minielixir.ex
+++ b/lib/sequin/transforms/minielixir.ex
@@ -192,11 +192,15 @@ defmodule Sequin.Transforms.MiniElixir do
     MatchError,
     KeyError,
     FunctionClauseError,
+    Protocol.UndefinedError,
     Sequin.Error.InvariantError
   ]
-  def encode_error(%{__struct__: s} = e) when s in @error_modules do
+  def encode_error(%s{} = e) when s in @error_modules do
     %{type: Atom.to_string(s), info: Map.drop(e, [:__struct__, :__exception__])}
   end
+
+  def encode_error(%_s{__exception__: true} = ex), do: Exception.message(ex)
+  def encode_error(_), do: "Unencodeable error"
 
   defp generate_module_name(id) when is_binary(id) do
     <<"UserTransform.", id::binary>>


### PR DESCRIPTION
On the subject of protocols, note that you can effectively call Sequin's Jason.Encoder impl for a struct by name because constructing structs is allowed.  However, a Jason.Encoder impl which is somehow dangerous when called with default values is a bad idea for other reasons.