### PR TITLE
Implement paginated sinks list

### DIFF
--- a/assets/svelte/consumers/SinkIndex.svelte
+++ b/assets/svelte/consumers/SinkIndex.svelte
@@ -34,6 +34,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import * as d3 from "d3";
   import { onMount } from "svelte";
+  import { Skeleton } from "$lib/components/ui/skeleton";
 
   export let consumers: Array<{
     id: string;
@@ -61,7 +62,7 @@
     metrics: {
       messages_processed_throughput_timeseries: number[];
     };
-  }>;
+  }> | null;
   export let live: any;
   export let hasDatabases: boolean;
   export let selfHosted: boolean;
@@ -71,7 +72,7 @@
   let selectedDestination: string;
   let dialogOpen = false;
 
-  let pageLoading = false;
+  $: pageLoading = consumers === null;
   $: hasConsumers = totalCount > 0;
   $: pageCount = Math.ceil(totalCount / pageSize);
   $: startIndex = page * pageSize + 1;
@@ -233,43 +234,45 @@
 
   onMount(() => {
     // Create charts for each consumer
-    consumers.forEach((consumer) => {
-      const element = chartElements[consumer.id];
-      if (
-        element &&
-        consumer.metrics.messages_processed_throughput_timeseries.length > 0
-      ) {
-        createMiniChart(
-          element,
-          consumer.metrics.messages_processed_throughput_timeseries,
-        );
-      }
-    });
+    if (consumers !== null) {
+      consumers.forEach((consumer) => {
+        const element = chartElements[consumer.id];
+        if (
+          element &&
+          consumer.metrics.messages_processed_throughput_timeseries.length > 0
+        ) {
+          createMiniChart(
+            element,
+            consumer.metrics.messages_processed_throughput_timeseries,
+          );
+        }
+      });
+    }
   });
 
