### PR TITLE
Add Kinesis sink

### DIFF
--- a/lib/sequin/aws/kinesis.ex
+++ b/lib/sequin/aws/kinesis.ex
@@ -1,0 +1,42 @@
+defmodule Sequin.Aws.Kinesis do
+  @moduledoc false
+
+  alias AWS.Client
+  alias Sequin.Error
+
+  @spec put_records(Client.t(), String.t(), list(map())) :: :ok | {:error, any()}
+  def put_records(%Client{} = client, stream_name, records) when is_list(records) do
+    request_body = %{
+      "StreamName" => stream_name,
+      "Records" => records
+    }
+
+    case AWS.Kinesis.put_records(client, request_body) do
+      {:ok, %{"FailedRecordCount" => 0}, _} ->
+        :ok
+
+      {:ok, resp, %{body: body}} ->
+        {:error, resp, %{body: body}}
+
+      {:error, {:unexpected_response, details}} ->
+        handle_unexpected_response(details)
+
+      {:error, error} ->
+        {:error, Error.service(service: :aws_kinesis, message: "Failed to put records", details: error)}
+    end
+  end
+
+  defp handle_unexpected_response(%{body: body, status_code: status_code}) do
+    message =
+      case Jason.decode(body) do
+        {:ok, %{"message" => message}} ->
+          message
+
+        _ ->
+          if is_binary(body), do: body, else: inspect(body)
+      end
+
+    {:error,
+     Error.service(service: :aws_kinesis, message: "Error from AWS: #{message} (status=#{status_code})", details: message)}
+  end
+end

--- a/lib/sequin/consumers/kinesis_sink.ex
+++ b/lib/sequin/consumers/kinesis_sink.ex
@@ -1,0 +1,33 @@
+defmodule Sequin.Consumers.KinesisSink do
+  @moduledoc false
+  use Ecto.Schema
+  use TypedEctoSchema
+
+  import Ecto.Changeset
+
+  alias Sequin.Aws.HttpClient
+  alias Sequin.Encrypted
+
+  @derive {Jason.Encoder, only: [:stream_name, :region]}
+  @derive {Inspect, except: [:secret_access_key]}
+  @primary_key false
+  typed_embedded_schema do
+    field :type, Ecto.Enum, values: [:kinesis], default: :kinesis
+    field :stream_name, :string
+    field :region, :string
+    field :access_key_id, :string
+    field :secret_access_key, Encrypted.Field
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:stream_name, :region, :access_key_id, :secret_access_key])
+    |> validate_required([:stream_name, :region, :access_key_id, :secret_access_key])
+  end
+
+  def aws_client(%__MODULE__{} = sink) do
+    sink.access_key_id
+    |> AWS.Client.create(sink.secret_access_key, sink.region)
+    |> HttpClient.put_client()
+  end
+end

--- a/lib/sequin/consumers/sink_consumer.ex
+++ b/lib/sequin/consumers/sink_consumer.ex
@@ -19,6 +19,7 @@ defmodule Sequin.Consumers.SinkConsumer do
   alias Sequin.Consumers.RabbitMqSink
   alias Sequin.Consumers.RedisStreamSink
   alias Sequin.Consumers.RedisStringSink
+  alias Sequin.Consumers.KinesisSink
   alias Sequin.Consumers.SequenceFilter
   alias Sequin.Consumers.SequinStreamSink
   alias Sequin.Consumers.SnsSink
