### PR TITLE
[docs] fix syntax for schema publication

### DIFF
--- a/docs/archive/ingesting-from-postgres.mdx
+++ b/docs/archive/ingesting-from-postgres.mdx
@@ -114,7 +114,7 @@ SELECT * FROM pg_create_logical_replication_slot('sequin', 'pgoutput');
 -- Create a publication for a select list of tables
 CREATE PUBLICATION sequin FOR TABLE my_table, my_other_table WITH (publish_via_partition_root = true);
 -- Or, create a publication for all tables in a schema
-CREATE PUBLICATION sequin FOR ALL TABLES IN SCHEMA my_schema WITH (publish_via_partition_root = true);
+CREATE PUBLICATION sequin FOR TABLES IN SCHEMA my_schema WITH (publish_via_partition_root = true);
 -- Or, create a publication for all tables in the database
 CREATE PUBLICATION sequin FOR ALL TABLES WITH (publish_via_partition_root = true);
 ```

--- a/docs/connect-postgres.mdx
+++ b/docs/connect-postgres.mdx
@@ -166,7 +166,7 @@ alter publication sequin_pub add table table1, table2;
 You can also add all tables in a specific schema:
 
 ```sql
-alter publication sequin_pub add all tables in schema my_schema;
+alter publication sequin_pub add tables in schema my_schema;
 ```
 
 To verify which tables are included in your publication, you can run:

--- a/docs/reference/databases.mdx
+++ b/docs/reference/databases.mdx
@@ -107,7 +107,7 @@ create publication sequin_publication for table table1, table2, table3;
 Or all tables in a schema:
 
 ```sql
-create publication sequin_publication for all tables in schema public;
+create publication sequin_publication for tables in schema public;
 ```
 
 ### Working with partitioned tables
@@ -144,9 +144,9 @@ alter publication sequin_publication add table table1, table2, table3;
 -- Drop tables
 alter publication sequin_publication drop table table1, table2, table3;
 -- Add all tables in a schema
-alter publication sequin_publication add all tables in schema my_schema;
+alter publication sequin_publication add tables in schema my_schema;
 -- Drop all tables in a schema
-alter publication sequin_publication drop all tables in schema my_schema;
+alter publication sequin_publication drop tables in schema my_schema;
 ```
 
 ### Deleting a Publication

--- a/postgres-replication.md
+++ b/postgres-replication.md
@@ -17,7 +17,7 @@ To prepare your Postgres database for replication with Sequin, follow these step
    You can add more tables by separating them with commas. To publish all tables in a schema:
 
    ```sql
-   CREATE PUBLICATION your_publication_name FOR ALL TABLES IN SCHEMA your_schema WITH (publish_via_partition_root = true);
+   CREATE PUBLICATION your_publication_name FOR TABLES IN SCHEMA your_schema WITH (publish_via_partition_root = true);
    ```
 
 3. Set the replica identity for each table. There are two main options:


### PR DESCRIPTION
fixes #1563 

it's confusing because GRANT is in fact `all tables in schema` but create/alter pub is just `tables in schema`