### PR TITLE
Hide transforms for message_kind=record

### DIFF
--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -512,156 +512,159 @@
       </CardContent>
     </Card>
 
-    <Card>
-      <CardHeader class="flex flex-row items-center justify-between">
-        <CardTitle class="flex items-center gap-2">
-          Transforms
-          <Popover.Root>
-            <Popover.Trigger asChild let:builder>
-              <Button
-                builders={[builder]}
-                variant="link"
-                class="text-muted-foreground hover:text-foreground p-0"
-              >
-                <Info class="h-4 w-4" />
-              </Button>
-            </Popover.Trigger>
-            <Popover.Content class="w-80">
-              <div class="grid gap-4">
-                <div class="space-y-2">
-                  <p class="text-sm text-muted-foreground font-normal">
-                    Transform your messages before they are sent to the sink
-                    destination.
-                  </p>
+    {#if form.messageKind === "event" || form.transform !== "none"}
+      <Card>
+        <CardHeader class="flex flex-row items-center justify-between">
+          <CardTitle class="flex items-center gap-2">
+            Transforms
+            <Popover.Root>
+              <Popover.Trigger asChild let:builder>
+                <Button
+                  builders={[builder]}
+                  variant="link"
+                  class="text-muted-foreground hover:text-foreground p-0"
+                >
+                  <Info class="h-4 w-4" />
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content class="w-80">
+                <div class="grid gap-4">
+                  <div class="space-y-2">
+                    <p class="text-sm text-muted-foreground font-normal">
+                      Transform your messages before they are sent to the sink
+                      destination.
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </Popover.Content>
-          </Popover.Root>
-          <Beta size="sm" variant="subtle" />
-        </CardTitle>
-        {#if consumer.type !== "redis"}
-          <button
-            type="button"
-            class="flex items-center space-x-2 text-sm hover:text-primary transition-colors disabled:opacity-50"
-            on:click={() =>
-              (transformSectionExpanded = !transformSectionExpanded)}
-            disabled={!selectedTable}
-          >
-            <div
-              class="transition-transform duration-200"
-              class:rotate-180={transformSectionExpanded}
+              </Popover.Content>
+            </Popover.Root>
+            <Beta size="sm" variant="subtle" />
+          </CardTitle>
+          {#if consumer.type !== "redis"}
+            <button
+              type="button"
+              class="flex items-center space-x-2 text-sm hover:text-primary transition-colors disabled:opacity-50"
+              on:click={() =>
+                (transformSectionExpanded = !transformSectionExpanded)}
+              disabled={!selectedTable}
             >
-              <ChevronDown class="h-4 w-4" />
-            </div>
-          </button>
-        {/if}
-      </CardHeader>
-      <CardContent>
-        <div class="space-y-2">
-          {#if consumer.type === "redis"}
-            <p class="text-sm text-muted-foreground">
-              Transforms are coming soon for Redis sinks. <a
-                href="https://github.com/sequinstream/sequin/issues/1186"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-primary underline">Let us know</a
-              > if you want this.
-            </p>
-          {:else if !transformSectionExpanded}
-            <p class="text-sm text-muted-foreground">
-              {#if form.transform === "none"}
-                No transform. Messages will be sent as-is to the sink
-                destination.
-              {:else}
-                <div class="font-medium">
-                  {transforms.find((t) => t.id === form.transform)?.name ||
-                    form.transform}
-                </div>
-                <div class="text-sm text-muted-foreground">
-                  {transforms.find((t) => t.id === form.transform)
-                    ?.description || ""}
-                </div>
-              {/if}
-            </p>
-          {:else if !selectedTable}
-            <p class="text-sm text-muted-foreground">
-              Please select a table first.
-            </p>
-          {:else}
-            <div class="space-y-4">
-              <div class="">
-                <div class="flex justify-end gap-2 mb-4">
-                  <Button
-                    variant="outline"
-                    class="whitespace-nowrap"
-                    on:click={refreshTransforms}
-                    disabled={transformRefreshState === "refreshing"}
-                    aria-label="Refresh Transforms"
-                  >
-                    {#if transformRefreshState === "refreshing"}
-                      <RotateCwIcon class="h-4 w-4 animate-spin" />
-                    {:else if transformRefreshState === "done"}
-                      <CheckIcon class="h-4 w-4 text-green-500" />
-                    {:else}
-                      <RotateCwIcon class="h-4 w-4" />
-                    {/if}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    class="whitespace-nowrap"
-                    on:click={() => window.open("/transforms/new", "_blank")}
-                  >
-                    <Plus class="h-4 w-4 mr-2" />
-                    Create new transform
-                  </Button>
-                </div>
+              <div
+                class="transition-transform duration-200"
+                class:rotate-180={transformSectionExpanded}
+              >
+                <ChevronDown class="h-4 w-4" />
+              </div>
+            </button>
+          {/if}
+        </CardHeader>
+        <CardContent>
+          <div class="space-y-2">
+            {#if consumer.type === "redis"}
+              <p class="text-sm text-muted-foreground">
+                Transforms are coming soon for Redis sinks. <a
+                  href="https://github.com/sequinstream/sequin/issues/1186"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary underline">Let us know</a
+                > if you want this.
+              </p>
+            {:else if !transformSectionExpanded}
+              <p class="text-sm text-muted-foreground">
+                {#if form.transform === "none"}
+                  No transform. Messages will be sent as-is to the sink
+                  destination.
+                {:else}
+                  <div class="font-medium">
+                    {transforms.find((t) => t.id === form.transform)?.name ||
+                      form.transform}
+                  </div>
+                  <div class="text-sm text-muted-foreground">
+                    {transforms.find((t) => t.id === form.transform)
+                      ?.description || ""}
+                  </div>
+                {/if}
+              </p>
+            {:else if !selectedTable}
+              <p class="text-sm text-muted-foreground">
+                Please select a table first.
+              </p>
+            {:else}
+              <div class="space-y-4">
+                <div class="">
+                  <div class="flex justify-end gap-2 mb-4">
+                    <Button
+                      variant="outline"
+                      class="whitespace-nowrap"
+                      on:click={refreshTransforms}
+                      disabled={transformRefreshState === "refreshing"}
+                      aria-label="Refresh Transforms"
+                    >
+                      {#if transformRefreshState === "refreshing"}
+                        <RotateCwIcon class="h-4 w-4 animate-spin" />
+                      {:else if transformRefreshState === "done"}
+                        <CheckIcon class="h-4 w-4 text-green-500" />
+                      {:else}
+                        <RotateCwIcon class="h-4 w-4" />
+                      {/if}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      class="whitespace-nowrap"
+                      on:click={() => window.open("/transforms/new", "_blank")}
+                    >
+                      <Plus class="h-4 w-4 mr-2" />
+                      Create new transform
+                    </Button>
+                  </div>
 
-                <div class="border rounded-lg overflow-hidden">
-                  <div class="max-h-[400px] overflow-y-auto">
-                    <Table>
-                      <TableBody>
-                        <TableRow
-                          on:click={() =>
-                            handleTransformChange({ value: "none" })}
-                          class="cursor-pointer {form.transform === 'none'
-                            ? 'bg-blue-50 hover:bg-blue-100'
-                            : 'hover:bg-gray-100'}"
-                        >
-                          <TableCell>
-                            <div class="font-medium">None</div>
-                            <div class="text-sm text-muted-foreground">
-                              No transform applied. Messages will be sent as-is.
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                        {#each transforms as transform}
+                  <div class="border rounded-lg overflow-hidden">
+                    <div class="max-h-[400px] overflow-y-auto">
+                      <Table>
+                        <TableBody>
                           <TableRow
                             on:click={() =>
-                              handleTransformChange({ value: transform.id })}
-                            class="cursor-pointer {transform.id ===
-                            form.transform
+                              handleTransformChange({ value: "none" })}
+                            class="cursor-pointer {form.transform === 'none'
                               ? 'bg-blue-50 hover:bg-blue-100'
                               : 'hover:bg-gray-100'}"
                           >
                             <TableCell>
-                              <div class="font-medium">{transform.name}</div>
+                              <div class="font-medium">None</div>
                               <div class="text-sm text-muted-foreground">
-                                {transform.description ||
-                                  "No description provided."}
+                                No transform applied. Messages will be sent
+                                as-is.
                               </div>
                             </TableCell>
                           </TableRow>
-                        {/each}
-                      </TableBody>
-                    </Table>
+                          {#each transforms as transform}
+                            <TableRow
+                              on:click={() =>
+                                handleTransformChange({ value: transform.id })}
+                              class="cursor-pointer {transform.id ===
+                              form.transform
+                                ? 'bg-blue-50 hover:bg-blue-100'
+                                : 'hover:bg-gray-100'}"
+                            >
+                              <TableCell>
+                                <div class="font-medium">{transform.name}</div>
+                                <div class="text-sm text-muted-foreground">
+                                  {transform.description ||
+                                    "No description provided."}
+                                </div>
+                              </TableCell>
+                            </TableRow>
+                          {/each}
+                        </TableBody>
+                      </Table>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          {/if}
-        </div>
-      </CardContent>
-    </Card>
+            {/if}
+          </div>
+        </CardContent>
+      </Card>
+    {/if}
 
     {#if !isEditMode}
       <Card>


### PR DESCRIPTION
We're going to be deprecating the message_kind=record soon in favor of using an event + transform. We want to ensure ~no one uses records + transforms, as that will make it harder to auto-migrate later.