### PR TITLE
Reload message_handler_ctx on every boot

### DIFF
--- a/lib/sequin/runtime/slot_processor_server.ex
+++ b/lib/sequin/runtime/slot_processor_server.ex
@@ -181,8 +181,9 @@ defmodule Sequin.Runtime.SlotProcessorServer do
 
     replication_slot = Keyword.fetch!(opts, :replication_slot)
     test_pid = Keyword.get(opts, :test_pid)
-    message_handler_ctx = Keyword.fetch!(opts, :message_handler_ctx)
     message_handler_module = Keyword.fetch!(opts, :message_handler_module)
+    message_handler_ctx_fn = Keyword.fetch!(opts, :message_handler_ctx_fn)
+    message_handler_ctx = message_handler_ctx_fn.(replication_slot)
     max_memory_bytes = Keyword.get_lazy(opts, :max_memory_bytes, &default_max_memory_bytes/0)
     bytes_between_limit_checks = Keyword.get(opts, :bytes_between_limit_checks, div(max_memory_bytes, 100))
 

--- a/lib/sequin/runtime/slot_processor_supervisor.ex
+++ b/lib/sequin/runtime/slot_processor_supervisor.ex
@@ -42,7 +42,7 @@ defmodule Sequin.Runtime.SlotProcessorSupervisor do
         publication: slot.publication_name,
         postgres_database: slot.postgres_database,
         replication_slot: slot,
-        message_handler_ctx: MessageHandler.context(slot),
+        message_handler_ctx_fn: &MessageHandler.context/1,
         message_handler_module: message_handler_module,
         connection: PostgresDatabase.to_postgrex_opts(slot.postgres_database),
         ipv6: slot.postgres_database.ipv6

--- a/test/sequin/postgres_replication_test.exs
+++ b/test/sequin/postgres_replication_test.exs
@@ -1829,13 +1829,15 @@ defmodule Sequin.PostgresReplicationTest do
           test_pid: self(),
           id: server_id(),
           message_handler_module: SlotMessageHandlerMock,
-          message_handler_ctx: %MessageHandler.Context{
-            consumers: [],
-            wal_pipelines: [],
-            replication_slot_id: id,
-            postgres_database: db,
-            table_reader_mod: TableReaderServer
-          },
+          message_handler_ctx_fn: fn _ ->
+            %MessageHandler.Context{
+              consumers: [],
+              wal_pipelines: [],
+              replication_slot_id: id,
+              postgres_database: db,
+              table_reader_mod: TableReaderServer
+            }
+          end,
           postgres_database: db,
           replication_slot: %PostgresReplicationSlot{id: id}
         ],


### PR DESCRIPTION
Minimal possible changes to ensure that SlotProcessorServer reloads its MessageHandler.Context on every boot. Without this, the SPS can get out-of-sync with the database // the list of sink_consumers in Context can become inaccurate. (On crash, it reverts to whatever the initial set was!)