### PR TITLE
Redirect to signup page if user is not authenticated after vistiting access invite link

### DIFF
--- a/lib/sequin_web/user_auth.ex
+++ b/lib/sequin_web/user_auth.ex
@@ -268,15 +268,30 @@ defmodule SequinWeb.UserAuth do
 
   If you want to enforce the user email is confirmed before
   they use the application at all, here would be a good place.
+
+  ## Options
+
+    * `:unauthenticated_redirect` - Specifies where to redirect unauthenticated users.
+      * `:login` - Redirects to the login page (default)
+      * `:register` - Redirects to the registration page
   """
-  def require_authenticated_user(conn, _opts) do
+  def require_authenticated_user(conn, opts) do
     if conn.assigns[:current_user] do
       conn
     else
+      {title, redirect_to} =
+        case Keyword.get(opts, :unauthenticated_redirect, :login) do
+          :login ->
+            {"Please log in to continue.", ~p"/login"}
+
+          :register ->
+            {"Please register to continue.", ~p"/register"}
+        end
+
       conn
-      |> put_flash(:toast, %{kind: :error, title: "Please log in to continue."})
+      |> put_flash(:toast, %{kind: :error, title: title})
       |> maybe_store_return_to()
-      |> redirect(to: ~p"/login")
+      |> redirect(to: redirect_to)
       |> halt()
     end
   end

--- a/test/sequin_web/user_auth_test.exs
+++ b/test/sequin_web/user_auth_test.exs
@@ -237,6 +237,16 @@ defmodule SequinWeb.UserAuthTest do
                "Please log in to continue."
     end
 
+    test "redirects to registration page when :unauthenticated_redirect is :register", %{conn: conn} do
+      conn = conn |> fetch_flash() |> UserAuth.require_authenticated_user(unauthenticated_redirect: :register)
+      assert conn.halted
+
+      assert redirected_to(conn) == ~p"/register"
+
+      assert flash_text(conn, :error) =~
+               "Please register to continue."
+    end
+
     test "stores the path to redirect to on GET", %{conn: conn} do
       halted_conn =
         %{conn | path_info: ["foo"], query_string: ""}


### PR DESCRIPTION
Hello all. Thank you for starting this amazing project in elixir. I started to play around with sequin and decided to start working on some simplest PR first. Apologize if I miss anything.

This PR
- Add :redirect_to option to control where unauthenticated users are sent. Default to login page, with option to redirect to registration
- New pipeline to use this option in order to redirect unauthenticated user to register page

Fixes #1598