### PR TITLE
fix: move KafkaMock into mock.ex to remove warnings about undefined Kafka functions

### DIFF
--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -14,6 +14,10 @@ Mox.defmock(Sequin.Sinks.RabbitMqMock,
   for: Sequin.Sinks.RabbitMq
 )
 
+Mox.defmock(Sequin.Sinks.KafkaMock,
+  for: Sequin.Sinks.Kafka
+)
+
 Mox.defmock(Sequin.Runtime.TableReaderServerMock,
   for: Sequin.Runtime.TableReaderServer
 )

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,4 +36,3 @@ tables =
 
 # Mocks
 Mox.defmock(Sequin.Sinks.RedisMock, for: Sequin.Sinks.Redis)
-Mox.defmock(Sequin.Sinks.KafkaMock, for: Sequin.Sinks.Kafka)


### PR DESCRIPTION
fixes these warnings:
```elixir
    warning: Sequin.Sinks.KafkaMock.publish/2 is undefined (module Sequin.Sinks.KafkaMock is not available or is yet to be defined)
    │
 20 │     @module.publish(consumer, record)
    │             ~
    │
    └─ lib/sequin/sinks/kafka/kafka.ex:20:13: Sequin.Sinks.Kafka.publish/2

    warning: Sequin.Sinks.KafkaMock.publish/2 is undefined (module Sequin.Sinks.KafkaMock is not available or is yet to be defined)
    │
 24 │     @module.publish(consumer, event)
    │             ~
    │
    └─ lib/sequin/sinks/kafka/kafka.ex:24:13: Sequin.Sinks.Kafka.publish/2

    warning: Sequin.Sinks.KafkaMock.publish/3 is undefined (module Sequin.Sinks.KafkaMock is not available or is yet to be defined)
    │
 28 │     @module.publish(consumer, partition, messages)
    │             ~
    │
    └─ lib/sequin/sinks/kafka/kafka.ex:28:13: Sequin.Sinks.Kafka.publish/3

    warning: Sequin.Sinks.KafkaMock.test_connection/1 is undefined (module Sequin.Sinks.KafkaMock is not available or is yet to be defined)
    │
 33 │     @module.test_connection(sink)
    │             ~
    │
    └─ lib/sequin/sinks/kafka/kafka.ex:33:13: Sequin.Sinks.Kafka.test_connection/1

....
```

after #1747 