### PR TITLE
chore: start iex shell via make dev and include observer in extra apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Prints target: [dep1 dep1 ...]  and what it does
 	@grep -E '^[a-zA-Z_-]+.*## .*$$' $(MAKEFILE_LIST) |  sed 's/^Makefile://' | column -t -s"##"
 
 dev: ## Run the app locally
-	elixir --name sequin-stream-dev@127.0.0.1 --cookie sequin-stream-dev -S mix phx.server
+	iex --name sequin-stream-dev@127.0.0.1 --cookie sequin-stream-dev -S mix phx.server
 
 dev2: ## Run a second node locally
 	SERVER_PORT=4001 elixir --name sequin-stream-dev2@127.0.0.1 --cookie sequin-stream-dev -S mix phx.server

--- a/mix.exs
+++ b/mix.exs
@@ -19,9 +19,12 @@ defmodule Sequin.MixProject do
   def application do
     [
       mod: {Sequin.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools] ++ extra_applications(Mix.env())
     ]
   end
+
+  defp extra_applications(:dev), do: [:wx, :observer]
+  defp extra_applications(_), do: []
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
This change improves the development experience by modifying the make dev command to start the application via the Interactive Elixir shell. This allows developers to interact with the running system directly from the terminal.

Additionally, :observer has been added to extra_applications in mix.exs, enabling runtime inspection and debugging tools like the Observer GUI.