### PR TITLE
feat: add idempotency_key

### DIFF
--- a/lib/sequin/consumers/consumer_event_data.ex
+++ b/lib/sequin/consumers/consumer_event_data.ex
@@ -28,6 +28,7 @@ defmodule Sequin.Consumers.ConsumerEventData do
       field :commit_lsn, :integer
       field :database_name, :string
       field :transaction_annotations, :map
+      field :idempotency_key, :string
 
       embeds_one :consumer, Sink, primary_key: false do
         @derive Jason.Encoder

--- a/lib/sequin/consumers/consumer_record_data.ex
+++ b/lib/sequin/consumers/consumer_record_data.ex
@@ -23,6 +23,7 @@ defmodule Sequin.Consumers.ConsumerRecordData do
       field :commit_timestamp, :utc_datetime_usec
       field :commit_lsn, :integer
       field :database_name, :string
+      field :idempotency_key, :string
 
       embeds_one :consumer, Sink, primary_key: false do
         @derive Jason.Encoder

--- a/lib/sequin/runtime/message_handler.ex
+++ b/lib/sequin/runtime/message_handler.ex
@@ -314,7 +314,8 @@ defmodule Sequin.Runtime.MessageHandler do
         id: consumer.id,
         name: consumer.name
       },
-      transaction_annotations: nil
+      transaction_annotations: nil,
+      idempotency_key: Base.encode64("#{message.commit_lsn}:#{message.commit_idx}")
     }
 
     if consumer.message_kind == :event do

--- a/test/sequin/table_reader_test.exs
+++ b/test/sequin/table_reader_test.exs
@@ -85,6 +85,15 @@ defmodule Sequin.TableReaderTest do
         [:sequence, :postgres_database]
       )
 
+    ConsumersFactory.insert_active_backfill!(
+      account_id: db.account_id,
+      sink_consumer_id: character_consumer.id,
+      initial_min_cursor: %{characters_table.sort_column_attnum => NaiveDateTime.utc_now()},
+      sort_column_attnum: characters_table.sort_column_attnum
+    )
+
+    character_consumer = Repo.preload(character_consumer, :active_backfill)
+
     character_multi_pk_consumer =
       Repo.preload(
         ConsumersFactory.insert_sink_consumer!(
@@ -106,6 +115,15 @@ defmodule Sequin.TableReaderTest do
         ),
         [:sequence, :postgres_database]
       )
+
+      ConsumersFactory.insert_active_backfill!(
+        account_id: db.account_id,
+        sink_consumer_id: character_detailed_consumer.id,
+        initial_min_cursor: %{characters_table.sort_column_attnum => NaiveDateTime.utc_now()},
+        sort_column_attnum: characters_table.sort_column_attnum
+      )
+
+      character_detailed_consumer = Repo.preload(character_detailed_consumer, :active_backfill)
 
     %{
       db: db,

--- a/test/sequin/table_reader_test.exs
+++ b/test/sequin/table_reader_test.exs
@@ -116,14 +116,14 @@ defmodule Sequin.TableReaderTest do
         [:sequence, :postgres_database]
       )
 
-      ConsumersFactory.insert_active_backfill!(
-        account_id: db.account_id,
-        sink_consumer_id: character_detailed_consumer.id,
-        initial_min_cursor: %{characters_table.sort_column_attnum => NaiveDateTime.utc_now()},
-        sort_column_attnum: characters_table.sort_column_attnum
-      )
+    ConsumersFactory.insert_active_backfill!(
+      account_id: db.account_id,
+      sink_consumer_id: character_detailed_consumer.id,
+      initial_min_cursor: %{characters_table.sort_column_attnum => NaiveDateTime.utc_now()},
+      sort_column_attnum: characters_table.sort_column_attnum
+    )
 
-      character_detailed_consumer = Repo.preload(character_detailed_consumer, :active_backfill)
+    character_detailed_consumer = Repo.preload(character_detailed_consumer, :active_backfill)
 
     %{
       db: db,


### PR DESCRIPTION
context: #1251 



- [x] add idempotency key to ConsumerEventData and ConsumerRecordData (for real-time/in MessageHandler)
- [x] add idempotency key during backfills
- [ ] update docs