### PR TITLE
fix: unify consumer sink :new and :edit into a single form live view

### DIFF
--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -386,7 +386,9 @@
 </script>
 
 <FullPageForm
-  title={isEditMode ? `Edit ${consumerTitle}` : `Create ${consumerTitle}`}
+  title={isEditMode
+    ? `Edit ${consumerTitle} ${form.name}`
+    : `Create ${consumerTitle}`}
   showConfirmOnExit={isDirty}
   on:close={handleClose}
 >

--- a/lib/sequin_web/live/components/consumer_form.ex
+++ b/lib/sequin_web/live/components/consumer_form.ex
@@ -1287,4 +1287,33 @@ defmodule SequinWeb.Components.ConsumerForm do
     Application.get_env(:sequin, :env) != :prod or
       Application.get_env(:sequin, :self_hosted)
   end
+
+  # Returns a default SinkConsumer struct for a given kind (as string or atom)
+  @spec default_for_kind(String.t() | atom) :: SinkConsumer.t()
+  def default_for_kind(kind) when is_binary(kind), do: default_for_kind(String.to_existing_atom(kind))
+
+  def default_for_kind(kind) do
+    sink_consumer = %SinkConsumer{type: kind}
+
+    {sink, attrs} =
+      case kind do
+        :http_push -> {%HttpPushSink{}, %{}}
+        :sqs -> {%SqsSink{}, %{batch_size: 10}}
+        :sns -> {%SnsSink{}, %{batch_size: 10}}
+        :kafka -> {%KafkaSink{tls: false}, %{batch_size: 10}}
+        :redis_stream -> {%RedisStreamSink{}, %{batch_size: 10}}
+        :sequin_stream -> {%SequinStreamSink{}, %{}}
+        :gcp_pubsub -> {%GcpPubsubSink{}, %{}}
+        :nats -> {%NatsSink{}, %{}}
+        :rabbitmq -> {%RabbitMqSink{virtual_host: "/"}, %{}}
+        :azure_event_hub -> {%AzureEventHubSink{}, %{}}
+        :typesense -> {%TypesenseSink{}, %{}}
+        :elasticsearch -> {%ElasticsearchSink{}, %{}}
+        :redis_string -> {%RedisStringSink{}, %{batch_size: 10}}
+      end
+
+    sink_consumer
+    |> Map.put(:sink, sink)
+    |> Map.merge(Map.take(attrs, [:batch_size]))
+  end
 end

--- a/lib/sequin_web/live/sink_consumers/form.ex
+++ b/lib/sequin_web/live/sink_consumers/form.ex
@@ -2,23 +2,12 @@ defmodule SequinWeb.SinkConsumersLive.Form do
   @moduledoc false
   use SequinWeb, :live_view
 
-  alias Sequin.Consumers.AzureEventHubSink
-  alias Sequin.Consumers.ElasticsearchSink
-  alias Sequin.Consumers.GcpPubsubSink
-  alias Sequin.Consumers.HttpPushSink
-  alias Sequin.Consumers.KafkaSink
-  alias Sequin.Consumers.NatsSink
-  alias Sequin.Consumers.RabbitMqSink
-  alias Sequin.Consumers.RedisStreamSink
-  alias Sequin.Consumers.RedisStringSink
-  alias Sequin.Consumers.SequinStreamSink
-  alias Sequin.Consumers.SinkConsumer
-  alias Sequin.Consumers.SnsSink
-  alias Sequin.Consumers.SqsSink
-  alias Sequin.Consumers.TypesenseSink
+  alias Sequin.Consumers
   alias Sequin.Databases
   alias Sequin.Databases.DatabaseUpdateWorker
   alias SequinWeb.Components.ConsumerForm
+
+  require Logger
 
   @impl true
   def render(assigns) do
@@ -30,16 +19,35 @@ defmodule SequinWeb.SinkConsumersLive.Form do
   end
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     account = current_account(socket)
     has_databases? = account.id |> Databases.list_dbs_for_account() |> Enum.any?()
+    id = Map.get(params, "id")
+    kind = Map.get(params, "type") || Map.get(params, "kind")
 
