### PR TITLE
Check for recently unblocked messages after ack

### DIFF
--- a/lib/sequin/runtime/consumer_producer.ex
+++ b/lib/sequin/runtime/consumer_producer.ex
@@ -39,7 +39,7 @@ defmodule Sequin.Runtime.ConsumerProducer do
       Mox.allow(Sequin.Runtime.SlotMessageStoreMock, test_pid, self())
     end
 
-    :syn.join(:consumers, {:messages_ingested, consumer.id}, self())
+    :syn.join(:consumers, {:messages_maybe_available, consumer.id}, self())
 
     state = %{
       demand: 0,
@@ -96,14 +96,8 @@ defmodule Sequin.Runtime.ConsumerProducer do
   end
 
   @impl GenStage
-  def handle_info(:messages_ingested, state) do
+  def handle_info(:messages_maybe_available, state) do
     new_state = maybe_schedule_demand(state)
-    {:noreply, [], new_state}
-  end
-
-  @impl GenStage
-  def handle_info(:messages_processed, state) do
-    new_state = schedule_receive_messages(state)
     {:noreply, [], new_state}
   end
 


### PR DESCRIPTION
SMS broadcasts when we ingest new messages. This prompts ConsumerProducer to schedule a pull to check for new messages.

However, there's another scenario where messages will be made available: when messages are *acked*. In that situation, a message that was previously blocked may be available for pulling.

So, we broadcast when that happens as well. Otherwise, you can see a weird pattern where a message belonging to the same group ID as a previous messages takes several seconds to deliver after its counterpart delivers.

Addresses #1327 