-  $: if (consumers) {
-    // Update charts when consumers data changes
-    consumers.forEach((consumer) => {
-      const element = chartElements[consumer.id];
-      if (
-        element &&
-        consumer.metrics.messages_processed_throughput_timeseries.length > 0
-      ) {
-        createMiniChart(
-          element,
-          consumer.metrics.messages_processed_throughput_timeseries,
-        );
-      }
-    });
+  $: {
+    if (consumers !== null) {
+      // Update charts when consumers data changes
+      consumers.forEach((consumer) => {
+        const element = chartElements[consumer.id];
+        if (
+          element &&
+          consumer.metrics.messages_processed_throughput_timeseries.length > 0
+        ) {
+          createMiniChart(
+            element,
+            consumer.metrics.messages_processed_throughput_timeseries,
+          );
+        }
+      });
+    }
   }
 
   function changePage(newPage: number) {
     if (newPage >= 0 && newPage < pageCount) {
       page = newPage;
       pageLoading = true;
-      live.pushEvent("change_page", { page }, () => {
-        pageLoading = false;
-      });
+      live.pushEvent("change_page", { page });
     }
   }
 </script>
@@ -330,49 +333,74 @@
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {#each consumers as consumer}
-          <Table.Row
-            on:click={() => handleConsumerClick(consumer.id, consumer.type)}
-            class="cursor-pointer"
-          >
-            <Table.Cell>
-              {#each sinks.filter((d) => d.id === consumer.type) as dest}
-                <svelte:component this={dest.icon} class="h-6 w-6" />
-              {/each}
-            </Table.Cell>
-            <Table.Cell>{consumer.name}</Table.Cell>
-            <Table.Cell>
-              <div class="flex items-center gap-2">
-                {#if consumer.status === "paused"}
-                  <Badge variant="warning">
-                    <Pause class="h-4 w-4 mr-1" />
-                    <span>Paused</span>
-                  </Badge>
-                {:else if consumer.status === "disabled"}
-                  <Badge variant="secondary">
-                    <StopCircle class="h-4 w-4 mr-1" />
-                    <span>Disabled</span>
-                  </Badge>
-                {:else}
-                  <HealthPill status={consumer.health.status} />
-                {/if}
-                {#if consumer.active_backfill}
-                  <Badge variant="secondary">
-                    <ArrowDownSquare class="h-4 w-4 mr-1" />
-                    <span>Backfilling</span>
-                  </Badge>
-                {/if}
-              </div>
-            </Table.Cell>
-            <Table.Cell>{consumer.database_name}</Table.Cell>
-            <Table.Cell>
-              <div use:bindChartElement={consumer.id} class="w-48 h-8" />
-            </Table.Cell>
-            <Table.Cell
-              >{formatRelativeTimestamp(consumer.insertedAt)}</Table.Cell
+        {#if pageLoading}
+          {#each Array(pageSize) as _, i}
+            <Table.Row>
+              <Table.Cell class="w-8">
+                <Skeleton class="h-6 w-6 rounded" />
+              </Table.Cell>
+              <Table.Cell class="w-32">
+                <Skeleton class="h-4 w-24" />
+              </Table.Cell>
+              <Table.Cell class="w-24">
+                <Skeleton class="h-6 w-24" />
+              </Table.Cell>
+              <Table.Cell class="w-40">
+                <Skeleton class="h-4 w-40" />
+              </Table.Cell>
+              <Table.Cell class="w-48">
+                <Skeleton class="h-8 w-48" />
+              </Table.Cell>
+              <Table.Cell class="w-24">
+                <Skeleton class="h-4 w-24" />
+              </Table.Cell>
+            </Table.Row>
+          {/each}
+        {:else}
+          {#each consumers as consumer}
+            <Table.Row
+              on:click={() => handleConsumerClick(consumer.id, consumer.type)}
+              class="cursor-pointer"
             >
-          </Table.Row>
-        {/each}
+              <Table.Cell class="w-8">
+                {#each sinks.filter((d) => d.id === consumer.type) as dest}
+                  <svelte:component this={dest.icon} class="h-6 w-6" />
+                {/each}
+              </Table.Cell>
+              <Table.Cell class="w-32">{consumer.name}</Table.Cell>
+              <Table.Cell class="w-24">
+                <div class="flex items-center gap-2">
+                  {#if consumer.status === "paused"}
+                    <Badge variant="warning">
+                      <Pause class="h-4 w-4 mr-1" />
+                      <span>Paused</span>
+                    </Badge>
+                  {:else if consumer.status === "disabled"}
+                    <Badge variant="secondary">
+                      <StopCircle class="h-4 w-4 mr-1" />
+                      <span>Disabled</span>
+                    </Badge>
+                  {:else}
+                    <HealthPill status={consumer.health.status} />
+                  {/if}
+                  {#if consumer.active_backfill}
+                    <Badge variant="secondary">
+                      <ArrowDownSquare class="h-4 w-4 mr-1" />
+                      <span>Backfilling</span>
+                    </Badge>
+                  {/if}
+                </div>
+              </Table.Cell>
+              <Table.Cell class="w-40">{consumer.database_name}</Table.Cell>
+              <Table.Cell class="w-48">
+                <div use:bindChartElement={consumer.id} class="w-48 h-8" />
+              </Table.Cell>
+              <Table.Cell class="w-24"
+                >{formatRelativeTimestamp(consumer.insertedAt)}</Table.Cell
+              >
+            </Table.Row>
+          {/each}
+        {/if}
       </Table.Body>
     </Table.Root>
     {#if totalCount > pageSize}

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -134,12 +134,15 @@ defmodule Sequin.Consumers do
     |> Repo.all()
   end
 
-  def list_sink_consumers_for_account_paginated(account_id, page, page_size, preload \\ []) do
+  def list_sink_consumers_for_account_paginated(account_id, page, page_size, opts \\ []) do
+    preload = Keyword.get(opts, :preload, [])
+    order_by = Keyword.get(opts, :order_by, [desc: :updated_at])
+
     offset = page * page_size
 
     account_id
     |> SinkConsumer.where_account_id()
-    |> order_by([sc], desc: sc.updated_at)
+    |> order_by([sc], ^order_by)
     |> preload(^preload)
     |> limit(^page_size)
     |> offset(^offset)

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -134,6 +134,18 @@ defmodule Sequin.Consumers do
     |> Repo.all()
   end
 
+  def list_sink_consumers_for_account_paginated(account_id, page, page_size, preload \\ []) do
+    offset = page * page_size
+
+    account_id
+    |> SinkConsumer.where_account_id()
+    |> order_by([sc], desc: sc.updated_at)
+    |> preload(^preload)
+    |> limit(^page_size)
+    |> offset(^offset)
+    |> Repo.all()
+  end
+
   def count_sink_consumers_for_account(account_id) do
     account_id
     |> SinkConsumer.where_account_id()

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -136,7 +136,7 @@ defmodule Sequin.Consumers do
 
   def list_sink_consumers_for_account_paginated(account_id, page, page_size, opts \\ []) do
     preload = Keyword.get(opts, :preload, [])
-    order_by = Keyword.get(opts, :order_by, [desc: :updated_at])
+    order_by = Keyword.get(opts, :order_by, desc: :updated_at, desc: :name)
 
     offset = page * page_size
 

--- a/lib/sequin_web/live/sink_consumers/index.ex
+++ b/lib/sequin_web/live/sink_consumers/index.ex
@@ -2,8 +2,8 @@ defmodule SequinWeb.SinkConsumersLive.Index do
   @moduledoc false
   use SequinWeb, :live_view
 
+  alias Phoenix.LiveView.AsyncResult
   alias Sequin.Consumers
-  alias Sequin.Consumers.SinkConsumer
   alias Sequin.Databases
   alias Sequin.Health
   alias Sequin.Metrics
@@ -11,7 +11,7 @@ defmodule SequinWeb.SinkConsumersLive.Index do
 
   @smoothing_window 5
   @timeseries_window_count 60
-  @page_size 50
+  @page_size 1
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -27,7 +27,7 @@ defmodule SequinWeb.SinkConsumersLive.Index do
       |> assign(:page, page)
       |> assign(:page_size, page_size)
       |> assign(:total_count, total_count)
-      |> assign(:consumers, load_consumers(socket, page, page_size))
+      |> assign_consumers()
 
     has_databases? = account.id |> Databases.list_dbs_for_account() |> Enum.any?()
 
@@ -64,10 +64,23 @@ defmodule SequinWeb.SinkConsumersLive.Index do
 
   @impl Phoenix.LiveView
   def render(assigns) do
-    consumers = Enum.filter(assigns.consumers, &is_struct(&1, SinkConsumer))
-    encoded_consumers = Enum.map(consumers, &encode_consumer/1)
+    dbg(assigns.consumers)
 
-    assigns = assign(assigns, :encoded_consumers, encoded_consumers)
+    consumers =
+      case assigns.consumers do
+        %AsyncResult{ok?: true, result: consumers} when is_list(consumers) ->
+          consumers
+
+        consumers when is_list(consumers) ->
+          consumers
+
+        %AsyncResult{ok?: false, failed: nil} ->
+          []
+      end
+
+    dbg(consumers)
+
+    assigns = assign(assigns, :encoded_consumers, Enum.map(consumers, &encode_consumer/1))
 
     ~H"""
     <div id="consumers-index">
@@ -96,19 +109,14 @@ defmodule SequinWeb.SinkConsumersLive.Index do
 
   @impl Phoenix.LiveView
   def handle_event("change_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-    total_count =
-      socket
-      |> current_account_id()
-      |> Consumers.count_sink_consumers_for_account()
+    account_id = current_account_id(socket)
+    total_count = Consumers.count_sink_consumers_for_account(account_id)
 
     socket =
       socket
       |> assign(:page, page)
       |> assign(:total_count, total_count)
-      |> assign_async(:consumers, fn ->
-        {:ok, %{consumers: load_consumers(socket, page, socket.assigns.page_size)}}
-      end)
+      |> assign_consumers()
 
     {:noreply, socket}
   end
@@ -122,18 +130,33 @@ defmodule SequinWeb.SinkConsumersLive.Index do
   @impl Phoenix.LiveView
   def handle_info(:update_consumers, socket) do
     Process.send_after(self(), :update_consumers, 1000)
-    page = socket.assigns.page
-    page_size = socket.assigns.page_size
-    {:noreply,
-     assign_async(socket, :consumers, fn ->
-       {:ok, %{consumers: load_consumers(socket, page, page_size)}}
-     end)}
+    {:noreply, assign_consumers(socket)}
   end
 
-  defp load_consumers(socket, page, page_size) do
-    socket
-    |> current_account_id()
-    |> Consumers.list_sink_consumers_for_account_paginated(page, page_size, [:postgres_database, :replication_slot, :active_backfill])
+  defp assign_consumers(socket) do
+    page = socket.assigns.page
+    page_size = socket.assigns.page_size
+    account_id = current_account_id(socket)
+
+    assign_async(
+      socket,
+      :consumers,
+      fn ->
+        {:ok, %{consumers: load_consumers(account_id, page, page_size)}}
+      end
+    )
+  end
+
+  defp load_consumers(account_id, page, page_size) do
+    account_id
+    |> Consumers.list_sink_consumers_for_account_paginated(page, page_size,
+      preload: [
+        :postgres_database,
+        :replication_slot,
+        :active_backfill
+      ],
+      order_by: [desc: :updated_at]
+    )
     |> load_consumer_health()
     |> load_consumer_metrics()
   end

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -2229,7 +2229,12 @@ defmodule Sequin.ConsumersTest do
       assert_lists_equal(Enum.map(page_desc, & &1.name), ["consumer-10", "consumer-09", "consumer-08"])
 
       # Test with preloads
-      page_with_preloads = Consumers.list_sink_consumers_for_account_paginated(account.id, 0, 3, preload: [:postgres_database], order_by: [asc: :name])
+      page_with_preloads =
+        Consumers.list_sink_consumers_for_account_paginated(account.id, 0, 3,
+          preload: [:postgres_database],
+          order_by: [asc: :name]
+        )
+
       assert length(page_with_preloads) == 3
       # Verify preloads worked - would raise error if not preloaded
       for consumer <- page_with_preloads do


### PR DESCRIPTION
## Summary
- add paginated query helper for sink consumers
- update sinks index LiveView to fetch pages synchronously on mount and asynchronously on page change
- expose pagination props and controls in `SinkIndex.svelte`

## Testing
- `mix test` *(fails: Hex not installed)*
- `npm test` in `assets` *(fails: missing script)*