### PR TITLE
fix: show missing Transform Function form validation errors

### DIFF
--- a/assets/svelte/transforms/Edit.svelte
+++ b/assets/svelte/transforms/Edit.svelte
@@ -608,9 +608,9 @@ Please help me create or modify the Elixir function transform to achieve the des
               />
             </SelectContent>
           </Select>
-          {#if showErrors && formErrors.transform?.type}
+          {#if showErrors && formErrors.transform && Array.isArray(formErrors.transform)}
             <p class="text-sm text-red-500 dark:text-red-400">
-              {formErrors.transform.type[0]}
+              {formErrors.transform[0]}
             </p>
           {/if}
 
@@ -640,9 +640,9 @@ Please help me create or modify the Elixir function transform to achieve the des
                 />
               </SelectContent>
             </Select>
-            {#if showErrors && formErrors.transform?.type}
+            {#if showErrors && formErrors.transform?.sink_type}
               <p class="text-sm text-red-500 dark:text-red-400">
-                {formErrors.transform.type[0]}
+                {formErrors.transform.sink_type[0]}
               </p>
             {/if}
           {/if}
@@ -802,17 +802,6 @@ Please help me create or modify the Elixir function transform to achieve the des
         </div>
 
         <div class="flex gap-2 pt-2">
-          {#if form.transform.type === "function"}
-            <CopyToClipboard
-              textFn={handleCopyForChatGPT}
-              buttonText="Copy for ChatGPT"
-              successText="Copied to clipboard"
-              buttonVariant="magic"
-              buttonSize="default"
-              className="w-48"
-            />
-          {/if}
-
           <AlertDialog bind:open={showUpdateDialog}>
             <Button
               type="submit"
@@ -864,6 +853,17 @@ Please help me create or modify the Elixir function transform to achieve the des
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
+
+          {#if form.transform.type === "function"}
+            <CopyToClipboard
+              textFn={handleCopyForChatGPT}
+              buttonText="Copy for ChatGPT"
+              successText="Copied to clipboard"
+              buttonVariant="magic"
+              buttonSize="default"
+              className="w-48"
+            />
+          {/if}
 
           {#if isEditing}
             <AlertDialog bind:open={showDeleteDialog}>


### PR DESCRIPTION
Fix showing missing Function form validation errors that were not being shown because they were accessing the wrong `formErrors` accessor paths.

This caused subsequent DB-related constraint errors (returned by `Repo.insert`) such as "name has already been taken" to not show up, as those validations are not happening in the first place due to the failed initial validations.

This seems to be the expected default behavior as [stated in the docs](https://hexdocs.pm/ecto/Ecto.Changeset.html#module-validations-and-constraints) and even though I would love to see those DB-related errors as soon as possible, it may involve a deeper set of changes and implications.

Additional, unrelated change:
Always show the "Create Function" button on the same spot, to be consistent. Thus moving the Copy to GPT from the left side of that button to the right side.


Fixes #1438