### PR TITLE
chore: replace Enum.map with Enum.each for side effects

### DIFF
--- a/lib/sequin/health/kickoff_check_http_endpoint_health_worker.ex
+++ b/lib/sequin/health/kickoff_check_http_endpoint_health_worker.ex
@@ -16,7 +16,7 @@ defmodule Sequin.Health.KickoffCheckHttpEndpointHealthWorker do
   def perform(_) do
     Consumers.list_http_endpoints()
     |> Enum.with_index()
-    |> Enum.map(fn {endpoint, index} ->
+    |> Enum.each(fn {endpoint, index} ->
       # Integer division to get the delay in seconds (10 per second)
       delay_seconds = div(index, 10)
       CheckHttpEndpointHealthWorker.enqueue_in(endpoint.id, delay_seconds)

--- a/lib/sequin/health/kickoff_check_postgres_replication_slot_worker.ex
+++ b/lib/sequin/health/kickoff_check_postgres_replication_slot_worker.ex
@@ -16,7 +16,7 @@ defmodule Sequin.Health.KickoffCheckPostgresReplicationSlotWorker do
   def perform(_) do
     Databases.list_dbs()
     |> Enum.with_index()
-    |> Enum.map(fn {db, index} ->
+    |> Enum.each(fn {db, index} ->
       # Integer division to get the delay in seconds (10 per second)
       delay_seconds = div(index, 10)
       CheckPostgresReplicationSlotWorker.enqueue_in(db.id, delay_seconds)

--- a/lib/sequin/health/kickoff_check_sink_configuration_worker.ex
+++ b/lib/sequin/health/kickoff_check_sink_configuration_worker.ex
@@ -16,7 +16,7 @@ defmodule Sequin.Health.KickoffCheckSinkConfigurationWorker do
   def perform(_) do
     Consumers.list_active_sink_consumers()
     |> Enum.with_index()
-    |> Enum.map(fn {consumer, index} ->
+    |> Enum.each(fn {consumer, index} ->
       # Integer division to get the delay in seconds (10 per second)
       delay_seconds = div(index, 10)
 

--- a/lib/sequin/runtime/sink_pipeline.ex
+++ b/lib/sequin/runtime/sink_pipeline.ex
@@ -378,7 +378,7 @@ defmodule Sequin.Runtime.SinkPipeline do
       |> Stream.map(&Consumers.advance_delivery_state_for_failure/1)
       |> Enum.map(&%{&1 | data: nil})
 
-    Enum.map(failed, fn %Message{} = message ->
+    Enum.each(failed, fn %Message{} = message ->
       error =
         case message.status do
           {:failed, error} when is_exception(error) ->


### PR DESCRIPTION
Replaced Enum.map with Enum.each since the mapped result wasn't used, to avoid unnecessary list allocation.
