### PR TITLE
fix UI issue where a long csv of filters expands and doesn't wrap

### DIFF
--- a/assets/svelte/consumers/ShowSequence.svelte
+++ b/assets/svelte/consumers/ShowSequence.svelte
@@ -90,15 +90,25 @@
             {#each consumer.sequence.column_filters as filter}
               <TableRow>
                 <TableCell
-                  ><code>
+                  class="whitespace-normal break-words max-w-[200px] align-top"
+                >
+                  <code>
                     {filter.column}
                     {#if filter.is_jsonb && filter.jsonb_path}
                       -> {filter.jsonb_path}
-                    {/if}</code
-                  ></TableCell
+                    {/if}
+                  </code>
+                </TableCell>
+                <TableCell
+                  class="whitespace-normal break-words max-w-[150px] align-top"
                 >
-                <TableCell><code>{filter.operator}</code></TableCell>
-                <TableCell><code>{filter.value}</code></TableCell>
+                  <code>{filter.operator}</code>
+                </TableCell>
+                <TableCell
+                  class="whitespace-normal break-words max-w-[300px] align-top"
+                >
+                  <code>{filter.value}</code>
+                </TableCell>
               </TableRow>
             {/each}
           </TableBody>


### PR DESCRIPTION
UI expands and doesn't give a good feel when there's a long list of a column filter in CSV fashion

Before:

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/a1b48005-2c0c-4665-beaa-fa0c0bfc6420" />

After:

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/211a7ba1-574b-496b-aa72-cb5a3ceebfd6" />
