### PR TITLE
fix: improve full page forms to avoid using a modal

### DIFF
--- a/assets/svelte/components/CodeWithCopy.svelte
+++ b/assets/svelte/components/CodeWithCopy.svelte
@@ -11,10 +11,10 @@
 </script>
 
 <div
-  class={`flex flex-row bg-muted p-4 rounded-md overflow-hidden ${codeClass}`}
+  class={`flex flex-row bg-muted rounded-md overflow-hidden ${codeClass}`}
   style="max-width: {maxWidth}"
 >
-  <pre class="text-sm overflow-x-auto flex flex-grow"><code class={language}
+  <pre class="p-4 text-sm overflow-x-auto flex flex-grow"><code class={language}
       >{codeContent}</code
     >
   </pre>

--- a/assets/svelte/components/FullPageForm.svelte
+++ b/assets/svelte/components/FullPageForm.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
-  import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import * as AlertDialog from "$lib/components/ui/alert-dialog";
   import { createEventDispatcher, onMount, onDestroy } from "svelte";
 
   export let title: string = "";
-  export let open = true;
-  export let showConfirmDialog = false;
-  export let showConfirmOnExit = false;
-  export let bodyPadding = 6;
+  let showConfirmDialog = false;
+  export let showConfirmOnExit = true;
 
   const dispatch = createEventDispatcher();
 
