### PR TITLE
⚙️  Allow inifinity_timestamps for Postgrex.Types

### DIFF
--- a/lib/sequin/postgres/postgrex_types.ex
+++ b/lib/sequin/postgres/postgrex_types.ex
@@ -1,1 +1,3 @@
-Postgrex.Types.define(Sequin.Postgres.PostgrexTypes, Pgvector.extensions() ++ Ecto.Adapters.Postgres.extensions(), [])
+Postgrex.Types.define(Sequin.Postgres.PostgrexTypes, Pgvector.extensions() ++ Ecto.Adapters.Postgres.extensions(),
+  allow_infinite_timestamps: true
+)


### PR DESCRIPTION
* This is needed for backfills on customer databases when they have
  infinity timestamps