### PR TITLE
fix: only display message not_visible_until date if its defined

### DIFF
--- a/assets/svelte/consumers/ShowMessages.svelte
+++ b/assets/svelte/consumers/ShowMessages.svelte
@@ -657,7 +657,7 @@
                         >Not visible until:</span
                       >
                       <span class="text-sm text-gray-900">
-                        {selectedMessage.last_delivered_at
+                        {selectedMessage.not_visible_until
                           ? formatDate(selectedMessage.not_visible_until)
                           : "N/A"}
                       </span>


### PR DESCRIPTION
Fix ternary check to properly display `message.not_visible_until` on Message Detail view

Fixes #1454 

## Evidence

<img width="651" alt="image" src="https://github.com/user-attachments/assets/46573f92-1e96-4129-9ade-afd857a0a7c0" />

