### PR TITLE
fix: avoid saving form to local storage if submission was successful

### DIFF
--- a/assets/svelte/databases/Form.svelte
+++ b/assets/svelte/databases/Form.svelte
@@ -185,7 +185,7 @@
     validating = true;
     clearFormStorage();
     pushEvent("form_submitted", { form }, (reply) => {
-      if (reply?.ok !== true) {
+      if (reply?.ok === false) {
         validating = false;
         progress.set(0);
         saveFormToStorage();


### PR DESCRIPTION
It seems that due to the use of `push_navigate` on a successful `form_submitted` event the callback receives `null` as a response, rather than `{ok: true}`

So now we just do the opposite check on submission: if the form response is `null` we don't restore to local storage, and if its `{ok: false}` we keep the form in local storage

Fixes #1472

Shoutout to @g14a for the amazing replication video! it was super helpful

--

Pre-fix replication steps:

1. Create two database records
2. Open up one, dont change anything, and click "Update Database" to cause a successful update
3. Open up the other db record, and you should see the polluted form details loaded from local storage