### PR TITLE
Add static redactor for LoggerJSON

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -116,7 +116,13 @@ end
 ecto_socket_opts = if (System.get_env("ECTO_IPV6") || System.get_env("PG_IPV6")) in ~w(true 1), do: [:inet6], else: []
 
 if config_env() == :prod do
-  config :logger, default_handler: [formatter: {Datadog, metadata: :all}]
+  config :logger,
+    default_handler: [
+      formatter:
+        {Datadog,
+         metadata: :all,
+         redactors: [{Sequin.Logger.StaticRedactor, []}]}
+    ]
 end
 
 if config_env() == :prod and self_hosted do
@@ -174,7 +180,13 @@ if config_env() == :prod and self_hosted do
 
   case System.get_env("SEQUIN_LOG_FORMAT") do
     "DATADOG_JSON" ->
-      config :logger, default_handler: [formatter: {Datadog, metadata: :all}]
+      config :logger,
+        default_handler: [
+          formatter:
+            {Datadog,
+             metadata: :all,
+             redactors: [{Sequin.Logger.StaticRedactor, []}]}
+        ]
 
     _ ->
       # Fallback to ConsoleLogger, set in prod.exs

--- a/lib/sequin/logger/static_redactor.ex
+++ b/lib/sequin/logger/static_redactor.ex
@@ -1,0 +1,29 @@
+defmodule Sequin.Logger.StaticRedactor do
+  @moduledoc false
+  @behaviour LoggerJSON.Redactor
+
+  @sensitive [
+    :access_key_id,
+    :api_key,
+    :auth_token,
+    :aws_access_key_id,
+    :aws_secret_access_key,
+    :client_secret,
+    :credentials,
+    :current_password,
+    :hashed_password,
+    :hashed_token,
+    :nkey_seed,
+    :password,
+    :private_key,
+    :private_key_id,
+    :secret_access_key,
+    :shared_access_key,
+    :shared_access_key_name,
+    :token
+  ]
+
+  @impl true
+  def redact(key, _value, _opts) when key in @sensitive, do: "[REDACTED]"
+  def redact(_key, value, _opts), do: value
+end


### PR DESCRIPTION
## Summary
- redact known credential fields in logs via `Sequin.Logger.StaticRedactor`
- enable the redactor for the Datadog formatter

## Testing
- `npm run format:check`
- `npm run tsc`
- `make spellcheck` *(fails: 403 Forbidden)*
- `make check-links` *(fails: 403 Forbidden)*
- `go test ./...` *(fails: 403 Forbidden)*
- `MIX_ENV=prod mix compile --warnings-as-errors` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6840e19812b8832698b89d683e4bc439