### PR TITLE
Fix outdated tables in playground config

### DIFF
--- a/docker/playground.yml
+++ b/docker/playground.yml
@@ -15,6 +15,3 @@ databases:
     port: 5432
     slot_name: "sequin_slot"
     publication_name: "sequin_pub"
-    tables:
-      - table_name: "products"
-        sort_column_name: "updated_at"

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -43,6 +43,10 @@ Sequin works great for CDC use cases like:
 
 Sequin is a Docker image you can run next to your Postgres database. Sequin itself is built on Postgres and uses Postgres to store sink state.
 
+<Note>
+  The Postgres instance Sequin uses for its own state is distinct from the databases you stream from. You configure Sequin's database connection with the `PG_*` environment variables and configure your source databases in [`sequin.yaml`](/reference/sequin-yaml#database-configuration).
+</Note>
+
 ## Demo
 
 See Sequin in action. In this demo, we'll stream changes to Kafka, deploy to production, and scale to 2,000 messages / second.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -49,6 +49,10 @@ You can provide a YAML configuration file to Sequin. This configuration file wil
 - `PG_SSL`: Enable SSL for Postgres connection (default: false)
 - `PG_POOL_SIZE`: Database connection pool size (default: 10)
 
+<Note>
+  These variables configure the Postgres database that Sequin itself uses to store state. They are not for the databases you stream from—those are defined in [`sequin.yaml`](/reference/sequin-yaml#database-configuration).
+</Note>
+
 #### `PG_POOL_SIZE`
 
 The `PG_POOL_SIZE` variable controls the maximum number of concurrent connections that Sequin will maintain to Postgres. For higher throughput on larger Postgres instances, you should increase this value.

--- a/docs/reference/sequin-yaml.mdx
+++ b/docs/reference/sequin-yaml.mdx
@@ -51,6 +51,10 @@ api_tokens:
 
 ### Database configuration
 
+<Note>
+  These database entries tell Sequin which Postgres instances to capture changes from. They are separate from the Postgres database that Sequin itself uses, which is configured via the `PG_*` environment variables.
+</Note>
+
 ```yaml
 databases:
   - name: "my-database"          # Required, unique identifier

--- a/docs/running-sequin.mdx
+++ b/docs/running-sequin.mdx
@@ -135,6 +135,10 @@ The easiest way to get started with Sequin is with our [Docker Compose file](htt
 
 Sequin uses a Postgres database for configuration and to assist with its change data capture process.
 
+<Note>
+  These `PG_*` variables configure Sequin's internal Postgres database. The Postgres databases you want to stream from are configured separately in [`sequin.yaml`](/reference/sequin-yaml#database-configuration).
+</Note>
+
 We recommend creating a new logical database for Sequin in your existing Postgres instance:
 
 ```sql


### PR DESCRIPTION
## Summary
- drop `tables` from `playground.yml`
- clarify difference between PG_* env vars and YAML DB config in docs

## Testing
- `mix format --check-formatted` *(fails: missing Hex and network access)*
- `MIX_ENV=prod mix compile --warnings-as-errors` *(fails: missing Hex and network access)*
- `go test ./cli` *(fails: cannot download toolchain)*
- `gofmt -s -l .`
- `go vet ./...` *(fails: cannot download toolchain)*
- `go build -o /dev/null ./...` *(fails: cannot download toolchain)*
- `make spellcheck` *(fails: npm registry unreachable)*
- `make check-links` *(fails: npm registry unreachable)*
- `npm run format:check`
- `npm run tsc`
