### PR TITLE
fix: update sequences inline on creating sink consumer to avoid race condition

### DIFF
--- a/lib/sequin/runtime/consumer_lifecycle_event_worker.ex
+++ b/lib/sequin/runtime/consumer_lifecycle_event_worker.ex
@@ -9,7 +9,6 @@ defmodule Sequin.Runtime.ConsumerLifecycleEventWorker do
 
   alias Sequin.Consumers
   alias Sequin.Consumers.Transform
-  alias Sequin.Databases
   alias Sequin.Health
   alias Sequin.Health.CheckHttpEndpointHealthWorker
   alias Sequin.Health.CheckSinkConfigurationWorker
@@ -59,9 +58,6 @@ defmodule Sequin.Runtime.ConsumerLifecycleEventWorker do
     case event do
       "create" ->
         with {:ok, consumer} <- Consumers.get_consumer(id) do
-          consumer = Repo.preload(consumer, :postgres_database)
-          # Lazy, just do this on every sink create. Eventually, we'll retire Sequence
-          Databases.update_sequences_from_db(consumer.postgres_database)
           CheckSinkConfigurationWorker.enqueue(consumer.id, unique: false)
           RuntimeSupervisor.start_for_sink_consumer(consumer)
           :ok = RuntimeSupervisor.refresh_message_handler_ctx(consumer.replication_slot_id)


### PR DESCRIPTION
Updating db sequences for a sink consumer are performed asynchronously in the ConsumerLifecycleEventWorker.
This leads to a race condition where the sink details are shown before the sequences are updated, resulting in error messages that may be missing schema and table names.

Fixes #1437
