### PR TITLE
🐛 Allow removal of transforms, filters, and routing functions

### DIFF
--- a/lib/sequin/transforms/transforms.ex
+++ b/lib/sequin/transforms/transforms.ex
@@ -680,7 +680,8 @@ defmodule Sequin.Transforms do
   end
 
   def from_external_sink_consumer(account_id, consumer_attrs, databases, http_endpoints) do
-    Enum.reduce_while(consumer_attrs, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+    consumer_attrs
+    |> Enum.reduce_while({:ok, %{}}, fn {key, value}, {:ok, acc} ->
       case key do
         "name" ->
           {:cont, {:ok, Map.put(acc, :name, value)}}
@@ -705,7 +706,7 @@ defmodule Sequin.Transforms do
           databases = Repo.preload(databases, [:sequences, :replication_slot])
 
           with {:ok, database} <- find_database_by_name(consumer_attrs["database"], databases),
-               {:ok, sequence} <- find_sequence_by_name(databases, consumer_attrs["database"], value) do
+               {:ok, sequence} <- find_sequence_by_name(database, value) do
             table = Sequin.Enum.find!(database.tables, &(&1.schema == schema && &1.name == table_name))
 
             {:cont,
@@ -789,6 +790,20 @@ defmodule Sequin.Transforms do
           {:halt, {:error, Error.validation(summary: "Unknown field: #{key}")}}
       end
     end)
+    |> case do
+      {:ok, acc} ->
+        {:ok,
+         acc
+         # These put_news will remove the transform, filter, and routing keys from the sink
+         # if the keys are not present in the consumer_attrs
+         |> Map.put_new(:transform_id, nil)
+         |> Map.put_new(:filter_id, nil)
+         |> Map.put_new(:routing_id, nil)
+         |> Map.put_new(:routing_mode, "static")}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   defp parse_sink(nil, _resources), do: {:error, Error.validation(summary: "`sink` is required on sink consumers.")}
@@ -1055,16 +1070,15 @@ defmodule Sequin.Transforms do
     end
   end
 
-  defp find_sequence_by_name(databases, database_name, table_name) do
+  defp find_sequence_by_name(%PostgresDatabase{} = database, table_name) do
     {schema, table_name} = parse_table_reference(table_name)
 
-    with %PostgresDatabase{tables: tables} = database <- Enum.find(databases, &(&1.name == database_name)),
-         %PostgresDatabaseTable{} = table <- Enum.find(tables, &(&1.schema == schema and &1.name == table_name)),
+    with %PostgresDatabaseTable{} = table <- Enum.find(database.tables, &(&1.schema == schema and &1.name == table_name)),
          {:ok, %Sequence{} = sequence} <- find_or_create_sequence(database, table) do
       {:ok, sequence}
     else
       {:error, error} -> {:error, error}
-      _ -> {:error, Error.not_found(entity: :sequence, params: %{database: database_name, table: table_name})}
+      _ -> {:error, Error.not_found(entity: :sequence, params: %{database: database.name, table: table_name})}
     end
   end
 

--- a/lib/sequin/yaml_loader.ex
+++ b/lib/sequin/yaml_loader.ex
@@ -59,8 +59,8 @@ defmodule Sequin.YamlLoader do
     :ok
   end
 
-  def apply_from_yml!(yml) do
-    case apply_from_yml(yml) do
+  def apply_from_yml!(account_id \\ nil, yml) do
+    case apply_from_yml(account_id, yml) do
       {:ok, _resources} ->
         :ok
 

--- a/test/support/factory/functions_factory.ex
+++ b/test/support/factory/functions_factory.ex
@@ -156,7 +156,7 @@ defmodule Sequin.Factory.FunctionsFactory do
           :redis_string ->
             """
             %{
-              key: record.id || 'default',
+              key: record["id"] || "default",
               value: record
             }
             """


### PR DESCRIPTION
* By removing the keys entirely
  * If users set `transform: none` they can remove ie. transform WITHOUT
    this PR
  * Do we want removing the key to lead to removing the function?