### PR TITLE
feat: persist pagination state when navigating to/from sink details

### DIFF
--- a/assets/svelte/consumers/ShowSinkHeader.svelte
+++ b/assets/svelte/consumers/ShowSinkHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { pageStore } from "../stores/pageStore";
   import {
     ArrowLeft,
     Clock,
@@ -133,7 +134,9 @@
   <div class="container mx-auto px-4 py-4">
     <div class="flex items-center justify-between">
       <div class="flex items-center space-x-4">
-        <LinkPushNavigate href="/sinks">
+        <LinkPushNavigate
+          href={$pageStore ? `/sinks?page=${$pageStore}` : "/sinks"}
+        >
           <Button variant="ghost" size="sm">
             <ArrowLeft class="h-4 w-4" />
           </Button>

--- a/assets/svelte/consumers/SinkIndex.svelte
+++ b/assets/svelte/consumers/SinkIndex.svelte
@@ -35,6 +35,7 @@
   import * as d3 from "d3";
   import { onMount } from "svelte";
   import { Skeleton } from "$lib/components/ui/skeleton";
+  import { pageStore } from "../stores/pageStore";
 
   export let consumers: Array<{
     id: string;
@@ -147,6 +148,8 @@
   ];
 
   function handleConsumerClick(id: string, type: string) {
+    // Store current page before navigation
+    pageStore.set(page.toString());
     live.pushEvent("consumer_clicked", { id, type });
   }
 

--- a/assets/svelte/stores/pageStore.ts
+++ b/assets/svelte/stores/pageStore.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const pageStore = writable<string>();

--- a/lib/sequin_web/live/sink_consumers/index.ex
+++ b/lib/sequin_web/live/sink_consumers/index.ex
@@ -13,11 +13,11 @@ defmodule SequinWeb.SinkConsumersLive.Index do
   @page_size 50
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     user = current_user(socket)
     account = current_account(socket)
 
-    page = 0
+    page = (params["page"] && String.to_integer(params["page"])) || 0
     page_size = @page_size
     total_count = Consumers.count_sink_consumers_for_account(account.id)
 
@@ -59,7 +59,8 @@ defmodule SequinWeb.SinkConsumersLive.Index do
 
   @impl Phoenix.LiveView
   def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+    page = (params["page"] && String.to_integer(params["page"])) || 0
+    {:noreply, socket |> apply_action(socket.assigns.live_action, params) |> assign(:page, page)}
   end
 
   @impl Phoenix.LiveView
@@ -100,6 +101,7 @@ defmodule SequinWeb.SinkConsumersLive.Index do
       |> assign(:total_count, total_count)
       |> assign(:encoded_consumers, nil)
       |> async_assign_consumers()
+      |> push_patch(to: ~p"/sinks?page=#{page}")
 
     {:noreply, socket}
   end

--- a/lib/sequin_web/live/sink_consumers/index.ex
+++ b/lib/sequin_web/live/sink_consumers/index.ex
@@ -101,7 +101,7 @@ defmodule SequinWeb.SinkConsumersLive.Index do
       |> assign(:total_count, total_count)
       |> assign(:encoded_consumers, nil)
       |> async_assign_consumers()
-      |> push_patch(to: ~p"/sinks?page=#{page}")
+      |> push_navigate(to: ~p"/sinks?page=#{page}", replace: true)
 
     {:noreply, socket}
   end


### PR DESCRIPTION

- Update sink consumers index LiveView to handle page query parameter in mount and handle_params
- Add pageStore to maintain current page number across navigation between Index and Show sink components
- Update sink Index to store current page before navigating to details
- Modify back button in Show sink to return to correct page

Fixes #1618