-    socket =
-      socket
-      |> assign(:has_databases?, has_databases?)
-      |> assign(:self_hosted, Application.get_env(:sequin, :self_hosted))
+    case fetch_or_build_consumer(socket, kind, id) do
+      {:ok, consumer} ->
+        socket =
+          socket
+          |> assign(:has_databases?, has_databases?)
+          |> assign(:self_hosted, Application.get_env(:sequin, :self_hosted))
+          |> assign(:consumer, consumer)
+          |> assign(:form_kind, kind)
 
-    {:ok, socket, layout: {SequinWeb.Layouts, :app_no_sidenav}}
+        {:ok, socket, layout: {SequinWeb.Layouts, :app_no_sidenav}}
+
+      {:error, _error} ->
+        Logger.error("Sink not found (id=#{id})")
+        {:ok, push_navigate(socket, to: ~p"/sinks")}
+    end
+  end
+
+  defp fetch_or_build_consumer(_socket, kind, nil) do
+    {:ok, ConsumerForm.default_for_kind(kind)}
+  end
+
+  defp fetch_or_build_consumer(socket, _kind, id) do
+    Consumers.get_sink_consumer_for_account(current_account_id(socket), id)
   end
 
   @impl Phoenix.LiveView
@@ -47,175 +55,32 @@ defmodule SequinWeb.SinkConsumersLive.Form do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  defp apply_action(socket, :new, %{"kind" => kind}) do
+  defp handle_edit_finish(updated_consumer) do
+    send(self(), {:updated_consumer, updated_consumer})
+  end
+
+  defp apply_action(socket, :edit, _params) do
+    socket
+  end
+
+  defp apply_action(socket, :new, _params) do
     # Refresh tables for all databases in the account
     account = current_account(socket)
     databases = Databases.list_dbs_for_account(account.id)
     Enum.each(databases, &DatabaseUpdateWorker.enqueue(&1.id))
 
     socket
-    |> assign(:page_title, "New Sink")
-    |> assign(:live_action, :new)
-    |> assign(:form_kind, kind)
   end
 
-  defp render_consumer_form(%{form_kind: "http_push"} = assigns) do
+  defp render_consumer_form(assigns) do
     ~H"""
     <.live_component
       current_user={@current_user}
       module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :http_push, sink: %HttpPushSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "sqs"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :sqs, sink: %SqsSink{}, batch_size: 10}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "sns"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :sns, sink: %SnsSink{}, batch_size: 10}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "kafka"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :kafka, batch_size: 10, sink: %KafkaSink{tls: false}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "redis_stream"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :redis_stream, batch_size: 10, sink: %RedisStreamSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "sequin_stream"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :sequin_stream, sink: %SequinStreamSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "gcp_pubsub"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={
-        %SinkConsumer{
-          type: :gcp_pubsub,
-          sink: %GcpPubsubSink{}
-        }
-      }
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "nats"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :nats, sink: %NatsSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "rabbitmq"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :rabbitmq, sink: %RabbitMqSink{virtual_host: "/"}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "azure_event_hub"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :azure_event_hub, sink: %AzureEventHubSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "typesense"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :typesense, sink: %TypesenseSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "elasticsearch"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :elasticsearch, sink: %ElasticsearchSink{}}}
-    />
-    """
-  end
-
-  defp render_consumer_form(%{form_kind: "redis_string"} = assigns) do
-    ~H"""
-    <.live_component
-      current_user={@current_user}
-      module={ConsumerForm}
-      id="new-consumer"
-      action={:new}
-      consumer={%SinkConsumer{type: :redis_string, batch_size: 10, sink: %RedisStringSink{}}}
+      id="consumer-form"
+      action={@live_action}
+      consumer={@consumer}
+      on_finish={&handle_edit_finish/1}
     />
     """
   end
@@ -223,7 +88,7 @@ defmodule SequinWeb.SinkConsumersLive.Form do
   @impl Phoenix.LiveView
   def handle_info({:database_tables_updated, _updated_database}, socket) do
     # Proxy down to ConsumerForm
