### PR TITLE
fix: improve yaml load for `sinks.max_retry_count`, `sinks.active_backfill` and `http_endpoints.encrypted_headers`

### DIFF
--- a/lib/sequin/transforms/transforms.ex
+++ b/lib/sequin/transforms/transforms.ex
@@ -403,6 +403,10 @@ defmodule Sequin.Transforms do
 
   defp encrypted_headers(%HttpEndpoint{encrypted_headers: nil}), do: %{}
 
+  defp encrypted_headers(%HttpEndpoint{encrypted_headers: encrypted_headers})
+       when is_map(encrypted_headers) and map_size(encrypted_headers) == 0,
+       do: %{}
+
   defp encrypted_headers(%HttpEndpoint{encrypted_headers: encrypted_headers}) do
     "(#{map_size(encrypted_headers)} encrypted header(s)) - sha256sum: #{sha256sum(encrypted_headers)}"
   end

--- a/lib/sequin/transforms/transforms.ex
+++ b/lib/sequin/transforms/transforms.ex
@@ -431,11 +431,9 @@ defmodule Sequin.Transforms do
             {:error, error} -> {:halt, {:error, error}}
           end
 
+        # Ignore encrypted_headers until encryption/decryption works
         "encrypted_headers" ->
-          case parse_headers(value) do
-            {:ok, headers} -> {:cont, {:ok, Map.put(acc, :encrypted_headers, headers)}}
-            {:error, error} -> {:halt, {:error, error}}
-          end
+          {:cont, {:ok, acc}}
 
         "webhook.site" ->
           if value in [true, "true"] do
@@ -597,6 +595,9 @@ defmodule Sequin.Transforms do
         "max_retry_count" when is_integer(value) and value >= 0 ->
           {:cont, {:ok, Map.put(acc, :max_retry_count, value)}}
 
+        "max_retry_count" when is_nil(value) ->
+          {:cont, {:ok, acc}}
+
         "max_retry_count" ->
           {:halt, {:error, Error.validation(summary: "max_retry_count must be a non-negative integer")}}
 
@@ -609,6 +610,10 @@ defmodule Sequin.Transforms do
 
         # temporary for backwards compatibility
         "consumer_start" ->
+          {:cont, {:ok, acc}}
+
+        # Ignore until it is properly implemented
+        "active_backfill" ->
           {:cont, {:ok, acc}}
 
         # Ignore internal fields that might be present in the external data

--- a/lib/sequin/transforms/transforms.ex
+++ b/lib/sequin/transforms/transforms.ex
@@ -435,9 +435,11 @@ defmodule Sequin.Transforms do
             {:error, error} -> {:halt, {:error, error}}
           end
 
-        # Ignore encrypted_headers until encryption/decryption works
         "encrypted_headers" ->
-          {:cont, {:ok, acc}}
+          case parse_headers(value) do
+            {:ok, headers} -> {:cont, {:ok, Map.put(acc, :encrypted_headers, headers)}}
+            {:error, error} -> {:halt, {:error, error}}
+          end
 
         "webhook.site" ->
           if value in [true, "true"] do

--- a/test/sequin_web/controllers/yaml_controller_test.exs
+++ b/test/sequin_web/controllers/yaml_controller_test.exs
@@ -4,6 +4,7 @@ defmodule SequinWeb.YamlControllerTest do
   alias Sequin.Databases.PostgresDatabase
   alias Sequin.Databases.Sequence
   alias Sequin.Test.UnboxedRepo
+  alias Sequin.TestSupport.Models.Character
   alias Sequin.TestSupport.ReplicationSlots
 
   @moduletag :unboxed
@@ -120,7 +121,7 @@ defmodule SequinWeb.YamlControllerTest do
             - insert
             - update
             - delete
-          source_table_name: accounts
+          source_table_name: #{Character.table_name()}
           source_table_schema: public
           destination_table_name: sequin_events
           destination_table_schema: public
@@ -133,19 +134,18 @@ defmodule SequinWeb.YamlControllerTest do
           pool_size: 10
           username: postgres
           password: '********'
-          database: sequin_example
+          database: sequin_test
           slot_name: sequin_slot
           use_local_tunnel: false
-          publication_name: sequin_pub
+          publication_name: characters_publication
       http_endpoints:
         - name: test_http_endpoint
           url: http://localhost:4000/something
           headers: {}
-          encrypted_headers: '(0 encrypted header(s)) - sha256sum: b4a8f200'
       sinks:
         - name: accounts_sink
           status: active
-          table: public.accounts
+          table: public.#{Character.table_name()}
           filters: []
           destination:
             port: 4222
@@ -164,7 +164,7 @@ defmodule SequinWeb.YamlControllerTest do
             - update
             - delete
           group_column_names:
-            - user_id
+            - id
       transforms:
         - name: record-transform
           type: path

--- a/test/support/models/character.ex
+++ b/test/support/models/character.ex
@@ -17,6 +17,10 @@ defmodule Sequin.TestSupport.Models.Character do
     timestamps(type: :naive_datetime_usec)
   end
 
+  def table_name do
+    "Characters"
+  end
+
   def quoted_table_name do
     ~s{"Characters"}
   end


### PR DESCRIPTION
While testing out CLI export->plan functionality, I detected a couple of issues when trying to load a config from a yaml.

1. `sinks.max_retry_count` - if is set to nil (as it seems its the default) the loader fails with an error stating that it should be greater than 0
2. `sinks.active_backfill` - if is present, and set to any value, the loader fails. I suggest to ignore this field for now until we support managing backfills via the yaml.
3. `http_endpoints.encrypted_headers` - seems to be [serialized as a string/binary](https://github.com/sequinstream/sequin/blob/main/lib/sequin/transforms/transforms.ex#L418-L420) (even if the map is empty, as it seems is the default) - causing to fail `parse_headers` validation. I suggest ignoring this field for now, unless we want to handle encrypting/decrypting them properly
  3.1. I also made a change to match if encrypted headers is an empty map, as opposed to `nil` and serialize them as an empty map 

I added a simple test that includes a single resource of each, mostly created with default settings. 

For a future iteration of an improved but similar check I would suggest to write a test that creates a bunch of records and combinations (`databases`, `change_retentions`, `sinks`, `http_endpoint`, `functions`); then assert that exporting->loading works. That way we can test that if the exporting/serializing logic changes, it is still compatible with the loading/deserializing logic and viceversa.