### PR TITLE
[cli] allow function code to be embedded via `file:` + smarter ENV embed in yaml

### DIFF
--- a/cli/cli/config_command_test.go
+++ b/cli/cli/config_command_test.go
@@ -187,11 +187,11 @@ functions:
 		}
 
 		testCases := []struct {
-			name        string
-			filePath    string // Path to use in YAML
-			codePath    string // Actual path where code should be written
-			cleanup     func()
-			useStdin    bool   // Whether to use STDIN for YAML input
+			name     string
+			filePath string // Path to use in YAML
+			codePath string // Actual path where code should be written
+			cleanup  func()
+			useStdin bool // Whether to use STDIN for YAML input
 		}{
 			{
 				name:     "from current directory with direct relative path",

--- a/cli/cli/config_command_test.go
+++ b/cli/cli/config_command_test.go
@@ -2,28 +2,41 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sequinstream/sequin/cli/testutil"
 )
 
 func TestInterpolateAction(t *testing.T) {
-	// Create a temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "config-command-test")
+	// Create a nested temporary directory structure for test files
+	parentDir, err := os.MkdirTemp("", "config-command-test-parent")
 	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
+		t.Fatalf("Failed to create parent temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(parentDir)
+
+	// We create also a child directory to test the `..` relative path without messing with files outside of the test directory
+	tmpDir, err := os.MkdirTemp(parentDir, "config-command-test-child")
+	if err != nil {
+		t.Fatalf("Failed to create child temp dir: %v", err)
+	}
 
 	// Create test YAML file
 	yamlContent := `
 # Test YAML file
 app:
-  name: ${APP_NAME:-test-app}
-  port: ${PORT:-8080}
   env: ${ENV:-development}
+  map:
+    name: ${APP_NAME:-test-app}
+    port: ${PORT:-8080}
+  list:
+  - ${RATIO:-3.1416}
+  - ${API_KEY:0}
 `
 	yamlPath := filepath.Join(tmpDir, "test.yaml")
 	outputPath := filepath.Join(tmpDir, "output.yaml")
@@ -34,8 +47,10 @@ app:
 	// Set environment variables for tests
 	os.Setenv("APP_NAME", "my-custom-app")
 	os.Setenv("ENV", "testing")
+	os.Setenv("API_KEY", "00000000123456789123456789")
 	defer os.Unsetenv("APP_NAME")
 	defer os.Unsetenv("ENV")
+	defer os.Unsetenv("API_KEY")
 
 	// Helper function to capture stdout
 	captureOutput := func(f func() error) (string, error) {
@@ -65,18 +80,18 @@ app:
 			return
 		}
 
-		// Expected full output
 		expectedOutput := `
 # Test YAML file
 app:
-  name: my-custom-app
-  port: 8080
   env: testing
+  map:
+    name: my-custom-app
+    port: "8080"
+  list:
+  - "3.1416"
+  - "00000000123456789123456789"
 `
-		// Compare full output
-		if output != expectedOutput {
-			t.Errorf("Output does not match expected.\nGot:\n%s\nWant:\n%s", output, expectedOutput)
-		}
+		testutil.CompareYAML(t, output, expectedOutput)
 	})
 
 	t.Run("interpolate to file", func(t *testing.T) {
@@ -99,24 +114,23 @@ app:
 			t.Errorf("Expected success message for file output, got: %s", output)
 		}
 
-		// Check the file content
 		content, err := os.ReadFile(outputPath)
 		if err != nil {
 			t.Fatalf("Failed to read output file: %v", err)
 		}
 
-		// Expected file content
 		expectedFileContent := `
 # Test YAML file
 app:
-  name: my-custom-app
-  port: 8080
   env: testing
+  map:
+    name: my-custom-app
+    port: "8080"
+  list:
+  - "3.1416"
+  - "00000000123456789123456789"
 `
-		// Compare full file content
-		if string(content) != expectedFileContent {
-			t.Errorf("File content does not match expected.\nGot:\n%s\nWant:\n%s", string(content), expectedFileContent)
-		}
+		testutil.CompareYAML(t, string(content), expectedFileContent)
 	})
 
 	t.Run("file not found", func(t *testing.T) {
@@ -128,6 +142,201 @@ app:
 
 		if err == nil {
 			t.Error("interpolateAction() expected error for nonexistent file, got nil")
+		}
+	})
+
+	// Helper function to indent each line of a string
+	indentLines := func(s string, indent int) string {
+		lines := strings.Split(s, "\n")
+		indentStr := strings.Repeat(" ", indent)
+		for i, line := range lines {
+			lines[i] = indentStr + line
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	t.Run("interpolate function code", func(t *testing.T) {
+		codeContent := `def transform(action, record, changes, metadata) do
+  %{
+    id: record["id"],
+    action: action
+  }
+end`
+
+		// Base YAML template that will be used for all tests
+		yamlTemplate := `
+# Test YAML file with function
+functions:
+  - name: "my-transform-function"
+    description: "Extract ID and action"
+    type: "transform"
+    file: "%s"
+`
+
+		// Helper function to create test files
+		createTestFiles := func(t *testing.T, codePath string) error {
+			// Create directory if it doesn't exist
+			dir := filepath.Dir(codePath)
+			if dir != "." {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return fmt.Errorf("failed to create directory: %v", err)
+				}
+			}
+			// Write the code file
+			return os.WriteFile(codePath, []byte(codeContent), 0644)
+		}
+
+		testCases := []struct {
+			name        string
+			filePath    string // Path to use in YAML
+			codePath    string // Actual path where code should be written
+			cleanup     func()
+			useStdin    bool   // Whether to use STDIN for YAML input
+		}{
+			{
+				name:     "from current directory with direct relative path",
+				filePath: "transform.ex",
+				codePath: filepath.Join(tmpDir, "transform.ex"),
+			},
+			{
+				name:     "from current directory with dot relative path",
+				filePath: "./transform.ex",
+				codePath: filepath.Join(tmpDir, "transform.ex"),
+			},
+			{
+				name:     "from subdirectory with relative path",
+				filePath: filepath.Join("functions", "transform.ex"),
+				codePath: filepath.Join(tmpDir, "functions", "transform.ex"),
+			},
+			{
+				name:     "from sibling directory with relative path",
+				filePath: filepath.Join("..", "sibling-functions", "transform.ex"),
+				codePath: filepath.Join(parentDir, "sibling-functions", "transform.ex"),
+			},
+			{
+				name:     "from any directory using absolute path",
+				filePath: filepath.Join(parentDir, "sibling-functions", "transform.ex"),
+				codePath: filepath.Join(parentDir, "sibling-functions", "transform.ex"),
+			},
+			{
+				name:     "from stdin with relative path",
+				filePath: "transform.ex",
+				codePath: filepath.Join(tmpDir, "transform.ex"),
+				useStdin: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Create the code file
+				if err := createTestFiles(t, tc.codePath); err != nil {
+					t.Fatalf("Failed to create test files: %v", err)
+				}
+
+				// Create YAML file with the appropriate path
+				yamlContent := fmt.Sprintf(yamlTemplate, tc.filePath)
+				yamlPath := filepath.Join(tmpDir, "test.yaml")
+				outputPath := filepath.Join(tmpDir, "output.yaml")
+
+				var cmd *ConfigCommands
+				if tc.useStdin {
+					// Save current directory and change to temp directory
+					originalDir, err := os.Getwd()
+					if err != nil {
+						t.Fatalf("Failed to get current directory: %v", err)
+					}
+					defer os.Chdir(originalDir)
+
+					if err := os.Chdir(tmpDir); err != nil {
+						t.Fatalf("Failed to change to temp directory: %v", err)
+					}
+
+					// Create a pipe to simulate stdin
+					oldStdin := os.Stdin
+					r, w, _ := os.Pipe()
+					os.Stdin = r
+					defer func() {
+						os.Stdin = oldStdin
+						r.Close()
+					}()
+
+					// Write YAML content to the pipe
+					go func() {
+						w.Write([]byte(yamlContent))
+						w.Close()
+					}()
+
+					cmd = &ConfigCommands{
+						yamlPath:   "-",
+						outputPath: outputPath,
+					}
+				} else {
+					if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+						t.Fatalf("Failed to write test YAML: %v", err)
+					}
+
+					cmd = &ConfigCommands{
+						yamlPath:   yamlPath,
+						outputPath: outputPath,
+					}
+				}
+
+				output, err := captureOutput(func() error {
+					return cmd.interpolateAction(nil)
+				})
+
+				if err != nil {
+					t.Errorf("interpolateAction() error = %v", err)
+					return
+				}
+
+				// Verify the message about writing to file
+				if !strings.Contains(output, "Interpolated YAML written to "+outputPath) {
+					t.Errorf("Expected success message for file output, got: %s", output)
+				}
+
+				content, err := os.ReadFile(outputPath)
+				if err != nil {
+					t.Fatalf("Failed to read output file: %v", err)
+				}
+
+				expectedFileContent := fmt.Sprintf(`
+# Test YAML file with function
+functions:
+  - name: "my-transform-function"
+    description: "Extract ID and action"
+    type: "transform"
+    code: |-
+%s
+`, indentLines(codeContent, 6))
+				testutil.CompareYAML(t, string(content), expectedFileContent)
+			})
+		}
+	})
+
+	t.Run("function file not found", func(t *testing.T) {
+		// Create test YAML file with non-existent function file
+		yamlContent := `
+# Test YAML file with missing function file
+functions:
+  - name: "my-transform-function"
+    description: "Extract ID and action"
+    type: "transform"
+    file: "nonexistent.ex"
+`
+		yamlPath := filepath.Join(tmpDir, "test.yaml")
+		if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+			t.Fatalf("Failed to write test YAML: %v", err)
+		}
+
+		cmd := &ConfigCommands{yamlPath: yamlPath}
+
+		_, err := captureOutput(func() error {
+			return cmd.interpolateAction(nil)
+		})
+
+		if err == nil {
+			t.Error("interpolateAction() expected error for nonexistent function file, got nil")
 		}
 	})
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -159,12 +159,12 @@ func processYAML(pctx *ProcessingContext, yamlContent []byte) ([]byte, error) {
 
 	with_subst, err := applyEnvSubst(yamlData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("environment variable substitution failed: %w", err)
 	}
 
 	with_files, err := processFunctions(pctx, with_subst)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("function parsing failed: %w", err)
 	}
 
 	processed, err := yaml.Marshal(with_files)
