### PR TITLE
fix: remove the brew tap command from CopyIcon for cli install

### DIFF
--- a/assets/svelte/cli/Index.svelte
+++ b/assets/svelte/cli/Index.svelte
@@ -81,7 +81,7 @@
                   class="absolute right-2 top-2"
                 >
                   <CopyIcon
-                    content={`brew tap sequinstream/sequin git@github.com:sequinstream/homebrew-sequin\nbrew install sequinstream/sequin/sequin`}
+                    content={`brew install sequinstream/sequin/sequin`}
                   />
                 </Button>
               </div>


### PR DESCRIPTION
Quick fix for the removal of `brew tap` from the CopyIcon cli installation instructions

cc @acco