@@ -78,6 +79,7 @@ defmodule Sequin.Consumers.SinkConsumer do
       values: [
         :http_push,
         :sqs,
+        :kinesis,
         :redis_stream,
         :redis_string,
         :kafka,
@@ -111,6 +113,7 @@ defmodule Sequin.Consumers.SinkConsumer do
       types: [
         http_push: HttpPushSink,
         sqs: SqsSink,
+        kinesis: Sequin.Consumers.KinesisSink,
         sns: SnsSink,
         redis_stream: RedisStreamSink,
         redis_string: RedisStringSink,

--- a/lib/sequin/runtime/kinesis_pipeline.ex
+++ b/lib/sequin/runtime/kinesis_pipeline.ex
@@ -1,0 +1,63 @@
+defmodule Sequin.Runtime.KinesisPipeline do
+  @moduledoc false
+  @behaviour Sequin.Runtime.SinkPipeline
+
+  alias Sequin.Aws.Kinesis
+  alias Sequin.Consumers.SinkConsumer
+  alias Sequin.Consumers.KinesisSink
+  alias Sequin.Runtime.SinkPipeline
+
+  @impl SinkPipeline
+  def init(context, _opts) do
+    %{consumer: consumer} = context
+    Map.put(context, :kinesis_client, KinesisSink.aws_client(consumer.sink))
+  end
+
+  @impl SinkPipeline
+  def batchers_config(_consumer) do
+    concurrency = min(System.schedulers_online() * 2, 80)
+
+    [
+      default: [
+        concurrency: concurrency,
+        batch_size: 10,
+        batch_timeout: 50
+      ]
+    ]
+  end
+
+  @impl SinkPipeline
+  def handle_batch(:default, messages, _batch_info, context) do
+    %{consumer: %SinkConsumer{sink: sink} = consumer, kinesis_client: kinesis_client, test_pid: test_pid} = context
+
+    setup_allowances(test_pid)
+
+    records =
+      Enum.map(messages, fn %{data: data} ->
+        partition_key =
+          consumer
+          |> Sequin.Consumers.group_column_values(data)
+          |> Enum.join(",")
+          |> case do
+            "" -> UUID.uuid4()
+            key -> key
+          end
+
+        %{
+          "Data" => Jason.encode!(Sequin.Transforms.Message.to_external(consumer, data)),
+          "PartitionKey" => partition_key
+        }
+      end)
+
+    case Kinesis.put_records(kinesis_client, sink.stream_name, records) do
+      :ok -> {:ok, messages, context}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp setup_allowances(nil), do: :ok
+  defp setup_allowances(test_pid) do
+    Req.Test.allow(Sequin.Aws.HttpClient, test_pid, self())
+    Mox.allow(Sequin.TestSupport.DateTimeMock, test_pid, self())
+  end
+end

--- a/lib/sequin/runtime/sink_pipeline.ex
+++ b/lib/sequin/runtime/sink_pipeline.ex
@@ -319,6 +319,7 @@ defmodule Sequin.Runtime.SinkPipeline do
       :gcp_pubsub -> Sequin.Runtime.GcpPubsubPipeline
       :http_push -> Sequin.Runtime.HttpPushPipeline
       :kafka -> Sequin.Runtime.KafkaPipeline
+      :kinesis -> Sequin.Runtime.KinesisPipeline
       :nats -> Sequin.Runtime.NatsPipeline
       :rabbitmq -> Sequin.Runtime.RabbitMqPipeline
       :redis_stream -> Sequin.Runtime.RedisStreamPipeline

--- a/lib/sequin/transforms/transforms.ex
+++ b/lib/sequin/transforms/transforms.ex
@@ -16,6 +16,7 @@ defmodule Sequin.Transforms do
   alias Sequin.Consumers.RabbitMqSink
   alias Sequin.Consumers.RedisStreamSink
   alias Sequin.Consumers.RedisStringSink
+  alias Sequin.Consumers.KinesisSink
   alias Sequin.Consumers.RoutingTransform
   alias Sequin.Consumers.SequenceFilter.ColumnFilter
   alias Sequin.Consumers.SequinStreamSink
@@ -239,6 +240,16 @@ defmodule Sequin.Transforms do
       access_key_id: maybe_obfuscate(sink.access_key_id, show_sensitive),
       secret_access_key: maybe_obfuscate(sink.secret_access_key, show_sensitive),
       is_fifo: sink.is_fifo
+    })
+  end
+
+  def to_external(%KinesisSink{} = sink, show_sensitive) do
+    Sequin.Map.reject_nil_values(%{
+      type: "kinesis",
+      stream_name: sink.stream_name,
+      region: sink.region,
+      access_key_id: maybe_obfuscate(sink.access_key_id, show_sensitive),
+      secret_access_key: maybe_obfuscate(sink.secret_access_key, show_sensitive)
     })
   end
 
