### PR TITLE
Include `commit_idx` in `metadata`

### DIFF
--- a/docs/guides/user-webhooks.mdx
+++ b/docs/guides/user-webhooks.mdx
@@ -296,7 +296,8 @@ With the infrastructure in place, you'll build a Node.js application that expose
                         "transaction_annotations": null,
                         "table_schema": "public",
                         "database_name": "local",
-                        "commit_lsn": 46346904
+                        "commit_lsn": 46346904,
+                        "commit_idx": 0
                     },
                     "action": "insert",
                     "changes": null

--- a/docs/reference/messages.mdx
+++ b/docs/reference/messages.mdx
@@ -28,6 +28,7 @@ A change message has this shape:
     table_name: string;
     commit_timestamp: string;  // ISO timestamp
     commit_lsn: integer;  // Logical replication LSN of the transaction
+    commit_idx: integer;  // The index of the message within the transaction
     idempotency_key: string; // Opaque token
     transaction_annotations: null | {
       [key: string]: any;  // User-provided transaction context

--- a/lib/sequin/consumers/consumer_event.ex
+++ b/lib/sequin/consumers/consumer_event.ex
@@ -13,6 +13,7 @@ defmodule Sequin.Consumers.ConsumerEvent do
            only: [
              :consumer_id,
              :commit_lsn,
+             :commit_idx,
              :ack_id,
              :deliver_count,
              :group_id,

--- a/lib/sequin/consumers/consumer_event_data.ex
+++ b/lib/sequin/consumers/consumer_event_data.ex
@@ -30,6 +30,7 @@ defmodule Sequin.Consumers.ConsumerEventData do
       field :table_name, :string
       field :commit_timestamp, :utc_datetime_usec
       field :commit_lsn, :integer
+      field :commit_idx, :integer
       field :database_name, :string
       field :transaction_annotations, :map
       field :idempotency_key, :string
@@ -55,8 +56,16 @@ defmodule Sequin.Consumers.ConsumerEventData do
 
   def metadata_changeset(metadata, attrs) do
     metadata
-    |> cast(attrs, [:table_schema, :table_name, :commit_timestamp, :commit_lsn, :database_name, :transaction_annotations])
-    |> validate_required([:table_schema, :table_name, :commit_timestamp, :commit_lsn])
+    |> cast(attrs, [
+      :table_schema,
+      :table_name,
+      :commit_timestamp,
+      :commit_lsn,
+      :commit_idx,
+      :database_name,
+      :transaction_annotations
+    ])
+    |> validate_required([:table_schema, :table_name, :commit_timestamp, :commit_lsn, :commit_idx])
     |> cast_embed(:consumer, required: true, with: &consumer_changeset/2)
   end
 

--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -1585,6 +1585,7 @@ defmodule Sequin.Consumers do
           table_name: "characters",
           commit_timestamp: DateTime.utc_now(),
           commit_lsn: 309_018_972_104,
+          commit_idx: 0,
           database_name: "dune",
           transaction_annotations: nil,
           consumer: %Metadata.Sink{

--- a/lib/sequin/runtime/message_handler.ex
+++ b/lib/sequin/runtime/message_handler.ex
@@ -289,6 +289,7 @@ defmodule Sequin.Runtime.MessageHandler do
       table_schema: message.table_schema,
       commit_timestamp: message.commit_timestamp,
       commit_lsn: message.commit_lsn,
+      commit_idx: message.commit_idx,
       consumer: %{
         id: consumer.id,
         name: consumer.name,


### PR DESCRIPTION
All messages in a transaction share the same `commit_lsn`. The `commit_idx` is the order (index) of a particular message inside of a transaction.