### PR TITLE
feat: automatically restart kafka producers

### DIFF
--- a/lib/sequin/consumers/kafka_sink.ex
+++ b/lib/sequin/consumers/kafka_sink.ex
@@ -158,6 +158,7 @@ defmodule Sequin.Consumers.KafkaSink do
     |> maybe_add_sasl(sink)
     |> maybe_add_ssl(sink)
     |> Keyword.put(:query_api_versions, true)
+    |> Keyword.put(:auto_start_producers, true)
   end
 
   # Add SASL authentication if username/password are configured


### PR DESCRIPTION
This PR enables the `auto_start_producers` option from the brod client. When this option is set, brod will automatically recreate and start a missing producer if it is invoked after termination.

Additional info:
https://hexdocs.pm/brod/brod.html#start_producer/3

https://github.com/kafka4beam/brod/blob/ee6e50c9fbefb4f093833c24c14aaf2ee07f74b6/src/brod_client.erl#L165-L166