### PR TITLE
feat: make actual links for sink index table so users can cmd/ctrl+click

### DIFF
--- a/assets/svelte/components/LinkPatchNavigate.svelte
+++ b/assets/svelte/components/LinkPatchNavigate.svelte
@@ -3,7 +3,13 @@
   export let href;
 </script>
 
-<a {href} {...$$restProps} data-phx-link="patch" data-phx-link-state="push">
+<a
+  {href}
+  {...$$restProps}
+  on:click={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+  data-phx-link="patch"
+  data-phx-link-state="push"
+>
   {#if $$slots.default}
     <slot />
   {/if}

--- a/assets/svelte/consumers/SinkIndex.svelte
+++ b/assets/svelte/consumers/SinkIndex.svelte
@@ -146,10 +146,6 @@
     },
   ];
 
-  function handleConsumerClick(id: string, type: string) {
-    live.pushEvent("consumer_clicked", { id, type });
-  }
-
   function createMiniChart(element, data, options = {}) {
     const config = {
       width: element.clientWidth,
@@ -358,46 +354,48 @@
           {/each}
         {:else}
           {#each consumers as consumer}
-            <Table.Row
-              on:click={() => handleConsumerClick(consumer.id, consumer.type)}
-              class="cursor-pointer"
-            >
-              <Table.Cell class="w-8">
-                {#each sinks.filter((d) => d.id === consumer.type) as dest}
-                  <svelte:component this={dest.icon} class="h-6 w-6" />
-                {/each}
-              </Table.Cell>
-              <Table.Cell class="w-32">{consumer.name}</Table.Cell>
-              <Table.Cell class="w-24">
-                <div class="flex items-center gap-2">
-                  {#if consumer.status === "paused"}
-                    <Badge variant="warning">
-                      <Pause class="h-4 w-4 mr-1" />
-                      <span>Paused</span>
-                    </Badge>
-                  {:else if consumer.status === "disabled"}
-                    <Badge variant="secondary">
-                      <StopCircle class="h-4 w-4 mr-1" />
-                      <span>Disabled</span>
-                    </Badge>
-                  {:else}
-                    <HealthPill status={consumer.health.status} />
-                  {/if}
-                  {#if consumer.active_backfill}
-                    <Badge variant="secondary">
-                      <ArrowDownSquare class="h-4 w-4 mr-1" />
-                      <span>Backfilling</span>
-                    </Badge>
-                  {/if}
-                </div>
-              </Table.Cell>
-              <Table.Cell class="w-40">{consumer.database_name}</Table.Cell>
-              <Table.Cell class="w-48">
-                <div use:bindChartElement={consumer.id} class="w-48 h-8" />
-              </Table.Cell>
-              <Table.Cell class="w-24"
-                >{formatRelativeTimestamp(consumer.insertedAt)}</Table.Cell
+            <Table.Row class="cursor-pointer">
+              <LinkPatchNavigate
+                href={`/sinks/${consumer.type}/${consumer.id}`}
+                class="contents"
               >
+                <Table.Cell class="w-8">
+                  {#each sinks.filter((d) => d.id === consumer.type) as dest}
+                    <svelte:component this={dest.icon} class="h-6 w-6" />
+                  {/each}
+                </Table.Cell>
+                <Table.Cell class="w-32">{consumer.name}</Table.Cell>
+                <Table.Cell class="w-24">
+                  <div class="flex items-center gap-2">
+                    {#if consumer.status === "paused"}
+                      <Badge variant="warning">
+                        <Pause class="h-4 w-4 mr-1" />
+                        <span>Paused</span>
+                      </Badge>
+                    {:else if consumer.status === "disabled"}
+                      <Badge variant="secondary">
+                        <StopCircle class="h-4 w-4 mr-1" />
+                        <span>Disabled</span>
+                      </Badge>
+                    {:else}
+                      <HealthPill status={consumer.health.status} />
+                    {/if}
+                    {#if consumer.active_backfill}
+                      <Badge variant="secondary">
+                        <ArrowDownSquare class="h-4 w-4 mr-1" />
+                        <span>Backfilling</span>
+                      </Badge>
+                    {/if}
+                  </div>
+                </Table.Cell>
+                <Table.Cell class="w-40">{consumer.database_name}</Table.Cell>
+                <Table.Cell class="w-48">
+                  <div use:bindChartElement={consumer.id} class="w-48 h-8" />
+                </Table.Cell>
+                <Table.Cell class="w-24"
+                  >{formatRelativeTimestamp(consumer.insertedAt)}</Table.Cell
+                >
+              </LinkPatchNavigate>
             </Table.Row>
           {/each}
         {/if}

--- a/lib/sequin_web/live/sink_consumers/index.ex
+++ b/lib/sequin_web/live/sink_consumers/index.ex
@@ -85,11 +85,6 @@ defmodule SequinWeb.SinkConsumersLive.Index do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("consumer_clicked", %{"id" => id, "type" => type}, socket) do
-    {:noreply, push_navigate(socket, to: ~p"/sinks/#{type}/#{id}")}
-  end
-
-  @impl Phoenix.LiveView
   def handle_event("change_page", %{"page" => page}, socket) do
     account_id = current_account_id(socket)
     total_count = Consumers.count_sink_consumers_for_account(account_id)


### PR DESCRIPTION
Make each row of the Sink Index page a link so users can cmd/ctrl+click on them to open in new tabs.

Also fix LinkPatchNavigate component to scroll to top as users might be scrolled all the way to the bottom and clicking on a sink should take them to the top of the page.

Fixes #1670
