### PR TITLE
fix: avoid scrolling to top whenever a popover is closed within a full page modal

### DIFF
--- a/assets/svelte/components/FullPageModal.svelte
+++ b/assets/svelte/components/FullPageModal.svelte
@@ -39,6 +39,24 @@
   onMount(() => {
     window.addEventListener("keydown", handleEscapeKey);
     listening = true;
+
+    // NOTE: This is an ugly hack to avoid page being scrolled to the top whenever a Popover is closed within a Dialog window
+    window.setTimeout(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      window.setTimeout(() => {
+        let overlay = (element = document.querySelector(
+          "[data-melt-dialog-overlay]",
+        ));
+        overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+        const cancelButton = document.querySelector(
+          "[data-alert-dialog-cancel]",
+        );
+        cancelButton.dispatchEvent(
+          new MouseEvent("mousedown", { bubbles: true }),
+        );
+        cancelButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      }, 20);
+    }, 20);
   });
 
   onDestroy(() => {

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -37,6 +37,7 @@
   import ElasticsearchSinkForm from "$lib/sinks/elasticsearch/ElasticsearchSinkForm.svelte";
   import * as Alert from "$lib/components/ui/alert/index.js";
   import TableSelector from "../components/TableSelector.svelte";
+  import * as Tooltip from "$lib/components/ui/tooltip";
   import * as Popover from "$lib/components/ui/popover";
   import * as Dialog from "$lib/components/ui/dialog";
   import MessageExamples from "$lib/components/MessageExamples.svelte";
@@ -525,29 +526,17 @@
     <ExpandableCard disabled={!transformSectionEnabled} expanded={!isEditMode}>
       <svelte:fragment slot="title">
         Transforms
-        <button on:click|stopPropagation>
-          <Popover.Root>
-            <Popover.Trigger asChild let:builder>
-              <Button
-                builders={[builder]}
-                variant="link"
-                class="text-muted-foreground hover:text-foreground p-0"
-              >
-                <Info class="h-4 w-4" />
-              </Button>
-            </Popover.Trigger>
-            <Popover.Content class="w-80">
-              <div class="grid gap-4">
-                <div class="space-y-2">
-                  <p class="text-sm text-muted-foreground font-normal">
-                    Transform your messages before they are sent to the sink
-                    destination.
-                  </p>
-                </div>
-              </div>
-            </Popover.Content>
-          </Popover.Root>
-        </button>
+        <Tooltip.Root openDelay={200}>
+          <Tooltip.Trigger>
+            <Info class="h-4 w-4 text-gray-400 cursor-help" />
+          </Tooltip.Trigger>
+          <Tooltip.Content class="p-4 max-w-xs">
+            <p class="text-sm text-muted-foreground font-normal">
+              Transform your messages before they are sent to the sink
+              destination.
+            </p>
+          </Tooltip.Content>
+        </Tooltip.Root>
         <Beta size="sm" variant="subtle" />
       </svelte:fragment>
 
@@ -598,36 +587,23 @@
       <ExpandableCard disabled={!backfillSectionEnabled} expanded={!isEditMode}>
         <svelte:fragment slot="title">
           Initial backfill
-
-          <button on:click|stopPropagation>
-            <Popover.Root>
-              <Popover.Trigger asChild let:builder>
-                <Button
-                  builders={[builder]}
-                  variant="link"
-                  class="text-muted-foreground hover:text-foreground p-0"
+          <Tooltip.Root openDelay={200}>
+            <Tooltip.Trigger>
+              <Info class="h-4 w-4 text-gray-400 cursor-help" />
+            </Tooltip.Trigger>
+            <Tooltip.Content class="p-4 max-w-xs">
+              <p class="text-sm text-muted-foreground font-normal">
+                Sequin will run an initial <a
+                  href="https://sequinstream.com/docs/reference/backfills"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary underline"
                 >
-                  <Info class="h-4 w-4" />
-                </Button>
-              </Popover.Trigger>
-              <Popover.Content class="w-80">
-                <div class="grid gap-4">
-                  <div class="space-y-2">
-                    <p class="text-sm text-muted-foreground font-normal">
-                      Sequin will run an initial <a
-                        href="https://sequinstream.com/docs/reference/backfills"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-primary underline"
-                      >
-                        backfill
-                      </a> of data from the selected table to the sink destination.
-                    </p>
-                  </div>
-                </div>
-              </Popover.Content>
-            </Popover.Root>
-          </button>
+                  backfill
+                </a> of data from the selected table to the sink destination.
+              </p>
+            </Tooltip.Content>
+          </Tooltip.Root>
         </svelte:fragment>
 
         <svelte:fragment slot="summary">


### PR DESCRIPTION
Fix the quirk where the page scrolls to top whenever a popover is closed within a full page modal

This is a **very** ugly hack, but after a couple of hours trying to find the underlying root cause, I was unable to, and this seems to reliably fix the issue while not including any other detectable issue (other than showing the exit dialog for about 20ms).

Hopefully we can get to the bottom of this at some point, but this could be a valid workaround for the time being.

Fixes #724