@@ -20,17 +17,16 @@
       if (showConfirmOnExit) {
         showConfirmDialog = true;
       } else {
-        open = false;
         dispatch("close");
       }
     }
   }
 
   $: {
-    if (open && !listening) {
+    if (!listening) {
       window.addEventListener("keydown", handleEscapeKey);
       listening = true;
-    } else if (!open && listening) {
+    } else {
       window.removeEventListener("keydown", handleEscapeKey);
       listening = false;
     }
@@ -47,7 +43,6 @@
 
   function confirmClose() {
     showConfirmDialog = false;
-    open = false;
     dispatch("close");
   }
 
@@ -56,54 +51,40 @@
   }
 </script>
 
-<Dialog.Root bind:open preventScroll={false} closeOnEscape={false}>
-  <Dialog.Portal>
-    <Dialog.Content
-      closeButton={false}
-      class="w-full h-full max-w-full max-h-full min-h-screen"
-    >
-      <div id="full-page-modal"></div>
-      <div class="flex flex-col h-full bg-background">
-        <div class="flex justify-between items-center p-6 border-b">
-          {#if $$slots.header}
-            <slot name="header" />
-          {:else}
-            <Dialog.Title class="text-2xl font-semibold">{title}</Dialog.Title>
-          {/if}
+<div class="fixed inset-0 bg-background">
+  <div class="flex flex-col h-full overflow-y-auto">
+    <div class="flex justify-between items-center p-6 border-b">
+      {#if $$slots.header}
+        <slot name="header" />
+      {:else}
+        <h2 class="text-2xl font-semibold">{title}</h2>
+      {/if}
 
-          <Dialog.Close asChild>
-            <Button
-              variant="outline"
-              on:click={() => {
-                if (showConfirmOnExit) {
-                  showConfirmDialog = true;
-                } else {
-                  open = false;
-                  dispatch("close");
-                }
-              }}
-            >
-              Exit
-            </Button>
-          </Dialog.Close>
-        </div>
+      <Button
+        variant="outline"
+        on:click={() => {
+          if (showConfirmOnExit) {
+            showConfirmDialog = true;
+          } else {
+            dispatch("close");
+          }
+        }}
+      >
+        Exit
+      </Button>
+    </div>
 
-        <div
-          class="flex-grow overflow-y-auto"
-          style="padding: {bodyPadding}px;"
-        >
-          <slot />
-        </div>
+    <div class="pt-8 pb-12">
+      <slot />
+    </div>
 
-        {#if $$slots.footer}
-          <div class="flex-shrink-0 border-t">
-            <slot name="footer" />
-          </div>
-        {/if}
+    {#if $$slots.footer}
+      <div class="flex-shrink-0 border-t">
+        <slot name="footer" />
       </div>
-    </Dialog.Content>
-  </Dialog.Portal>
-</Dialog.Root>
+    {/if}
+  </div>
+</div>
 
 <AlertDialog.Root bind:open={showConfirmDialog}>
   <AlertDialog.Content>

--- a/assets/svelte/consumers/GroupColumnsForm.svelte
+++ b/assets/svelte/consumers/GroupColumnsForm.svelte
@@ -109,7 +109,7 @@
 
   <!-- Create Mode - Normal -->
 {:else}
-  <ExpandableCard disabled={!selectedTable}>
+  <ExpandableCard disabled={!selectedTable} expanded={!isEditMode}>
     <svelte:fragment slot="title">
       <div class="flex items-center justify-between">
         <CardTitle>Message grouping</CardTitle>

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -796,38 +796,36 @@
         <div class="flex justify-end items-center gap-2">
           {#if consumer.type !== "http_push" && consumer.type !== "sequin_stream"}
             <Popover.Root bind:open={showLocalhostWarningDialog}>
-              <Popover.Trigger asChild let:builder>
-                <Button
-                  loading={testConnectionState.status === "loading"}
-                  variant="outline"
-                  class="self-end"
-                  builders={[builder]}
-                  on:click={onTestConnection}
-                >
-                  {#if testConnectionState.status === "success" && testConnectionState.displayStatus}
-                    <span
-                      class="flex items-center p-1 gap-1 mr-2 bg-green-500 rounded-full"
-                    ></span>
-                    Connection succeeded
-                  {:else if testConnectionState.status === "error" && testConnectionState.displayStatus}
-                    <span
-                      class="flex items-center p-1 gap-1 mr-2 bg-red-500 rounded-full"
-                    ></span>
-                    Connection failed
-                  {:else}
-                    <span
-                      class="flex items-center w-2 h-2 mr-2 rounded-full"
-                      class:bg-green-500={testConnectionState.lastTestStatus ===
-                        "success"}
-                      class:bg-red-500={testConnectionState.lastTestStatus ===
-                        "error"}
-                      class:bg-gray-300={testConnectionState.lastTestStatus ===
-                        "none"}
-                    ></span>
-                    Test Connection
-                  {/if}
-                </Button>
-              </Popover.Trigger>
+              <Popover.Trigger />
+              <Button
+                loading={testConnectionState.status === "loading"}
+                variant="outline"
+                class="self-end"
+                on:click={onTestConnection}
+              >
+                {#if testConnectionState.status === "success" && testConnectionState.displayStatus}
+                  <span
+                    class="flex items-center p-1 gap-1 mr-2 bg-green-500 rounded-full"
+                  ></span>
+                  Connection succeeded
+                {:else if testConnectionState.status === "error" && testConnectionState.displayStatus}
+                  <span
+                    class="flex items-center p-1 gap-1 mr-2 bg-red-500 rounded-full"
+                  ></span>
+                  Connection failed
+                {:else}
+                  <span
+                    class="flex items-center w-2 h-2 mr-2 rounded-full"
+                    class:bg-green-500={testConnectionState.lastTestStatus ===
+                      "success"}
+                    class:bg-red-500={testConnectionState.lastTestStatus ===
+                      "error"}
+                    class:bg-gray-300={testConnectionState.lastTestStatus ===
+                      "none"}
+                  ></span>
+                  Test Connection
+                {/if}
+              </Button>
               <Popover.Content class="w-80">
                 <div class="grid gap-4">
                   <div class="space-y-2">

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -16,7 +16,7 @@
     ExpandableCard,
   } from "$lib/components/ui/card";
   import { Label } from "$lib/components/ui/label";
-  import FullPageModal from "../components/FullPageModal.svelte";
+  import FullPageForm from "../components/FullPageForm.svelte";
   import { cn } from "$lib/utils";
   import FilterForm from "../components/FilterForm.svelte";
   import GroupColumnsForm from "./GroupColumnsForm.svelte";
@@ -37,6 +37,7 @@
   import ElasticsearchSinkForm from "$lib/sinks/elasticsearch/ElasticsearchSinkForm.svelte";
   import * as Alert from "$lib/components/ui/alert/index.js";
   import TableSelector from "../components/TableSelector.svelte";
+  import * as Tooltip from "$lib/components/ui/tooltip";
   import * as Popover from "$lib/components/ui/popover";
   import * as Dialog from "$lib/components/ui/dialog";
   import MessageExamples from "$lib/components/MessageExamples.svelte";
@@ -253,8 +254,6 @@
   }
 
   const isEditMode = !!consumer.id;
-  let dialogOpen = true;
-  let showConfirmDialog = false;
 
   function handleConsumerSubmit() {
     isSubmitting = true;
@@ -382,16 +381,14 @@
   const exampleUnixMicrosecondTimestamp = 1704086400000000;
 </script>
 
-<FullPageModal
+<FullPageForm
   title={isEditMode ? `Edit ${consumerTitle}` : `Create ${consumerTitle}`}
-  bind:open={dialogOpen}
-  bind:showConfirmDialog
   showConfirmOnExit={isDirty}
   on:close={handleClose}
 >
   <form
     on:submit|preventDefault={handleConsumerSubmit}
-    class="space-y-6 max-w-3xl mx-auto mt-6"
+    class="space-y-6 max-w-3xl mx-auto"
   >
     <Card>
       <CardHeader>
@@ -527,29 +524,17 @@
     <ExpandableCard disabled={!transformSectionEnabled} expanded={!isEditMode}>
       <svelte:fragment slot="title">
         Transforms
-        <button on:click|stopPropagation>
-          <Popover.Root>
-            <Popover.Trigger asChild let:builder>
-              <Button
-                builders={[builder]}
-                variant="link"
-                class="text-muted-foreground hover:text-foreground p-0"
-              >
-                <Info class="h-4 w-4" />
-              </Button>
-            </Popover.Trigger>
-            <Popover.Content class="w-80">
-              <div class="grid gap-4">
-                <div class="space-y-2">
-                  <p class="text-sm text-muted-foreground font-normal">
-                    Transform your messages before they are sent to the sink
-                    destination.
-                  </p>
-                </div>
-              </div>
-            </Popover.Content>
-          </Popover.Root>
-        </button>
+        <Tooltip.Root openDelay={200}>
+          <Tooltip.Trigger>
+            <Info class="h-4 w-4 text-gray-400 cursor-help" />
+          </Tooltip.Trigger>
+          <Tooltip.Content class="p-4 max-w-xs">
+            <p class="text-sm text-muted-foreground font-normal">
+              Transform your messages before they are sent to the sink
+              destination.
+            </p>
+          </Tooltip.Content>
+        </Tooltip.Root>
         <Beta size="sm" variant="subtle" />
       </svelte:fragment>
 
@@ -601,35 +586,23 @@
         <svelte:fragment slot="title">
           Initial backfill
 
-          <button on:click|stopPropagation>
-            <Popover.Root>
-              <Popover.Trigger asChild let:builder>
-                <Button
-                  builders={[builder]}
-                  variant="link"
-                  class="text-muted-foreground hover:text-foreground p-0"
+          <Tooltip.Root openDelay={200}>
+            <Tooltip.Trigger>
+              <Info class="h-4 w-4 text-gray-400 cursor-help" />
+            </Tooltip.Trigger>
+            <Tooltip.Content class="p-4 max-w-xs">
+              <p class="text-sm text-muted-foreground font-normal">
+                Sequin will run an initial <a
+                  href="https://sequinstream.com/docs/reference/backfills"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary underline"
                 >
-                  <Info class="h-4 w-4" />
-                </Button>
-              </Popover.Trigger>
-              <Popover.Content class="w-80">
-                <div class="grid gap-4">
-                  <div class="space-y-2">
-                    <p class="text-sm text-muted-foreground font-normal">
-                      Sequin will run an initial <a
-                        href="https://sequinstream.com/docs/reference/backfills"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-primary underline"
-                      >
-                        backfill
-                      </a> of data from the selected table to the sink destination.
-                    </p>
-                  </div>
-                </div>
-              </Popover.Content>
-            </Popover.Root>
-          </button>
+                  backfill
+                </a> of data from the selected table to the sink destination.
+              </p>
+            </Tooltip.Content>
+          </Tooltip.Root>
         </svelte:fragment>
 
         <svelte:fragment slot="summary">
@@ -823,36 +796,38 @@
         <div class="flex justify-end items-center gap-2">
           {#if consumer.type !== "http_push" && consumer.type !== "sequin_stream"}
             <Popover.Root bind:open={showLocalhostWarningDialog}>
-              <Popover.Trigger />
-              <Button
-                loading={testConnectionState.status === "loading"}
-                variant="outline"
-                class="self-end"
-                on:click={onTestConnection}
-              >
-                {#if testConnectionState.status === "success" && testConnectionState.displayStatus}
-                  <span
-                    class="flex items-center p-1 gap-1 mr-2 bg-green-500 rounded-full"
-                  ></span>
-                  Connection succeeded
-                {:else if testConnectionState.status === "error" && testConnectionState.displayStatus}
-                  <span
-                    class="flex items-center p-1 gap-1 mr-2 bg-red-500 rounded-full"
-                  ></span>
-                  Connection failed
-                {:else}
-                  <span
-                    class="flex items-center w-2 h-2 mr-2 rounded-full"
-                    class:bg-green-500={testConnectionState.lastTestStatus ===
-                      "success"}
-                    class:bg-red-500={testConnectionState.lastTestStatus ===
-                      "error"}
-                    class:bg-gray-300={testConnectionState.lastTestStatus ===
-                      "none"}
-                  ></span>
-                  Test Connection
-                {/if}
-              </Button>
+              <Popover.Trigger asChild let:builder>
+                <Button
+                  loading={testConnectionState.status === "loading"}
+                  variant="outline"
+                  class="self-end"
+                  builders={[builder]}
+                  on:click={onTestConnection}
+                >
+                  {#if testConnectionState.status === "success" && testConnectionState.displayStatus}
+                    <span
+                      class="flex items-center p-1 gap-1 mr-2 bg-green-500 rounded-full"
+                    ></span>
+                    Connection succeeded
+                  {:else if testConnectionState.status === "error" && testConnectionState.displayStatus}
+                    <span
+                      class="flex items-center p-1 gap-1 mr-2 bg-red-500 rounded-full"
+                    ></span>
+                    Connection failed
+                  {:else}
+                    <span
+                      class="flex items-center w-2 h-2 mr-2 rounded-full"
+                      class:bg-green-500={testConnectionState.lastTestStatus ===
+                        "success"}
+                      class:bg-red-500={testConnectionState.lastTestStatus ===
+                        "error"}
+                      class:bg-gray-300={testConnectionState.lastTestStatus ===
+                        "none"}
+                    ></span>
+                    Test Connection
+                  {/if}
+                </Button>
+              </Popover.Trigger>
               <Popover.Content class="w-80">
                 <div class="grid gap-4">
                   <div class="space-y-2">
@@ -928,7 +903,7 @@
       </CardContent>
     </Card>
   </form>
-</FullPageModal>
+</FullPageForm>
 
 <Dialog.Root bind:open={showMessageTypeExampleModal}>
   <Dialog.Portal>

--- a/assets/svelte/databases/Form.svelte
+++ b/assets/svelte/databases/Form.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { slide, fade } from "svelte/transition";
-  import FullPageModal from "../components/FullPageModal.svelte";
+  import FullPageForm from "../components/FullPageForm.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
@@ -163,8 +163,6 @@
     }
   }
 
-  let dialogOpen = true;
-  let showConfirmDialog = false;
   let validating = false;
 
   const progress = tweened(0, { duration: 10000, easing: cubicOut });
@@ -309,13 +307,8 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
   }
 </script>
 
-<FullPageModal
-  title="Connect Database"
-  bind:open={dialogOpen}
-  bind:showConfirmDialog
-  on:close={handleClose}
->
-  <form on:submit={handleSubmit} class="space-y-6 max-w-3xl mx-auto mt-6">
+<FullPageForm title="Connect Database" on:close={handleClose}>
+  <form on:submit={handleSubmit} class="space-y-6 max-w-3xl mx-auto">
     <Card>
       <CardHeader class="flex flex-row items-center">
         <CardTitle class="flex-grow">Database connection details</CardTitle>
@@ -323,8 +316,8 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
       <CardContent class="space-y-4">
         <div class="flex items-center space-x-2 mb-2">
           <Popover bind:open={popoverOpen}>
-            <PopoverTrigger>
-              <Button variant="magic">
+            <PopoverTrigger asChild let:builder>
+              <Button variant="magic" builders={[builder]}>
                 <Wand class="inline-block h-4 w-4 mr-2" /> Autofill with Connection
                 String
               </Button>
@@ -363,15 +356,18 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
                   disabled={isEdit}
                 />
                 <Label for="use-localhost">Use localhost</Label>
-                <Popover>
-                  <PopoverTrigger>
-                    <Info class="w-4 h-4 text-muted-foreground" />
-                  </PopoverTrigger>
-                  <PopoverContent>
-                    You can use the Sequin CLI to connect Sequin to a database
-                    running on your local machine.
-                  </PopoverContent>
-                </Popover>
+
+                <Tooltip.Root openDelay={200}>
+                  <Tooltip.Trigger>
+                    <Info class="h-4 w-4 text-gray-400 cursor-help" />
+                  </Tooltip.Trigger>
+                  <Tooltip.Content class="p-4 max-w-xs">
+                    <p class="text-sm text-muted-foreground font-normal">
+                      You can use the Sequin CLI to connect Sequin to a database
+                      running on your local machine.
+                    </p>
+                  </Tooltip.Content>
+                </Tooltip.Root>
               {/if}
             </div>
           </div>
@@ -763,4 +759,4 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
       </CardContent>
     </Card>
   </form>
-</FullPageModal>
+</FullPageForm>

--- a/assets/svelte/http_endpoints/Form.svelte
+++ b/assets/svelte/http_endpoints/Form.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import FullPageModal from "../components/FullPageModal.svelte";
+  import FullPageForm from "../components/FullPageForm.svelte";
   import { Button } from "$lib/components/ui/button";
   import {
     Card,
@@ -10,6 +10,7 @@
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
   import { PlusCircle, Eye, EyeOff } from "lucide-svelte";
+  import * as Tooltip from "$lib/components/ui/tooltip";
   import {
     Popover,
     PopoverContent,
@@ -39,8 +40,6 @@
 
   let form = { ...httpEndpoint, baseUrl };
   let isEdit = !!form.id;
-  let dialogOpen = true;
-  let showConfirmDialog = false;
   let validating = false;
   let showEncryptedValues: Record<string, boolean> = {};
   let showLocalhostWarningDialog = false;
@@ -143,14 +142,12 @@ sequin context add default --api-token={{secret}} --set-default
 sequin tunnel --ports=[your-local-port]:${form.name}`;
 </script>
 
-<FullPageModal
+<FullPageForm
   title={isEdit ? "Edit HTTP Endpoint" : "Create HTTP Endpoint"}
-  bind:open={dialogOpen}
-  bind:showConfirmDialog
   on:close={handleClose}
 >
   <form on:submit={handleSubmit} class="space-y-6 max-w-3xl mx-auto">
-    <Card class="mt-12">
+    <Card>
       <CardHeader>
         <CardTitle>HTTP Endpoint Configuration</CardTitle>
       </CardHeader>
@@ -191,15 +188,18 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
                   disabled={isEdit}
                 />
                 <Label for="use-localhost">Use localhost</Label>
-                <Popover>
-                  <PopoverTrigger>
-                    <Info class="w-4 h-4 text-muted-foreground" />
-                  </PopoverTrigger>
-                  <PopoverContent>
-                    You can use the Sequin CLI to connect Sequin to an HTTP
-                    endpoint running on your local machine.
-                  </PopoverContent>
-                </Popover>
+
+                <Tooltip.Root openDelay={200}>
+                  <Tooltip.Trigger>
+                    <Info class="h-4 w-4 text-gray-400 cursor-help" />
+                  </Tooltip.Trigger>
+                  <Tooltip.Content class="p-4 max-w-xs">
+                    <p class="text-sm text-muted-foreground font-normal">
+                      You can use the Sequin CLI to connect Sequin to an HTTP
+                      endpoint running on your local machine.
+                    </p>
+                  </Tooltip.Content>
+                </Tooltip.Root>
               </div>
             </div>
             {#if form.useLocalTunnel}
@@ -357,15 +357,21 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
       </CardHeader>
       <CardContent class="space-y-4">
         <Popover bind:open={showLocalhostWarningDialog}>
-          <PopoverTrigger />
-          <Button type="submit" loading={validating} variant="default">
-            <span slot="loading"> Validating... </span>
-            {#if isEdit}
-              Update HTTP Endpoint
-            {:else}
-              Create HTTP Endpoint
-            {/if}
-          </Button>
+          <PopoverTrigger asChild let:builder>
+            <Button
+              type="submit"
+              loading={validating}
+              variant="default"
+              builders={[builder]}
+            >
+              <span slot="loading"> Validating... </span>
+              {#if isEdit}
+                Update HTTP Endpoint
+              {:else}
+                Create HTTP Endpoint
+              {/if}
+            </Button>
+          </PopoverTrigger>
           <PopoverContent class="w-80">
             <div class="grid gap-4">
               <div class="space-y-2">
@@ -404,4 +410,4 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
       </CardContent>
     </Card>
   </form>
-</FullPageModal>
+</FullPageForm>

--- a/assets/svelte/http_endpoints/Form.svelte
+++ b/assets/svelte/http_endpoints/Form.svelte
@@ -357,21 +357,20 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
       </CardHeader>
       <CardContent class="space-y-4">
         <Popover bind:open={showLocalhostWarningDialog}>
-          <PopoverTrigger asChild let:builder>
-            <Button
-              type="submit"
-              loading={validating}
-              variant="default"
-              builders={[builder]}
-            >
-              <span slot="loading"> Validating... </span>
-              {#if isEdit}
-                Update HTTP Endpoint
-              {:else}
-                Create HTTP Endpoint
-              {/if}
-            </Button>
-          </PopoverTrigger>
+          <PopoverTrigger />
+          <Button
+            type="submit"
+            loading={validating}
+            variant="default"
+            on:click={checkForLocalhost}
+          >
+            <span slot="loading"> Validating... </span>
+            {#if isEdit}
+              Update HTTP Endpoint
+            {:else}
+              Create HTTP Endpoint
+            {/if}
+          </Button>
           <PopoverContent class="w-80">
             <div class="grid gap-4">
               <div class="space-y-2">

--- a/assets/svelte/wal_pipelines/Form.svelte
+++ b/assets/svelte/wal_pipelines/Form.svelte
@@ -15,7 +15,7 @@
   } from "$lib/components/ui/card";
   import TableSelector from "../components/TableSelector.svelte";
   import FilterForm from "../components/FilterForm.svelte";
-  import FullPageModal from "../components/FullPageModal.svelte";
+  import FullPageForm from "../components/FullPageForm.svelte";
   import { cn } from "$lib/utils";
 
   export let walPipeline: any;
@@ -87,15 +87,13 @@
   }
 </script>
 
-<FullPageModal
+<FullPageForm
   title={isEdit ? "Edit Change Retention" : "Setup Change Retention"}
-  bind:open={dialogOpen}
-  bind:showConfirmDialog
   on:close={handleClose}
 >
   <form
     on:submit|preventDefault={handleSubmit}
-    class="space-y-6 max-w-3xl mx-auto mt-6"
+    class="space-y-6 max-w-3xl mx-auto"
   >
     <Card>
       <CardHeader>
@@ -253,4 +251,4 @@
       </CardContent>
     </Card>
   </form>
-</FullPageModal>
+</FullPageForm>

--- a/lib/sequin_web/live/databases/form.ex
+++ b/lib/sequin_web/live/databases/form.ex
@@ -43,11 +43,11 @@ defmodule SequinWeb.DatabasesLive.Form do
           |> put_changesets(%{"database" => %{}, "replication_slot" => %{}})
           |> assign(:pooler_type, nil)
 
-        {:ok, socket}
+        {:ok, socket, layout: {SequinWeb.Layouts, :app_no_sidenav}}
 
       {:error, %NotFoundError{}} ->
         Logger.error("Database not found (id=#{id})")
-        {:ok, push_navigate(socket, to: ~p"/databases")}
+        {:ok, push_navigate(socket, to: ~p"/databases"), layout: {SequinWeb.Layouts, :app_no_sidenav}}
     end
   end
 

--- a/lib/sequin_web/live/http_endpoints/form.ex
+++ b/lib/sequin_web/live/http_endpoints/form.ex
@@ -35,10 +35,10 @@ defmodule SequinWeb.HttpEndpointsLive.Form do
           |> assign(:api_tokens, encode_api_tokens(ApiTokens.list_tokens_for_account(current_account.id)))
           |> put_changeset(%{"http_endpoint" => %{}})
 
-        {:ok, socket}
+        {:ok, socket, layout: {SequinWeb.Layouts, :app_no_sidenav}}
 
       {:error, _} ->
-        {:ok, push_navigate(socket, to: ~p"/http-endpoints")}
+        {:ok, push_navigate(socket, to: ~p"/http-endpoints"), layout: {SequinWeb.Layouts, :app_no_sidenav}}
     end
   end
 

--- a/lib/sequin_web/live/sink_consumers/form.ex
+++ b/lib/sequin_web/live/sink_consumers/form.ex
@@ -1,0 +1,230 @@
+defmodule SequinWeb.SinkConsumersLive.Form do
+  @moduledoc false
+  use SequinWeb, :live_view
+
+  alias Sequin.Consumers.AzureEventHubSink
+  alias Sequin.Consumers.ElasticsearchSink
+  alias Sequin.Consumers.GcpPubsubSink
+  alias Sequin.Consumers.HttpPushSink
+  alias Sequin.Consumers.KafkaSink
+  alias Sequin.Consumers.NatsSink
+  alias Sequin.Consumers.RabbitMqSink
+  alias Sequin.Consumers.RedisStreamSink
+  alias Sequin.Consumers.RedisStringSink
+  alias Sequin.Consumers.SequinStreamSink
+  alias Sequin.Consumers.SinkConsumer
+  alias Sequin.Consumers.SnsSink
+  alias Sequin.Consumers.SqsSink
+  alias Sequin.Consumers.TypesenseSink
+  alias Sequin.Databases
+  alias Sequin.Databases.DatabaseUpdateWorker
+  alias SequinWeb.Components.ConsumerForm
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="consumers-form">
+      <%= render_consumer_form(assigns) %>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    account = current_account(socket)
+    has_databases? = account.id |> Databases.list_dbs_for_account() |> Enum.any?()
+
+    socket =
+      socket
+      |> assign(:has_databases?, has_databases?)
+      |> assign(:self_hosted, Application.get_env(:sequin, :self_hosted))
+
+    {:ok, socket, layout: {SequinWeb.Layouts, :app_no_sidenav}}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :new, %{"kind" => kind}) do
+    # Refresh tables for all databases in the account
+    account = current_account(socket)
+    databases = Databases.list_dbs_for_account(account.id)
+    Enum.each(databases, &DatabaseUpdateWorker.enqueue(&1.id))
+
+    socket
+    |> assign(:page_title, "New Sink")
+    |> assign(:live_action, :new)
+    |> assign(:form_kind, kind)
+  end
+
+  defp render_consumer_form(%{form_kind: "http_push"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :http_push, sink: %HttpPushSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "sqs"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :sqs, sink: %SqsSink{}, batch_size: 10}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "sns"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :sns, sink: %SnsSink{}, batch_size: 10}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "kafka"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :kafka, batch_size: 10, sink: %KafkaSink{tls: false}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "redis_stream"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :redis_stream, batch_size: 10, sink: %RedisStreamSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "sequin_stream"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :sequin_stream, sink: %SequinStreamSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "gcp_pubsub"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={
+        %SinkConsumer{
+          type: :gcp_pubsub,
+          sink: %GcpPubsubSink{}
+        }
+      }
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "nats"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :nats, sink: %NatsSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "rabbitmq"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :rabbitmq, sink: %RabbitMqSink{virtual_host: "/"}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "azure_event_hub"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :azure_event_hub, sink: %AzureEventHubSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "typesense"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :typesense, sink: %TypesenseSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "elasticsearch"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :elasticsearch, sink: %ElasticsearchSink{}}}
+    />
+    """
+  end
+
+  defp render_consumer_form(%{form_kind: "redis_string"} = assigns) do
+    ~H"""
+    <.live_component
+      current_user={@current_user}
+      module={ConsumerForm}
+      id="new-consumer"
+      action={:new}
+      consumer={%SinkConsumer{type: :redis_string, batch_size: 10, sink: %RedisStringSink{}}}
+    />
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:database_tables_updated, _updated_database}, socket) do
+    # Proxy down to ConsumerForm
+    send_update(ConsumerForm, id: "new-consumer", event: :database_tables_updated)
+
+    {:noreply, socket}
+  end
+end

--- a/lib/sequin_web/live/wal_pipelines/form.ex
+++ b/lib/sequin_web/live/wal_pipelines/form.ex
@@ -24,13 +24,15 @@ defmodule SequinWeb.WalPipelinesLive.Form do
 
     case fetch_or_build_wal_pipeline(socket, wal_pipeline_id) do
       {:ok, %WalPipeline{} = wal_pipeline} ->
-        {:ok,
-         socket
-         |> assign(wal_pipeline: wal_pipeline)
-         |> assign(is_edit: is_edit)
-         |> assign(show_errors?: false)
-         |> assign(submit_error: nil)
-         |> assign_changeset(%{}), layout: {SequinWeb.Layouts, :app_no_sidenav}}
+        socket =
+          socket
+          |> assign(wal_pipeline: wal_pipeline)
+          |> assign(is_edit: is_edit)
+          |> assign(show_errors?: false)
+          |> assign(submit_error: nil)
+          |> assign_changeset(%{})
+
+        {:ok, socket, layout: {SequinWeb.Layouts, :app_no_sidenav}}
 
       {:ok, nil} ->
         {:ok, push_navigate(socket, to: ~p"/change-capture-pipelines"), layout: {SequinWeb.Layouts, :app_no_sidenav}}

--- a/lib/sequin_web/live/wal_pipelines/form.ex
+++ b/lib/sequin_web/live/wal_pipelines/form.ex
@@ -30,10 +30,10 @@ defmodule SequinWeb.WalPipelinesLive.Form do
          |> assign(is_edit: is_edit)
          |> assign(show_errors?: false)
          |> assign(submit_error: nil)
-         |> assign_changeset(%{})}
+         |> assign_changeset(%{}), layout: {SequinWeb.Layouts, :app_no_sidenav}}
 
       {:ok, nil} ->
-        {:ok, push_navigate(socket, to: ~p"/change-capture-pipelines")}
+        {:ok, push_navigate(socket, to: ~p"/change-capture-pipelines"), layout: {SequinWeb.Layouts, :app_no_sidenav}}
     end
   end
 

--- a/lib/sequin_web/router.ex
+++ b/lib/sequin_web/router.ex
@@ -93,7 +93,7 @@ defmodule SequinWeb.Router do
 
     live_session :default, on_mount: [{SequinWeb.UserAuth, :ensure_authenticated}, {SequinWeb.LiveHooks, :global}] do
       live "/sinks", SinkConsumersLive.Index, :index
-      live "/sinks/new", SinkConsumersLive.Index, :new
+      live "/sinks/new", SinkConsumersLive.Form, :new
       live "/sinks/:type/:id", SinkConsumersLive.Show, :show
       live "/sinks/:type/:id/messages", SinkConsumersLive.Show, :messages
       live "/sinks/:type/:id/edit", SinkConsumersLive.Show, :edit


### PR DESCRIPTION
Improve rendering full page forms by removing the Modal/Dialog wrapper that was causing some quirks with some event handling.

Forms:
 - Sink
 - Database
 - HTTP endpoint
 - WAL Pipeline

Related additional improvements:
 - The new component name is changed from `FullPageModal` to `FullPageForm`
   - Simplified external props
 - Now we ask for confirmation on exit by default, instead of the opposite. It is still configurable via a prop if needed to override.
 - Replaced read only `Popovers` for `Tooltips`. Keep Popovers for cases where we need an additional input. This improves usability as information is shown on hover.
 - Fixed Message Group card on Sink form to be expanded by default
 - Improved rendering the horizontal scrollbar on `CodeWithCopy` blocks

Shoutout to @acco for the help figuring a robust solution!

Fixes #724
