### PR TITLE
feat: add ExpandableCard component and use it in SinkConsumerForm

### DIFF
--- a/assets/svelte/components/ui/card/expandable-card.svelte
+++ b/assets/svelte/components/ui/card/expandable-card.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { Card, CardContent, CardHeader, CardTitle } from ".";
+  import { ChevronDown } from "lucide-svelte";
+
+  export let expanded: boolean = false;
+  export let disabled: boolean = false;
+
+  function handleClick() {
+    if (disabled) return;
+    expanded = !expanded;
+  }
+</script>
+
+<Card>
+  <CardHeader class="flex flex-row items-center justify-between">
+    <button
+      type="button"
+      class="flex flex-row items-center justify-between w-full"
+      on:click={handleClick}
+      {disabled}
+    >
+      <CardTitle class="flex items-center gap-2">
+        <slot name="title" />
+      </CardTitle>
+      <div
+        class="transition-transform duration-200"
+        class:rotate-180={expanded}
+        class:text-gray-300={disabled}
+      >
+        <ChevronDown class="h-4 w-4" />
+      </div>
+    </button>
+  </CardHeader>
+
+  <CardContent>
+    <div class="space-y-2">
+      {#if !expanded}
+        <slot name="summary" />
+      {:else}
+        <slot name="content" />
+      {/if}
+    </div>
+  </CardContent>
+</Card>

--- a/assets/svelte/components/ui/card/expandable-card.svelte
+++ b/assets/svelte/components/ui/card/expandable-card.svelte
@@ -34,7 +34,7 @@
 
   <CardContent>
     <div class="space-y-2">
-      {#if !expanded}
+      {#if disabled || !expanded}
         <slot name="summary" />
       {:else}
         <slot name="content" />

--- a/assets/svelte/components/ui/card/index.ts
+++ b/assets/svelte/components/ui/card/index.ts
@@ -4,6 +4,7 @@ import Footer from "./card-footer.svelte";
 import Header from "./card-header.svelte";
 import Title from "./card-title.svelte";
 import Root from "./card.svelte";
+import ExpandableCard from "./expandable-card.svelte";
 
 export {
   //
@@ -15,6 +16,7 @@ export {
   Title as CardTitle,
   Content,
   Description,
+  ExpandableCard,
   Footer,
   Header,
   Root,

--- a/assets/svelte/consumers/GroupColumnsForm.svelte
+++ b/assets/svelte/consumers/GroupColumnsForm.svelte
@@ -4,6 +4,7 @@
     CardContent,
     CardHeader,
     CardTitle,
+    ExpandableCard,
   } from "$lib/components/ui/card";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
   import ColumnList from "./ColumnList.svelte";
@@ -107,60 +108,52 @@
   </Card>
 
   <!-- Create Mode - Normal -->
-{:else if selectedTable}
-  <Card>
-    <CardHeader>
+{:else}
+  <ExpandableCard disabled={!selectedTable}>
+    <svelte:fragment slot="title">
       <div class="flex items-center justify-between">
         <CardTitle>Message grouping</CardTitle>
-        <button
-          type="button"
-          class="flex items-center space-x-2 text-sm hover:text-primary transition-colors"
-          on:click={() => (isExpanded = !isExpanded)}
-          disabled={!selectedTable}
-        >
-          <div
-            class="transition-transform duration-200"
-            class:rotate-180={isExpanded}
-          >
-            <ChevronDown class="h-4 w-4" />
-          </div>
-        </button>
       </div>
-    </CardHeader>
-    <CardContent>
-      <div class="space-y-4">
-        {#if !isExpanded}
-          <p class="text-sm text-muted-foreground">
-            {summaryText}
-          </p>
-        {:else}
-          <p class="text-sm text-muted-foreground">
-            {selectedTable.is_event_table
-              ? "By default, Sequin uses these columns to group event table messages: source_database_id, source_table_oid, and record_pk. This ensures that records are processed serially."
-              : "By default, Sequin uses primary keys to group messages. This ensures that records are processed serially for each individual record."}
-          </p>
-          <p class="text-sm text-muted-foreground">
-            Alternatively, select custom columns to use for grouping.
-          </p>
+    </svelte:fragment>
 
-          <ColumnList
-            columns={selectedTable.columns}
-            selectedAttnums={groupColumnAttnums}
-            onToggle={toggleColumnGrouping}
-            readonly={isEditMode}
-          />
+    <svelte:fragment slot="summary">
+      {#if !selectedTable}
+        <p class="text-sm text-muted-foreground">
+          Please select a table first.
+        </p>
+      {:else}
+        <p class="text-sm text-muted-foreground">
+          {summaryText}
+        </p>
+      {/if}
+    </svelte:fragment>
 
-          {#if infoText}
-            <p class="text-sm text-muted-foreground">
-              {infoText}
-            </p>
-          {/if}
+    <svelte:fragment slot="content">
+      <p class="text-sm text-muted-foreground">
+        {selectedTable.is_event_table
+          ? "By default, Sequin uses these columns to group event table messages: source_database_id, source_table_oid, and record_pk. This ensures that records are processed serially."
+          : "By default, Sequin uses primary keys to group messages. This ensures that records are processed serially for each individual record."}
+      </p>
+      <p class="text-sm text-muted-foreground">
+        Alternatively, select custom columns to use for grouping.
+      </p>
 
-          {#if groupColumnError}
-            <p class="text-destructive text-sm">{groupColumnError}</p>
-          {/if}
-        {/if}
-      </div>
-    </CardContent>
-  </Card>
+      <ColumnList
+        columns={selectedTable.columns}
+        selectedAttnums={groupColumnAttnums}
+        onToggle={toggleColumnGrouping}
+        readonly={isEditMode}
+      />
+
+      {#if infoText}
+        <p class="text-sm text-muted-foreground">
+          {infoText}
+        </p>
+      {/if}
+
+      {#if groupColumnError}
+        <p class="text-destructive text-sm">{groupColumnError}</p>
+      {/if}
+    </svelte:fragment>
+  </ExpandableCard>
 {/if}

--- a/assets/svelte/consumers/GroupColumnsForm.svelte
+++ b/assets/svelte/consumers/GroupColumnsForm.svelte
@@ -109,7 +109,7 @@
 
   <!-- Create Mode - Normal -->
 {:else}
-  <ExpandableCard disabled={!selectedTable}>
+  <ExpandableCard disabled={!selectedTable} expanded={!isEditMode}>
     <svelte:fragment slot="title">
       <div class="flex items-center justify-between">
         <CardTitle>Message grouping</CardTitle>

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -522,7 +522,7 @@
       </CardContent>
     </Card>
 
-    <ExpandableCard disabled={!transformSectionEnabled}>
+    <ExpandableCard disabled={!transformSectionEnabled} expanded={!isEditMode}>
       <svelte:fragment slot="title">
         Transforms
         <button on:click|stopPropagation>
@@ -595,7 +595,7 @@
     </ExpandableCard>
 
     {#if !isEditMode}
-      <ExpandableCard disabled={!backfillSectionEnabled}>
+      <ExpandableCard disabled={!backfillSectionEnabled} expanded={!isEditMode}>
         <svelte:fragment slot="title">
           Initial backfill
 


### PR DESCRIPTION
Hello!

Here we add an `ExpandableCard` component which handles the proper UI behavior for these type of cards. And implement usages of it in SinkConsumerForm, and GroupColumnsForm. This fixes issue #1288.



Additional notes:

- To avoid confusion, now the ChevronDown is hidden from the Card title if the card is in disabled state, such as when no table is selected when creating or editing a sink
- Also fixes a bug where if a table is not selected, it didn't show the "Please select a table first." message in each section.
- Because the `ExpandableCard` component may show a summary or a content fragment depending on the state of the card, I opted to use named slots via svelte:fragment tags, instead of a single slot that handles those state variants. Hopefully thats fine.
- I had to add some hacky `<a on:click|stopPropagation>` wrappers to the Popovers to avoid expanding the cards when clicking on the the Popover info icon located in some card titles. Probably would be best to add this to a custom Popover component, or suggest that improvement in bits-ui, but perhaps for another time.
  - There is a small quirk (existing prior to this hack) where if you click the Popover it takes you to the top of the page. Didn't have time to look into that but definitely something that can be polished later.

Any feedback is more than welcome!

---


# Dynamic Evidence

## Gif

![image](https://s4.ezgif.com/tmp/ezgif-48cbf098e6556e.gif)

# Static Evidence

## Page: Sink creation

### Scenario 1: No table selected
<img width="811" alt="image" src="https://github.com/user-attachments/assets/204d4cf2-89ce-45fd-b7e9-7a0a14eb69dd" />

### Scenario 2: Table selected, all components collapsed by default
<img width="803" alt="image" src="https://github.com/user-attachments/assets/a2c167a3-5a22-421b-997c-70f3c4de5fd2" />

### Scenario 3: Table selected, all components expanded after clicking header
<img width="746" alt="image" src="https://github.com/user-attachments/assets/d2664317-d29d-45fc-9e08-e006222531c2" />


## Page: Sink edition

### Scenario 1: Transform card collapsed by default
<img width="727" alt="image" src="https://github.com/user-attachments/assets/56ab8e2c-4278-4989-ac34-94db437bdf36" />


### Scenario 2: Transform card expanded after clicking header
<img width="729" alt="image" src="https://github.com/user-attachments/assets/95a68cc0-330c-49f2-a528-45c8fe7a6c27" />