@@ -810,6 +821,17 @@ defmodule Sequin.Transforms do
      %{
        type: :sns,
        topic_arn: attrs["topic_arn"],
+       region: attrs["region"],
+       access_key_id: attrs["access_key_id"],
+       secret_access_key: attrs["secret_access_key"]
+     }}
+  end
+
+  defp parse_sink(%{"type" => "kinesis"} = attrs, _resources) do
+    {:ok,
+     %{
+       type: :kinesis,
+       stream_name: attrs["stream_name"],
        region: attrs["region"],
        access_key_id: attrs["access_key_id"],
        secret_access_key: attrs["secret_access_key"]

--- a/test/sequin/aws_kinesis_test.exs
+++ b/test/sequin/aws_kinesis_test.exs
@@ -1,0 +1,43 @@
+defmodule Sequin.Aws.KinesisTest do
+  use Sequin.Case, async: true
+
+  alias Sequin.Aws.HttpClient
+  alias Sequin.Aws.Kinesis
+  alias Sequin.Factory.SinkFactory
+
+  @stream "test-stream"
+
+  setup do
+    client =
+      "test"
+      |> AWS.Client.create("test", "us-east-1")
+      |> HttpClient.put_client()
+
+    {:ok, client: client}
+  end
+
+  describe "put_records/3" do
+    test "successfully sends batch of records", %{client: client} do
+      records = [SinkFactory.kinesis_record(), SinkFactory.kinesis_record()]
+
+      Req.Test.stub(Sequin.Aws.HttpClient, fn conn ->
+        assert conn.host == "kinesis.us-east-1.amazonaws.com"
+        assert conn.method == "POST"
+
+        Req.Test.json(conn, %{"FailedRecordCount" => 0, "Records" => []})
+      end)
+
+      assert :ok = Kinesis.put_records(client, @stream, records)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      records = [SinkFactory.kinesis_record()]
+
+      Req.Test.stub(Sequin.Aws.HttpClient, fn conn ->
+        Req.Test.json(conn, %{"FailedRecordCount" => 1, "Records" => []})
+      end)
+
+      assert {:error, _} = Kinesis.put_records(client, @stream, records)
+    end
+  end
+end

--- a/test/sequin/kinesis_pipeline_test.exs
+++ b/test/sequin/kinesis_pipeline_test.exs
@@ -1,0 +1,95 @@
+defmodule Sequin.Runtime.KinesisPipelineTest do
+  use Sequin.DataCase, async: true
+
+  alias Sequin.Aws.HttpClient
+  alias Sequin.Consumers
+  alias Sequin.Consumers.ConsumerRecord
+  alias Sequin.Databases.ConnectionCache
+  alias Sequin.Factory.AccountsFactory
+  alias Sequin.Factory.CharacterFactory
+  alias Sequin.Factory.ConsumersFactory
+  alias Sequin.Factory.DatabasesFactory
+  alias Sequin.Factory.ReplicationFactory
+  alias Sequin.Runtime.SinkPipeline
+  alias Sequin.Runtime.SlotMessageStore
+  alias Sequin.Runtime.SlotMessageStoreSupervisor
+  alias Sequin.TestSupport.Models.Character
+
+  describe "events are sent to Kinesis" do
+    setup do
+      account = AccountsFactory.insert_account!()
+
+      postgres_database =
+        DatabasesFactory.insert_configured_postgres_database!(account_id: account.id, tables: :character_tables)
+
+      ConnectionCache.cache_connection(postgres_database, Sequin.Repo)
+
+      replication =
+        ReplicationFactory.insert_postgres_replication!(
+          account_id: account.id,
+          postgres_database_id: postgres_database.id
+        )
+
+      sequence =
+        DatabasesFactory.insert_sequence!(
+          postgres_database_id: postgres_database.id,
+          account_id: account.id,
+          table_oid: Character.table_oid()
+        )
+
+      consumer =
+        ConsumersFactory.insert_sink_consumer!(
+          account_id: account.id,
+          type: :kinesis,
+          message_kind: :record,
+          batch_size: 10,
+          sequence_filter: ConsumersFactory.sequence_filter_attrs(group_column_attnums: [1]),
+          sequence_id: sequence.id,
+          replication_slot_id: replication.id
+        )
+
+      {:ok, %{consumer: consumer}}
+    end
+
+    test "events are sent to Kinesis", %{consumer: consumer} do
+      test_pid = self()
+
+      record = CharacterFactory.character_attrs()
+
+      event =
+        [consumer_id: consumer.id, source_record: :character]
+        |> ConsumersFactory.insert_deliverable_consumer_record!()
+        |> Map.put(:data, ConsumersFactory.consumer_record_data(record: record))
+
+      Req.Test.stub(HttpClient, fn conn ->
+        send(test_pid, {:kinesis_request, conn})
+        Req.Test.json(conn, %{"FailedRecordCount" => 0, "Records" => []})
+      end)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_event(consumer, event)
+      assert_receive {:ack, ^ref, [%{data: %ConsumerRecord{}}], []}, 1_000
+      assert_receive {:kinesis_request, _}, 1_000
+    end
+  end
+
+  defp start_pipeline!(consumer) do
+    start_supervised!(
+      {SinkPipeline,
+       [
+         consumer: consumer,
+         producer: Broadway.DummyProducer,
+         test_pid: self()
+       ]}
+    )
+  end
+
+  defp send_test_event(consumer, event) do
+    Broadway.test_message(broadway(consumer), event, metadata: %{topic: "test", headers: []})
+  end
+
+  defp broadway(consumer) do
+    SinkPipeline.via_tuple(consumer.id)
+  end
+end

--- a/test/support/factory/consumers_factory.ex
+++ b/test/support/factory/consumers_factory.ex
@@ -17,6 +17,7 @@ defmodule Sequin.Factory.ConsumersFactory do
   alias Sequin.Consumers.RabbitMqSink
   alias Sequin.Consumers.RedisStreamSink
   alias Sequin.Consumers.RedisStringSink
+  alias Sequin.Consumers.KinesisSink
   alias Sequin.Consumers.SequenceFilter
   alias Sequin.Consumers.SequenceFilter.ColumnFilter
   alias Sequin.Consumers.SequinStreamSink
@@ -55,6 +56,7 @@ defmodule Sequin.Factory.ConsumersFactory do
           :redis_stream,
           :redis_string,
           :sqs,
+          :kinesis,
           :sns,
           :kafka,
           :sequin_stream,
@@ -202,6 +204,19 @@ defmodule Sequin.Factory.ConsumersFactory do
         access_key_id: Factory.word(),
         secret_access_key: Factory.word(),
         is_fifo: Enum.random([true, false])
+      },
+      attrs
+    )
+  end
+
+  defp sink(:kinesis, _account_id, attrs) do
+    merge_attributes(
+      %KinesisSink{
+        type: :kinesis,
+        stream_name: Factory.word(),
+        region: Enum.random(["us-east-1", "us-west-1", "us-west-2"]),
+        access_key_id: Factory.word(),
+        secret_access_key: Factory.word()
       },
       attrs
     )

--- a/test/support/factory/destination_factory.ex
+++ b/test/support/factory/destination_factory.ex
@@ -41,4 +41,19 @@ defmodule Sequin.Factory.SinkFactory do
       attrs
     )
   end
+
+  def kinesis_record(attrs \\ []) do
+    attrs = Map.new(attrs)
+
+    merge_attributes(
+      %{
+        data: %{
+          "event" => Factory.word(),
+          "payload" => %{Factory.word() => Factory.word()}
+        },
+        partition_key: Factory.unique_word()
+      },
+      attrs
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- add Kinesis sink schema and AWS helper
- add Kinesis pipeline implementation
- wire Kinesis into consumer and runtime
- support Kinesis in factories and YAML loader
- add basic tests for AWS client and pipeline

## Testing
- ❌ `mix format --check-formatted` *(fails: Could not fetch Hex)*