### PR TITLE
feat: show clearer connectivity errors and run extra checks for IPv6

### DIFF
--- a/lib/sequin/network_utils.ex
+++ b/lib/sequin/network_utils.ex
@@ -20,7 +20,7 @@ defmodule Sequin.NetworkUtils do
   end
 
   @doc """
-  Pings a host on a port to see if it is reachable.
+  Establishes a test TCP connection to a host on a port to see if it is reachable.
   """
   @spec test_tcp_reachability(host :: String.t(), port :: number(), ipv6 :: boolean(), timeout :: number()) ::
           :ok | {:error, Error.t()}
@@ -28,9 +28,43 @@ defmodule Sequin.NetworkUtils do
     with :ok <- validate_port(port) do
       case :gen_tcp.connect(to_charlist(host), port, ipv6_opts(ipv6), timeout) do
         {:ok, port} when is_port(port) ->
-          # Succcess, we could reach host
+          # Success, we could reach host
           :gen_tcp.close(port)
           :ok
+
+        {:error, error} when ipv6 == true ->
+          if check_ipv6_support() do
+            case error do
+              err when err in [:nxdomain, :ehostunreach] ->
+                {:error,
+                 Error.validation(
+                   summary:
+                     "The IPv6 host is not reachable (#{inspect(error)}). Your system seems to support IPv6, but your ISP or network may not. Consider selecting an IPv4 host, or using an IPv4-to-IPv6 tunnel.",
+                   code: error
+                 )}
+
+              :econnrefused ->
+                {:error,
+                 Error.validation(
+                   summary: "The IPv6 host is not reachable on that port (econnrefused).",
+                   code: :econnrefused
+                 )}
+
+              :timeout ->
+                {:error, Error.validation(summary: "Timed out attempting to reach the IPv6 host.", code: :timeout)}
+
+              error ->
+                {:error,
+                 Error.validation(summary: "Unknown error connecting to IPv6 host: #{inspect(error)}", code: error)}
+            end
+          else
+            {:error,
+             Error.validation(
+               summary:
+                 "Your system does not seem to support IPv6. Consider selecting an IPv4 host, or using an IPv4-to-IPv6 tunnel.",
+               code: :no_ipv6_support
+             )}
+          end
 
         {:error, error} ->
           case error do
@@ -45,7 +79,7 @@ defmodule Sequin.NetworkUtils do
               {:error, Error.validation(summary: "Timed out attempting to reach the host on that port.", code: :timeout)}
 
             error ->
-              {:error, Error.validation(summary: "Unknown error connecting to host: #{inspect(error)}")}
+              {:error, Error.validation(summary: "Unknown error connecting to host: #{inspect(error)}", code: error)}
           end
       end
     end
@@ -68,6 +102,22 @@ defmodule Sequin.NetworkUtils do
 
   defp ipv6_opts(false), do: []
   defp ipv6_opts(true), do: [:inet6]
+
+  def check_ipv6_support do
+    case :inet.getifaddrs() do
+      {:ok, ifs} ->
+        Enum.any?(ifs, fn {_ifname, attrs} ->
+          attrs
+          |> Keyword.get_values(:addr)
+          |> Enum.any?(fn addr ->
+            is_tuple(addr) and tuple_size(addr) == 8
+          end)
+        end)
+
+      {:error, _reason} ->
+        false
+    end
+  end
 
   @doc """
   Measures average TCP latency to a given endpoint.


### PR DESCRIPTION
Show clearer error messages when performing checks for IPv6 hosts, and also perform additional check if machine has any IPv6 assigned to any network interface as a way to determine machine support.

Notes:
 - I have only tested with ISP/networks not supporting IPv6, and manually disabling IPv6 for my network interface, however and I am actively looking for a way to test this with a machine with actual full non-IPv6 support. Any ideas are welcome.
 - Another additional approach would be to try to open a socket and bind it to a IPv6 address, but I am yet unsure if it provides any benefit over checking network interface support.
 - All tests were performed in the Connect Database page
 - In the case of performing a connectivity test to an IPv6 host, we need to mainly catch the `:ehostunreach` - so I grouped it with the existing `:nxdomain` error case (which should not ever happen I think, as we already did DNS resolutions and determined it is an IPv6 host)
 - I opted to implement the additional check in `NetworkUtils.test_tcp_reachability` rather than the suggested `NetworkUtils.check_ipv6` mainly because even if your machine supports it, your ISP/network may not, and we can only check that by actually opening a TCP socket to the given ip+port - also because UI errors are mainly surfaced from the `test_tcp_reachability`, and would require more piping to forward them from `check_ipv6`

Fixes #1097

----

# Evidence

**Before**
![image](https://github.com/user-attachments/assets/d30dc7df-eb80-4f05-b1b0-eca94f778dbb)

**After**
When your machine seems to support IPv6 but not your ISP/network
![image](https://github.com/user-attachments/assets/322be226-1e91-44f1-9599-670ef3ef1c2b)

When your machine seems to not support IPv6
![image](https://github.com/user-attachments/assets/064ded12-a5a5-4e89-bd3e-fcd9068a18a8)

