### PR TITLE
🐛 Serialize events/record through changesets

### DIFF
--- a/lib/sequin/consumers/consumer_event.ex
+++ b/lib/sequin/consumers/consumer_event.ex
@@ -40,7 +40,7 @@ defmodule Sequin.Consumers.ConsumerEvent do
     field :not_visible_until, :utc_datetime_usec
     field :replication_message_trace_id, Ecto.UUID
 
-    embeds_one :data, ConsumerEventData
+    embeds_one :data, ConsumerEventData, on_replace: :update
 
     # For SlotMessageStore
     field :ingested_at, :utc_datetime_usec, virtual: true
@@ -105,6 +105,14 @@ defmodule Sequin.Consumers.ConsumerEvent do
 
   def stringify_record_pks(pks) when is_list(pks) do
     Enum.map(pks, &to_string/1)
+  end
+
+  def map_from_struct(%ConsumerEvent{} = consumer_event) do
+    consumer_event
+    |> Sequin.Map.from_ecto()
+    |> update_in([:data], &Sequin.Map.from_ecto/1)
+    |> update_in([:data, :metadata], &Sequin.Map.from_ecto/1)
+    |> update_in([:data, :metadata, :consumer], &Sequin.Map.from_ecto/1)
   end
 
   def where_consumer_id(query \\ base_query(), consumer_id) do

--- a/lib/sequin/consumers/consumer_event_data.ex
+++ b/lib/sequin/consumers/consumer_event_data.ex
@@ -23,7 +23,7 @@ defmodule Sequin.Consumers.ConsumerEventData do
     field :changes_deserializers, :map
     field :action, Ecto.Enum, values: [:insert, :update, :delete, :read]
 
-    embeds_one :metadata, Metadata, primary_key: false do
+    embeds_one :metadata, Metadata, primary_key: false, on_replace: :update do
       @derive Jason.Encoder
 
       field :table_schema, :string
@@ -34,7 +34,7 @@ defmodule Sequin.Consumers.ConsumerEventData do
       field :transaction_annotations, :map
       field :idempotency_key, :string
 
-      embeds_one :consumer, Sink, primary_key: false do
+      embeds_one :consumer, Sink, primary_key: false, on_replace: :update do
         @derive Jason.Encoder
 
         field :id, :string
@@ -56,6 +56,13 @@ defmodule Sequin.Consumers.ConsumerEventData do
     metadata
     |> cast(attrs, [:table_schema, :table_name, :commit_timestamp, :commit_lsn, :database_name, :transaction_annotations])
     |> validate_required([:table_schema, :table_name, :commit_timestamp, :commit_lsn])
+    |> cast_embed(:consumer, required: true, with: &consumer_changeset/2)
+  end
+
+  def consumer_changeset(consumer, attrs) do
+    consumer
+    |> cast(attrs, [:id, :name])
+    |> validate_required([:id, :name])
   end
 
   def deserialize(%ConsumerEventData{} = data) do

--- a/lib/sequin/consumers/consumer_record.ex
+++ b/lib/sequin/consumers/consumer_record.ex
@@ -39,7 +39,7 @@ defmodule Sequin.Consumers.ConsumerRecord do
     field :not_visible_until, :utc_datetime_usec
     field :replication_message_trace_id, Ecto.UUID
 
-    embeds_one :data, ConsumerRecordData
+    embeds_one :data, ConsumerRecordData, on_replace: :update
 
     # For SlotMessageStore
     field :ingested_at, :utc_datetime_usec, virtual: true
@@ -123,6 +123,14 @@ defmodule Sequin.Consumers.ConsumerRecord do
       end)
 
     struct!(__MODULE__, attrs)
+  end
+
+  def map_from_struct(%ConsumerRecord{} = consumer_record) do
+    consumer_record
+    |> Sequin.Map.from_ecto()
+    |> update_in([:data], &Sequin.Map.from_ecto/1)
+    |> update_in([:data, :metadata], &Sequin.Map.from_ecto/1)
+    |> update_in([:data, :metadata, :consumer], &Sequin.Map.from_ecto/1)
   end
 
   def where_consumer_id(query \\ base_query(), consumer_id) do

--- a/lib/sequin/consumers/consumer_record_data.ex
+++ b/lib/sequin/consumers/consumer_record_data.ex
@@ -18,7 +18,7 @@ defmodule Sequin.Consumers.ConsumerRecordData do
     field :record_deserializers, :map
     field :action, Ecto.Enum, values: [:insert, :update, :delete, :read]
 
-    embeds_one :metadata, Metadata, primary_key: false do
+    embeds_one :metadata, Metadata, primary_key: false, on_replace: :update do
       @derive Jason.Encoder
 
       field :table_schema, :string
@@ -28,7 +28,7 @@ defmodule Sequin.Consumers.ConsumerRecordData do
       field :database_name, :string
       field :idempotency_key, :string
 
