### PR TITLE
fix: normalize code formatting with `mix format`

### DIFF
--- a/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
+++ b/test/support/unboxed_repo/migrations/20240816005458_create_test_tables.exs
@@ -5,12 +5,24 @@ defmodule Sequin.Test.UnboxedRepo.Migrations.CreateTestTables do
   alias Sequin.Constants
 
   def my_version, do: 1
+
   def check_version!(repo) do
-    if my_version() != get_version(repo) do
-      IO.puts(:stderr,
-        [IO.ANSI.red(), "UnboxedRepo version has been updated!", IO.ANSI.reset(), "\n",
-         IO.ANSI.bright(), "Please run the following command to re-create:", IO.ANSI.reset(), "\n\n",
-         "MIX_ENV=test mix ecto.reset\n"])
+    unless my_version() == get_version(repo) do
+      IO.puts(
+        :stderr,
+        [
+          IO.ANSI.red(),
+          "UnboxedRepo version has been updated!",
+          IO.ANSI.reset(),
+          "\n",
+          IO.ANSI.bright(),
+          "Please run the following command to re-create:",
+          IO.ANSI.reset(),
+          "\n\n",
+          "MIX_ENV=test mix ecto.reset\n"
+        ]
+      )
+
       System.halt(1)
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,6 @@ Sequin.TestSupport.ReplicationSlots.setup_all()
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Sequin.Repo, :manual)
 
-
 migrations_dir = Path.join(UnboxedRepo.config()[:priv], "migrations")
 [{create_mod, _}] = Code.require_file(Path.join(migrations_dir, "20240816005458_create_test_tables.exs"))
 create_mod.check_version!(UnboxedRepo)


### PR DESCRIPTION
A couple of changes were accidentally merged without running `mix format`

~~I opened an issue to keep track of adding a mix format check on CI runs:~~
~~https://github.com/sequinstream/sequin/issues/1416~~

We already have a check in place for PRs, I guess this change was merged without a PR