-    send_update(ConsumerForm, id: "new-consumer", event: :database_tables_updated)
+    send_update(ConsumerForm, id: "consumer-form", event: :database_tables_updated)
 
     {:noreply, socket}
   end

--- a/lib/sequin_web/live/sink_consumers/show.ex
+++ b/lib/sequin_web/live/sink_consumers/show.ex
@@ -41,7 +41,6 @@ defmodule SequinWeb.SinkConsumersLive.Show do
   alias Sequin.Runtime.KeysetCursor
   alias Sequin.Runtime.SlotMessageStore
   alias Sequin.Transforms.Message
-  alias SequinWeb.Components.ConsumerForm
   alias SequinWeb.RouteHelpers
 
   require Logger
@@ -122,19 +121,7 @@ defmodule SequinWeb.SinkConsumersLive.Show do
       end
 
     socket = assign(socket, :show_acked, show_acked)
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-  end
-
-  defp apply_action(socket, :show, _params) do
-    assign(socket, :page_title, "Show Consumer")
-  end
-
-  defp apply_action(socket, :edit, _params) do
-    assign(socket, :page_title, "Edit Consumer")
-  end
-
-  defp apply_action(socket, :messages, _params) do
-    assign(socket, :page_title, "Messages")
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView
@@ -160,16 +147,6 @@ defmodule SequinWeb.SinkConsumersLive.Show do
       <!-- Main content area that fills the remaining space -->
       <div class="flex-1 overflow-auto">
         <%= case {@live_action, @consumer} do %>
-          <% {:edit, _consumer} -> %>
-            <!-- Edit component -->
-            <.live_component
-              module={ConsumerForm}
-              id="edit-consumer"
-              consumer={@consumer}
-              on_finish={&handle_edit_finish/1}
-              current_user={@current_user}
-              transforms={Enum.map(@transforms, &encode_transform/1)}
-            />
           <% {:show, %SinkConsumer{}} -> %>
             <!-- ShowHttpPush component -->
             <.svelte
@@ -213,10 +190,9 @@ defmodule SequinWeb.SinkConsumersLive.Show do
     """
   end
 
-  @impl Phoenix.LiveView
   def handle_event("edit", _params, socket) do
     type = Consumers.kind(socket.assigns.consumer)
-    {:noreply, push_patch(socket, to: ~p"/sinks/#{type}/#{socket.assigns.consumer.id}/edit")}
+    {:noreply, push_navigate(socket, to: ~p"/sinks/#{type}/#{socket.assigns.consumer.id}/edit")}
   end
 
   @impl Phoenix.LiveView
@@ -480,10 +456,6 @@ defmodule SequinWeb.SinkConsumersLive.Show do
         {:reply, %{ok: false},
          put_flash(socket, :toast, %{kind: :error, title: "Failed to reset message visibility: #{inspect(reason)}"})}
     end
-  end
-
-  defp handle_edit_finish(updated_consumer) do
-    send(self(), {:updated_consumer, updated_consumer})
   end
 
   @impl Phoenix.LiveView

--- a/lib/sequin_web/router.ex
+++ b/lib/sequin_web/router.ex
@@ -97,7 +97,7 @@ defmodule SequinWeb.Router do
       live "/sinks/:type/:id", SinkConsumersLive.Show, :show
       live "/sinks/:type/:id/messages", SinkConsumersLive.Show, :messages
       live "/sinks/:type/:id/messages/:ack_id", SinkConsumersLive.Show, :messages
-      live "/sinks/:type/:id/edit", SinkConsumersLive.Show, :edit
+      live "/sinks/:type/:id/edit", SinkConsumersLive.Form, :edit
 
       live "/functions", TransformsLive.Index, :index
       live "/functions/new", TransformsLive.Edit, :new


### PR DESCRIPTION
Unify rendering Sink :new and :edit actions into a single unit of logic, in order to re-use as many components as we can, and also use the same layer without sidebar. Also refactor a couple of things to make things a bit more clear to edit/understand.

Also added the sink name to the title

Fixes #1497 

@g14a thanks for reporting this issue and suggesting improvements! Keep them coming 🙌🏼 