### PR TITLE
🐛 Fix constraints on SECRET_KEY_BASE and VAULT_KEY

### DIFF
--- a/lib/sequin/config_parser.ex
+++ b/lib/sequin/config_parser.ex
@@ -38,36 +38,41 @@ defmodule Sequin.ConfigParser do
 
   def secret_key_base(env) do
     secret = Map.get(env, "SECRET_KEY_BASE")
-    validate_secret!(secret, "SECRET_KEY_BASE", 64)
+    validate_required(secret, "SECRET_KEY_BASE")
+    validate_length_gte(secret, "SECRET_KEY_BASE", 48)
     secret
   end
 
   def vault_key(env) do
     secret = Map.get(env, "VAULT_KEY")
-    validate_secret!(secret, "VAULT_KEY", 32)
+    validate_required(secret, "VAULT_KEY")
+    validate_length_gte(secret, "VAULT_KEY", 32)
+    validate_base64(secret, "VAULT_KEY")
     secret
   end
 
-  defp validate_secret!(nil, secret_name, _expected_length) do
-    raise ArgumentError, """
-    Environment variable #{secret_name} is not set.
-
-    See: #{@secret_generation_docs_link}
-    """
+  defp validate_required(env_var, env_name) do
+    if is_nil(env_var) do
+      raise ArgumentError, """
+      Environment variable #{env_name} is not set.
+      """
+    end
   end
 
-  defp validate_secret!(secret, secret_name, expected_length) do
+  defp validate_length_gte(env_var, env_name, expected_length) when is_binary(env_var) do
+    if byte_size(env_var) < expected_length do
+      raise ArgumentError, """
+      Environment variable #{env_name} is too short.
+
+      Expected at least #{expected_length} bytes. Got #{byte_size(env_var)} bytes.
+      """
+    end
+  end
+
+  defp validate_base64(secret, secret_name) do
     case Base.decode64(secret) do
-      {:ok, decoded} ->
-        unless byte_size(decoded) == expected_length do
-          raise ArgumentError, """
-          Secret #{secret_name} is of the wrong length.
-
-          Expected a #{expected_length} byte string that is then base64 encoded. Got #{byte_size(decoded)} bytes after decoding.
-
-          See: #{@secret_generation_docs_link}
-          """
-        end
+      {:ok, _} ->
+        :ok
 
       :error ->
         raise ArgumentError, """

--- a/test/sequin/config_parser_test.exs
+++ b/test/sequin/config_parser_test.exs
@@ -102,25 +102,13 @@ defmodule Sequin.ConfigParserTest do
       end
     end
 
-    test "raises error when SECRET_KEY_BASE is not valid base64" do
-      env = %{"SECRET_KEY_BASE" => "not_valid_base64!@#"}
-
-      assert_raise ArgumentError, ~r/SECRET_KEY_BASE is not valid base64/, fn ->
-        ConfigParser.secret_key_base(env)
-      end
-    end
-
     test "raises error when SECRET_KEY_BASE has incorrect length" do
-      # Generate a base64 encoded string that's not 64 bytes when decoded
       too_short = 32 |> :crypto.strong_rand_bytes() |> Base.encode64()
-      too_long = 80 |> :crypto.strong_rand_bytes() |> Base.encode64()
 
-      for invalid_secret <- [too_short, too_long] do
-        env = %{"SECRET_KEY_BASE" => invalid_secret}
+      env = %{"SECRET_KEY_BASE" => too_short}
 
-        assert_raise ArgumentError, ~r/Secret SECRET_KEY_BASE is of the wrong length/, fn ->
-          ConfigParser.secret_key_base(env)
-        end
+      assert_raise ArgumentError, ~r/Environment variable SECRET_KEY_BASE is too short/, fn ->
+        ConfigParser.secret_key_base(env)
       end
     end
   end
@@ -141,7 +129,7 @@ defmodule Sequin.ConfigParserTest do
     end
 
     test "raises error when VAULT_KEY is not valid base64" do
-      env = %{"VAULT_KEY" => "not_valid_base64!@#"}
+      env = %{"VAULT_KEY" => "not_valid_base64!@# some padding for length"}
 
       assert_raise ArgumentError, ~r/VAULT_KEY is not valid base64/, fn ->
         ConfigParser.vault_key(env)
@@ -151,14 +139,11 @@ defmodule Sequin.ConfigParserTest do
     test "raises error when VAULT_KEY has incorrect length" do
       # Generate a base64 encoded string that's not 32 bytes when decoded
       too_short = 16 |> :crypto.strong_rand_bytes() |> Base.encode64()
-      too_long = 48 |> :crypto.strong_rand_bytes() |> Base.encode64()
 
-      for invalid_key <- [too_short, too_long] do
-        env = %{"VAULT_KEY" => invalid_key}
+      env = %{"VAULT_KEY" => too_short}
 
-        assert_raise ArgumentError, ~r/Secret VAULT_KEY is of the wrong length/, fn ->
-          ConfigParser.vault_key(env)
-        end
+      assert_raise ArgumentError, ~r/Environment variable VAULT_KEY is too short/, fn ->
+        ConfigParser.vault_key(env)
       end
     end
   end


### PR DESCRIPTION
* SECRET_KEY_BASE does not have to be base674 encoded and can be any
  string gte 64 bytes
* VAULT_KEY must be base64 encoded and the decoded string must be gte 32
  bytes