### PR TITLE
Add redactor for sensitive logs, remove errors from metadata

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,6 +2,7 @@ import Config
 
 alias LoggerJSON.Formatters.Datadog
 alias Sequin.ConfigParser
+alias Sequin.Logger.Redactor
 
 require Logger
 
@@ -116,7 +117,10 @@ end
 ecto_socket_opts = if (System.get_env("ECTO_IPV6") || System.get_env("PG_IPV6")) in ~w(true 1), do: [:inet6], else: []
 
 if config_env() == :prod do
-  config :logger, default_handler: [formatter: {Datadog, metadata: :all}]
+  config :logger,
+    default_handler: [
+      formatter: {Datadog, metadata: :all, redactors: [{Redactor, []}]}
+    ]
 end
 
 if config_env() == :prod and self_hosted do
@@ -174,7 +178,10 @@ if config_env() == :prod and self_hosted do
 
   case System.get_env("SEQUIN_LOG_FORMAT") do
     "DATADOG_JSON" ->
-      config :logger, default_handler: [formatter: {Datadog, metadata: :all}]
+      config :logger,
+        default_handler: [
+          formatter: {Datadog, metadata: :all, redactors: [{Redactor, []}]}
+        ]
 
     _ ->
       # Fallback to ConsoleLogger, set in prod.exs

--- a/lib/sequin/logger/redactor.ex
+++ b/lib/sequin/logger/redactor.ex
@@ -1,0 +1,37 @@
+defmodule Sequin.Logger.Redactor do
+  @moduledoc """
+  Redactor that's applied to message + metadata of JSON log entries.
+  """
+
+  @behaviour LoggerJSON.Redactor
+
+  @sensitive [
+    "access_key_id",
+    "api_key",
+    "auth_token",
+    "auth_value",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "client_email",
+    "client_secret",
+    "contact_email",
+    "credentials",
+    "current_password",
+    "email",
+    "hashed_password",
+    "hashed_token",
+    "jwt",
+    "nkey_seed",
+    "password",
+    "private_key",
+    "private_key_id",
+    "secret_access_key",
+    "shared_access_key",
+    "shared_access_key_name",
+    "token"
+  ]
+
+  @impl true
+  def redact(key, value, _opts) when key in @sensitive and is_binary(value), do: "[REDACTED]"
+  def redact(_key, value, _opts), do: value
+end


### PR DESCRIPTION
- Add redactor to filter logs
- However, the redactor does not seem to work on deep metadata keys. Remove areas where we pass errors as metadata to logs