@@ -226,8 +226,6 @@ func processFunctionsList(pctx *ProcessingContext, node interface{}) (interface{
 func processFileInFunction(pctx *ProcessingContext, funcObj map[string]interface{}) (map[string]interface{}, error) {
 	if filePathRaw, hasFile := funcObj["file"]; hasFile {
 		if filePath, ok := filePathRaw.(string); ok {
-			fmt.Printf("Processing file reference: %s\n", filePath)
-
 			resolvedPath, err := resolveFilePath(pctx, filePath)
 			if err != nil {
 				return nil, fmt.Errorf("error resolving file path %s: %w", filePath, err)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.3.2 // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -33,6 +33,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=

--- a/cli/testutil/yaml.go
+++ b/cli/testutil/yaml.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+// CompareYAML parses two YAML strings and compares their semantic meaning
+func CompareYAML(t *testing.T, got, want string) {
+	var gotObj, wantObj interface{}
+	if err := yaml.Unmarshal([]byte(got), &gotObj); err != nil {
+		t.Errorf("Failed to parse got YAML: %v", err)
+		return
+	}
+	if err := yaml.Unmarshal([]byte(want), &wantObj); err != nil {
+		t.Errorf("Failed to parse want YAML: %v", err)
+		return
+	}
+	if !reflect.DeepEqual(gotObj, wantObj) {
+		t.Errorf("YAML objects do not match.\nGot:\n%s\nWant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
Previously, the cli did not parse yaml and applied env var subst to the entire yaml as a flat string.  
This PR adds a real yaml parser and applies env var substitution in a structure-aware way, so that you can't interpolate into yaml keys, or interpolate in content which would result in malformed yaml.
Finally, with the parser, we can support a file: key on functions, where we will read the file, path relative to our cwd, and pass the content upstream under the code: key as the api expects.

Consider:
- should we keep the file: separate key, or do in-band signaling where we automatically read files into anything that starts with file:// or something?
- should we interpret paths as relative to process cwd, or relative to the location of the yaml file, or both?

closes #1584 