### PR TITLE
fix: put back execution redis command in fun

### DIFF
--- a/lib/sequin/sinks/redis/client.ex
+++ b/lib/sequin/sinks/redis/client.ex
@@ -21,7 +21,7 @@ defmodule Sequin.Sinks.Redis.Client do
     with {:ok, connection} <- ConnectionCache.connection(sink) do
       commands = xadd_commands(consumer, messages)
 
-      {time, res} = :timer.tc(__MODULE__, :qp, [connection, commands], :millisecond)
+      {time, res} = :timer.tc(fn -> qp(connection, commands) end, :millisecond)
 
       if time > 200 do
         Logger.warning("[Sequin.Sinks.Redis] Slow command execution", duration_ms: time)


### PR DESCRIPTION
The `qp/2` function is private, so it doesn't work when called via mfa. Probably need to add more tests to cover all such cases 🤦🤦🤦 