-      embeds_one :consumer, Sink, primary_key: false do
+      embeds_one :consumer, Sink, primary_key: false, on_replace: :update do
         @derive Jason.Encoder
 
         field :id, :string
@@ -49,6 +49,13 @@ defmodule Sequin.Consumers.ConsumerRecordData do
     metadata
     |> cast(attrs, [:table_schema, :table_name, :commit_timestamp, :commit_lsn, :database_name])
     |> validate_required([:table_schema, :table_name, :commit_timestamp, :commit_lsn])
+    |> cast_embed(:consumer, required: true, with: &consumer_changeset/2)
+  end
+
+  def consumer_changeset(consumer, attrs) do
+    consumer
+    |> cast(attrs, [:id, :name])
+    |> validate_required([:id, :name])
   end
 
   def deserialize(%ConsumerRecordData{} = data) do

--- a/test/sequin/consumers_test.exs
+++ b/test/sequin/consumers_test.exs
@@ -2300,8 +2300,19 @@ defmodule Sequin.ConsumersTest do
       assert inserted_msg.ack_id == msg.ack_id
     end
 
-    test "updates existing message" do
+    test "inserts a new message with record_serializers" do
       consumer = ConsumersFactory.insert_sink_consumer!()
+      msg = ConsumersFactory.consumer_message(message_kind: consumer.message_kind, consumer_id: consumer.id)
+      msg = put_in(msg.data.record["date_field"], Date.utc_today())
+
+      assert {:ok, 1} = Consumers.upsert_consumer_messages(consumer, [msg])
+
+      assert [inserted_msg] = Consumers.list_consumer_messages_for_consumer(consumer)
+      assert %Date{} = inserted_msg.data.record["date_field"]
+    end
+
+    test "updates existing message" do
+      consumer = ConsumersFactory.insert_sink_consumer!(message_kind: :event)
 
       existing_msg =
         ConsumersFactory.insert_consumer_message!(message_kind: consumer.message_kind, consumer_id: consumer.id)

--- a/test/sequin/slot_message_store_test.exs
+++ b/test/sequin/slot_message_store_test.exs
@@ -79,7 +79,7 @@ defmodule Sequin.SlotMessageStoreTest do
       consumer = ConsumersFactory.insert_sink_consumer!(partition_count: 1)
 
       data = ConsumersFactory.consumer_message_data(message_kind: consumer.message_kind)
-      data_size_bytes = :erlang.external_size(put_in(data.metadata.consumer, nil))
+      data_size_bytes = :erlang.external_size(data)
 
       for _ <- 1..20 do
         ConsumersFactory.insert_consumer_message!(
@@ -119,7 +119,7 @@ defmodule Sequin.SlotMessageStoreTest do
       consumer = ConsumersFactory.insert_sink_consumer!(partition_count: 3)
 
       data = ConsumersFactory.consumer_message_data(message_kind: consumer.message_kind)
-      data_size_bytes = :erlang.external_size(put_in(data.metadata.consumer, nil))
+      data_size_bytes = :erlang.external_size(data)
 
       for _ <- 1..20 do
         ConsumersFactory.insert_consumer_message!(
@@ -906,7 +906,7 @@ defmodule Sequin.SlotMessageStoreTest do
       consumer = ConsumersFactory.insert_sink_consumer!(partition_count: 1, max_memory_mb: 128, max_storage_mb: 1024)
 
       data = ConsumersFactory.consumer_message_data(message_kind: consumer.message_kind)
-      data_size_bytes = :erlang.external_size(put_in(data.metadata.consumer, nil))
+      data_size_bytes = :erlang.external_size(data)
 
       for _ <- 1..20 do
         ConsumersFactory.insert_consumer_message!(
@@ -960,7 +960,7 @@ defmodule Sequin.SlotMessageStoreTest do
       consumer = ConsumersFactory.insert_sink_consumer!(partition_count: 1, max_memory_mb: 128, max_storage_mb: 1024)
 
       data = ConsumersFactory.consumer_message_data(message_kind: consumer.message_kind)
-      data_size_bytes = :erlang.external_size(put_in(data.metadata.consumer, nil))
+      data_size_bytes = :erlang.external_size(data)
 
       for _ <- 1..30 do
         ConsumersFactory.insert_consumer_message!(
@@ -1008,7 +1008,7 @@ defmodule Sequin.SlotMessageStoreTest do
     consumer = ConsumersFactory.insert_sink_consumer!(partition_count: 2, max_memory_mb: 128, max_storage_mb: 1024)
 
     data = ConsumersFactory.consumer_message_data(message_kind: consumer.message_kind)
-    data_size_bytes = :erlang.external_size(put_in(data.metadata.consumer, nil))
+    data_size_bytes = :erlang.external_size(data)
 
     for _ <- 1..30 do
       ConsumersFactory.insert_consumer_message!(


### PR DESCRIPTION
* This fixes a bug where record_ and change_serializers were not set
  on consumer events/records inserted into the database

  The effect of this PR is that all consumer events/records are passed
  through changesets before insertion to the database