### PR TITLE
⚡Change default soft memory limit for sinks

### DIFF
--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -115,7 +115,7 @@
   let initialForm: FormState = {
     type: consumer.type,
     messageKind: (consumer.message_kind || "event") as MessageKind,
-    maxMemoryMb: Number(consumer.max_memory_mb) || 1024,
+    maxMemoryMb: Number(consumer.max_memory_mb),
     postgresDatabaseId: consumer.postgres_database_id,
     tableOid: consumer.table_oid,
     sourceTableFilters: consumer.source_table_filters || [],
@@ -794,7 +794,7 @@
                       </div>
                       <p class="text-xs font-light">
                         The soft memory limit for this specific sink. Defaults
-                        to 1GB, which is a good starting point.
+                        to 128MB, which is a good starting point.
                       </p>
                     </div>
                     {#if errors.consumer.max_memory_mb}

--- a/lib/sequin/consumers/sink_consumer.ex
+++ b/lib/sequin/consumers/sink_consumer.ex
@@ -65,7 +65,7 @@ defmodule Sequin.Consumers.SinkConsumer do
     field :batch_size, :integer, default: 1
     field :batch_timeout_ms, :integer, default: nil
     field :annotations, :map, default: %{}
-    field :max_memory_mb, :integer, default: 1024
+    field :max_memory_mb, :integer, default: 128
     field :partition_count, :integer, default: 1
     field :legacy_transform, Ecto.Enum, values: [:none, :record_only], default: :none
     field :timestamp_format, Ecto.Enum, values: [:iso8601, :unix_microsecond], default: :iso8601
@@ -224,7 +224,7 @@ defmodule Sequin.Consumers.SinkConsumer do
     |> put_change(:ack_wait_ms, get_field(changeset, :ack_wait_ms) || 30_000)
     |> put_change(:max_waiting, get_field(changeset, :max_waiting) || 20)
     |> put_change(:max_ack_pending, get_field(changeset, :max_ack_pending) || 10_000)
-    |> put_change(:max_memory_mb, get_field(changeset, :max_memory_mb) || 1024)
+    |> put_change(:max_memory_mb, get_field(changeset, :max_memory_mb) || 128)
     |> put_change(:partition_count, get_field(changeset, :partition_count) || 1)
     |> put_change(:legacy_transform, get_field(changeset, :legacy_transform) || :none)
     |> put_change(:message_kind, get_field(changeset, :message_kind) || :event)


### PR DESCRIPTION
Lowering to 128MB – this is a better default experience for Sequin that significantly reduces risk that a Sequin instance will OOM under high load.

Larger deployments of Sequin will want to set this value to a higher number to keep downstream sink workers saturated.