### PR TITLE
feat: add Oban.Plugins.Pruner to delete completed jobs older than 14 days

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -44,6 +44,8 @@ config :sequin, Oban,
   ],
   repo: Sequin.Repo,
   plugins: [
+    # Prune jobs that are older than 14 days
+    {Oban.Plugins.Pruner, max_age: 14 * 24 * 60 * 60, limit: 5_000, interval: 20_000},
     {Oban.Plugins.Cron,
      crontab: [
        # Runs every 6 hours (at minute 0)


### PR DESCRIPTION
Add Oban Plugin [`Oban.Plugins.Pruner`](https://hexdocs.pm/oban/Oban.Plugins.Pruner.html) to clean up completed jobs older than 14 days.

Fixes #1687 