### PR TITLE
feat: add support for transforms for redis stream sink

### DIFF
--- a/assets/svelte/consumers/ShowSink.svelte
+++ b/assets/svelte/consumers/ShowSink.svelte
@@ -1046,7 +1046,7 @@
             <h2 class="text-lg font-semibold flex items-center gap-2">
               Transform
             </h2>
-            {#if transform && !isRedisStreamConsumer(consumer)}
+            {#if transform}
               <a
                 href="/functions/{transform.id}"
                 data-phx-link="redirect"

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -325,8 +325,7 @@
   let backfillSectionEnabled = false;
   let backfillSectionExpanded = false;
   $: {
-    transformSectionEnabled =
-      (selectedTable || selectedSchema) && consumer.type !== "redis_stream";
+    transformSectionEnabled = selectedTable || selectedSchema;
     transformSectionExpanded = transformSectionEnabled && !isEditMode;
 
     backfillSectionEnabled = (selectedTable || selectedSchema) && !isEditMode;
@@ -513,16 +512,7 @@
       </svelte:fragment>
 
       <svelte:fragment slot="summary">
-        {#if consumer.type === "redis_stream"}
-          <p class="text-sm text-muted-foreground">
-            Transforms are coming soon for Redis Stream sinks. <a
-              href="https://github.com/sequinstream/sequin/issues/1186"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-primary underline">Let us know</a
-            > if you want this.
-          </p>
-        {:else if !selectedTable && !selectedSchema}
+        {#if !selectedTable && !selectedSchema}
           <p class="text-sm text-muted-foreground">
             Please select a table or schema.
           </p>

--- a/docs/reference/sinks/redis-stream.mdx
+++ b/docs/reference/sinks/redis-stream.mdx
@@ -58,6 +58,33 @@ For change messages:
 
 For the shape of the fields `metadata` and `changes` as well as information about `action`, see the reference for [messages](/reference/messages).
 
+## Transforms
+
+You can use transforms to customize the fields sent to Redis Streams. The transform function should return a map where:
+
+- Each key becomes a field name in the Redis Stream entry
+- String values are stored as-is
+- Non-string values are JSON-encoded
+
+Example transform:
+
+```elixir
+def transform(_action, record, changes, metadata) do
+  %{
+    id: record["id"],
+    name: record["name"],
+    changes: changes,
+    table: metadata.table_name
+  }
+end
+```
+
+This would result in a Redis Stream entry like:
+
+```
+XADD mystream * id 123 name "John" changes "{\"email\":\"newemail@domain.com\"}" table "users"
+```
+
 ## Retry behavior
 
 If Sequin is unable to deliver a message to Redis, it will retry the message indefinitely. Sequin will exponentially back off the retry interval, with a maximum backoff of roughly 3 minutes.

--- a/test/sequin/redis_stream_pipeline_test.exs
+++ b/test/sequin/redis_stream_pipeline_test.exs
@@ -1,0 +1,111 @@
+defmodule Sequin.RedisStreamPipelineTest do
+  use Sequin.DataCase, async: true
+
+  alias Sequin.Consumers
+  alias Sequin.Factory.AccountsFactory
+  alias Sequin.Factory.ConsumersFactory
+  alias Sequin.Functions.MiniElixir
+  alias Sequin.Runtime.SinkPipeline
+  alias Sequin.Sinks.RedisMock
+
+  describe "redis stream pipeline" do
+    setup do
+      account = AccountsFactory.insert_account!()
+
+      consumer =
+        ConsumersFactory.insert_sink_consumer!(
+          account_id: account.id,
+          batch_size: 10,
+          type: :redis_stream,
+          sink: %{type: :redis_stream, stream_key: "test-stream"},
+          message_kind: :event
+        )
+
+      {:ok, %{consumer: consumer}}
+    end
+
+    test "sends message to redis", %{consumer: consumer} do
+      message = ConsumersFactory.insert_consumer_event!(consumer_id: consumer.id)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_message(consumer, message)
+
+      Mox.expect(RedisMock, :send_messages, fn _, _ -> :ok end)
+
+      assert_receive {:ack, ^ref, [%{data: %{data: data}}], []}, 1_000
+      assert data == message.data
+    end
+
+    test "sends messages to redis", %{consumer: consumer} do
+      message1 = ConsumersFactory.insert_consumer_event!(consumer_id: consumer.id)
+      message2 = ConsumersFactory.insert_consumer_event!(consumer_id: consumer.id)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_batch(consumer, [message1, message2])
+
+      Mox.expect(RedisMock, :send_messages, fn _, _ -> :ok end)
+
+      assert_receive {:ack, ^ref, [%{data: %{data: data1}}, %{data: %{data: data2}}], []}, 1_000
+      assert data1 == message1.data
+      assert data2 == message2.data
+    end
+
+    test "transforms messages with function transforms", %{consumer: consumer} do
+      transform_code = """
+      def transform(action, record, changes, metadata) do
+        %{"transformed" => record["column"]}
+      end
+      """
+
+      assert {:ok, transform} =
+               Consumers.create_function(consumer.account_id, %{
+                 name: "test",
+                 function: %{
+                   type: "transform",
+                   code: transform_code
+                 }
+               })
+
+      assert MiniElixir.create(transform.id, transform.function.code)
+      {:ok, consumer} = Consumers.update_sink_consumer(consumer, %{transform_id: transform.id})
+
+      message = ConsumersFactory.insert_consumer_event!(consumer_id: consumer.id)
+
+      column_value = message.data.record["column"]
+
+      start_pipeline!(consumer)
+
+      ref = send_test_message(consumer, message)
+
+      Mox.expect(RedisMock, :send_messages, fn _, [%{data: %{"transformed" => ^column_value}}] -> :ok end)
+
+      assert_receive {:ack, ^ref, [%{data: %{data: data}}], []}, 1_000
+      assert data == message.data
+    end
+  end
+
+  defp start_pipeline!(consumer) do
+    start_supervised!(
+      {SinkPipeline,
+       [
+         consumer_id: consumer.id,
+         producer: Broadway.DummyProducer,
+         test_pid: self()
+       ]}
+    )
+  end
+
+  defp send_test_message(consumer, message) do
+    Broadway.test_message(broadway(consumer), message)
+  end
+
+  defp send_test_batch(consumer, messages) do
+    Broadway.test_batch(broadway(consumer), messages)
+  end
+
+  defp broadway(consumer) do
+    SinkPipeline.via_tuple(consumer.id)
+  end
+end


### PR DESCRIPTION
Add support for Transforms for Redis Stream sink

Fixes #1186 

----

## Evidence

### Function definition

```elixir
def transform(action, record, changes, metadata) do
  %{
    action: action,
    record: record,
    changes: changes,
    metadata: metadata,
    name: record["username"],
    user: %{email: record["email"]}
  }
end

```


### Sink definition

stream key: `test-stream-key`

using the function defined above

### Redis CLI

After inserting a record, modifying it, and then deleting it:

The results below are fragments of the `XRANGE` command executed with redis-cli

```redis
XRANGE test-stream-key - +
```

Creating a record
```
1) 1) "1749072830694-0"
   2)  1) "name"
       2) "username0.569994519823773"
       3) "user"
       4) "{\"email\":\"email0.2740232599967376\"}"
       5) "record"
       6) "{\"created_at\":\"2025-06-04T15:33:50.515421\",\"email\":\"email0.2740232599967376\",\"foo\":null,\"last_login\":null,\"password\":\"password0.8512212681386511\",\"user_id\":191,\"username\":\"username0.569994519823773\"}"
       7) "metadata"
       8) "{\"consumer\":{\"id\":\"cdcc4485-0e69-434e-b845-04639d832183\",\"name\":\"accounts_sink_redis_stream\",\"annotations\":{}},\"commit_lsn\":8342592552,\"commit_idx\":0,\"commit_timestamp\":\"2025-06-04T21:33:50.516120Z\",\"database_name\":\"sequin_example_222\",\"table_name\":\"accounts\",\"table_schema\":\"public\",\"transaction_annotations\":null,\"idempotency_key\":\"ODM0MjU5MjU1Mjow\"}"
       9) "action"
      10) "insert"
      11) "changes"
      12) "null"

```

Modifying a record
```
2) 1) "1749072832162-0"
   2)  1) "name"
       2) "username0.569994519823773"
       3) "user"
       4) "{\"email\":\"newemail@domain.com\"}"
       5) "record"
       6) "{\"created_at\":\"2025-06-04T15:33:50.515421\",\"email\":\"newemail@domain.com\",\"foo\":null,\"last_login\":null,\"password\":\"password0.8512212681386511\",\"user_id\":191,\"username\":\"username0.569994519823773\"}"
       7) "metadata"
       8) "{\"consumer\":{\"id\":\"cdcc4485-0e69-434e-b845-04639d832183\",\"name\":\"accounts_sink_redis_stream\",\"annotations\":{}},\"commit_lsn\":8342598584,\"commit_idx\":0,\"commit_timestamp\":\"2025-06-04T21:33:52.021936Z\",\"database_name\":\"sequin_example_222\",\"table_name\":\"accounts\",\"table_schema\":\"public\",\"transaction_annotations\":null,\"idempotency_key\":\"ODM0MjU5ODU4NDow\"}"
       9) "action"
      10) "update"
      11) "changes"
      12) "{\"email\":\"email0.2740232599967376\"}"

```

Deleting a record
```
3) 1) "1749072834097-0"
   2)  1) "name"
       2) "username0.569994519823773"
       3) "user"
       4) "{\"email\":\"newemail@domain.com\"}"
       5) "record"
       6) "{\"created_at\":\"2025-06-04T15:33:50.515421\",\"email\":\"newemail@domain.com\",\"foo\":null,\"last_login\":null,\"password\":\"password0.8512212681386511\",\"user_id\":191,\"username\":\"username0.569994519823773\"}"
       7) "metadata"
       8) "{\"consumer\":{\"id\":\"cdcc4485-0e69-434e-b845-04639d832183\",\"name\":\"accounts_sink_redis_stream\",\"annotations\":{}},\"commit_lsn\":8342604296,\"commit_idx\":0,\"commit_timestamp\":\"2025-06-04T21:33:53.896836Z\",\"database_name\":\"sequin_example_222\",\"table_name\":\"accounts\",\"table_schema\":\"public\",\"transaction_annotations\":null,\"idempotency_key\":\"ODM0MjYwNDI5Njow\"}"
       9) "action"
      10) "delete"
      11) "changes"
      12) "null"
```
