### PR TITLE
fix: only show database exit confirm dialog when form is dirty

### DIFF
--- a/assets/svelte/databases/Form.svelte
+++ b/assets/svelte/databases/Form.svelte
@@ -80,6 +80,20 @@
 
   let form = { ...database };
 
+  let lastPushedFormJSON = null;
+  let isDirty = false;
+
+  $: {
+    isDirty = JSON.stringify(form) !== JSON.stringify(database);
+
+    // Only push the form if it has changed since the last push
+    // Prevents infinite loop of pushing the same form over and over
+    if (JSON.stringify(form) !== lastPushedFormJSON) {
+      pushEvent("form_updated", { form });
+      lastPushedFormJSON = JSON.stringify(form);
+    }
+  }
+
   const isEdit = !!form.id;
 
   let databaseErrors: any = {};
@@ -318,6 +332,7 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
 
 <FullPageForm
   title={isEdit ? `Edit database ${form.name}` : "Connect Database"}
+  showConfirmOnExit={isDirty}
   on:close={handleClose}
 >
   <form on:submit={handleSubmit} class="space-y-6 max-w-3xl mx-auto">

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -45,7 +45,7 @@ defmodule Sequin.Databases.PostgresDatabase do
     field :queue_interval, :integer, default: 1000
     field :queue_target, :integer, default: 50
     field :name, :string
-    field :ssl, :boolean, default: false
+    field :ssl, :boolean, default: true
     field :username, :string
     field(:password, Sequin.Encrypted.Binary) :: String.t()
     field :tables_refreshed_at, :utc_datetime

--- a/lib/sequin_web/live/databases/form.ex
+++ b/lib/sequin_web/live/databases/form.ex
@@ -404,7 +404,7 @@ defmodule SequinWeb.DatabasesLive.Form do
       "port" => database.port || 5432,
       "username" => database.username || "postgres",
       "password" => database.password,
-      "ssl" => database.ssl || true,
+      "ssl" => database.ssl,
       "publication_name" => database.replication_slot.publication_name || "sequin_pub",
       "slot_name" => database.replication_slot.slot_name || "sequin_slot",
       "useLocalTunnel" => database.use_local_tunnel || false,


### PR DESCRIPTION
Only show database exit confirm dialog when form is dirty, using the same implementation as the sink consumer form.

Also set the ssl default value to `true` in the `typed_schema` definition rather than in the `render` fn, as doing `database.ssl || true` always causes the value to be `true` regardless of the existing boolean set in `ssl`