### PR TITLE
Fix telemetry for acknowledged messages 

### DIFF
--- a/lib/sequin/consumers/consumers.ex
+++ b/lib/sequin/consumers/consumers.ex
@@ -211,11 +211,8 @@ defmodule Sequin.Consumers do
     |> Function.where_id(id)
     |> Repo.one()
     |> case do
-      nil ->
-        {:error, Error.not_found(entity: :function, params: %{id: id, account_id: account_id})}
-
-      function ->
-        {:ok, function}
+      nil -> {:error, Error.not_found(entity: :function, params: %{id: id, account_id: account_id})}
+      function -> {:ok, function}
     end
   end
 
@@ -606,10 +603,7 @@ defmodule Sequin.Consumers do
     |> Stream.map(&module.deserialize/1)
   end
 
-  @spec upsert_consumer_messages(
-          SinkConsumer.t(),
-          list(ConsumerEvent.t()) | list(ConsumerRecord.t())
-        ) ::
+  @spec upsert_consumer_messages(SinkConsumer.t(), list(ConsumerEvent.t()) | list(ConsumerRecord.t())) ::
           {:ok, non_neg_integer()}
   def upsert_consumer_messages(%SinkConsumer{} = consumer, messages) do
     case consumer.message_kind do
@@ -639,9 +633,7 @@ defmodule Sequin.Consumers do
       Repo.insert_all(
         ConsumerEvent,
         events,
-        on_conflict:
-          {:replace,
-           [:state, :updated_at, :deliver_count, :last_delivered_at, :not_visible_until]},
+        on_conflict: {:replace, [:state, :updated_at, :deliver_count, :last_delivered_at, :not_visible_until]},
         conflict_target: [:consumer_id, :ack_id]
       )
 
@@ -651,10 +643,7 @@ defmodule Sequin.Consumers do
   @exponential_backoff_max :timer.minutes(10)
   def advance_delivery_state_for_failure(%{data: message}) do
     deliver_count = message.deliver_count + 1
-
-    backoff_time =
-      Time.exponential_backoff(:timer.seconds(1), deliver_count, @exponential_backoff_max)
-
+    backoff_time = Time.exponential_backoff(:timer.seconds(1), deliver_count, @exponential_backoff_max)
     not_visible_until = DateTime.add(DateTime.utc_now(), backoff_time, :millisecond)
 
     %{message | deliver_count: deliver_count, not_visible_until: not_visible_until}
@@ -770,9 +759,7 @@ defmodule Sequin.Consumers do
       Repo.insert_all(
         ConsumerRecord,
         records,
-        on_conflict:
-          {:replace,
-           [:state, :updated_at, :deliver_count, :last_delivered_at, :not_visible_until]},
+        on_conflict: {:replace, [:state, :updated_at, :deliver_count, :last_delivered_at, :not_visible_until]},
         conflict_target: [:consumer_id, :ack_id]
       )
 
@@ -785,8 +772,7 @@ defmodule Sequin.Consumers do
   # Completely arbitrary number, but must be consistent
   @partition_lock_key "partition_lock_key" |> :erlang.crc32() |> rem(32_768)
 
-  def create_consumer_partition(%{message_kind: kind} = consumer)
-      when kind in [:event, :record] do
+  def create_consumer_partition(%{message_kind: kind} = consumer) when kind in [:event, :record] do
     table_name = if kind == :event, do: "consumer_events", else: "consumer_records"
 
     with {:ok, _} <- Repo.query("SELECT pg_advisory_xact_lock($1)", [@partition_lock_key]),
@@ -800,8 +786,7 @@ defmodule Sequin.Consumers do
     end
   end
 
-  def delete_consumer_partition(%{message_kind: kind} = consumer)
-      when kind in [:event, :record] do
+  def delete_consumer_partition(%{message_kind: kind} = consumer) when kind in [:event, :record] do
     with {:ok, _} <- Repo.query("SELECT pg_advisory_xact_lock($1)", [@partition_lock_key]),
          {:ok, %Postgrex.Result{command: :drop_table}} <-
            Repo.query("""
@@ -812,9 +797,7 @@ defmodule Sequin.Consumers do
   end
 
   def consumer_partition_size_bytes(%SinkConsumer{} = consumer) do
-    case Repo.query(
-           "SELECT pg_total_relation_size('#{stream_schema()}.#{partition_name(consumer)}')"
-         ) do
+    case Repo.query("SELECT pg_total_relation_size('#{stream_schema()}.#{partition_name(consumer)}')") do
       {:ok, %Postgrex.Result{rows: [[size]]}} when is_integer(size) ->
         {:ok, size}
 
@@ -855,17 +838,11 @@ defmodule Sequin.Consumers do
   This is easy to do in Postgres with a single entry. When we want to perform an update
   for multiple messages, cleanest thing to do is to craft an upsert query.
   """
-  def nack_messages_with_backoff(
-        %{message_kind: :event} = consumer,
-        ack_ids_with_not_visible_until
-      ) do
+  def nack_messages_with_backoff(%{message_kind: :event} = consumer, ack_ids_with_not_visible_until) do
     nack_messages_with_backoff(ConsumerEvent, consumer, ack_ids_with_not_visible_until)
   end
 
-  def nack_messages_with_backoff(
-        %{message_kind: :record} = consumer,
-        ack_ids_with_not_visible_until
-      ) do
+  def nack_messages_with_backoff(%{message_kind: :record} = consumer, ack_ids_with_not_visible_until) do
     nack_messages_with_backoff(ConsumerRecord, consumer, ack_ids_with_not_visible_until)
   end
 
@@ -897,12 +874,7 @@ defmodule Sequin.Consumers do
 
       # Perform the upsert
       Repo.insert_all(model, updates,
-        on_conflict: [
-          set: [
-            not_visible_until: dynamic([cr], fragment("EXCLUDED.not_visible_until")),
-            state: :available
-          ]
-        ],
+        on_conflict: [set: [not_visible_until: dynamic([cr], fragment("EXCLUDED.not_visible_until")), state: :available]],
         conflict_target: [:consumer_id, :ack_id]
       )
     end)
@@ -1205,10 +1177,7 @@ defmodule Sequin.Consumers do
   end
 
   # Source Table Matching
-  def matches_message?(%SinkConsumer{message_kind: :record}, %SlotProcessor.Message{
-        action: :delete
-      }),
-      do: false
+  def matches_message?(%SinkConsumer{message_kind: :record}, %SlotProcessor.Message{action: :delete}), do: false
 
   # Schema Matching
   def matches_message?(
@@ -1224,8 +1193,7 @@ defmodule Sequin.Consumers do
 
   # Sequence Matching
   def matches_message?(
-        %{sequence: %Sequence{} = sequence, sequence_filter: %SequenceFilter{} = sequence_filter} =
-          consumer,
+        %{sequence: %Sequence{} = sequence, sequence_filter: %SequenceFilter{} = sequence_filter} = consumer,
         %SlotProcessor.Message{} = message
       ) do
     matches? = message_matches_sequence?(sequence, sequence_filter, message)
@@ -1280,10 +1248,7 @@ defmodule Sequin.Consumers do
       reraise error, __STACKTRACE__
   end
 
-  defp message_matches_schema?(
-         %SchemaFilter{} = schema_filter,
-         %SlotProcessor.Message{} = message
-       ) do
+  defp message_matches_schema?(%SchemaFilter{} = schema_filter, %SlotProcessor.Message{} = message) do
     message.table_schema == schema_filter.schema
   end
 
@@ -1300,26 +1265,19 @@ defmodule Sequin.Consumers do
   end
 
   def matches_record?(
-        %{sequence: %Sequence{} = sequence, sequence_filter: %SequenceFilter{} = sequence_filter} =
-          consumer,
+        %{sequence: %Sequence{} = sequence, sequence_filter: %SequenceFilter{} = sequence_filter} = consumer,
         table_oid,
         record_attnums_to_values
       ) do
     table_matches? = sequence.table_oid == table_oid
-
-    column_filters_match? =
-      column_filters_match_record?(sequence_filter.column_filters, record_attnums_to_values)
+    column_filters_match? = column_filters_match_record?(sequence_filter.column_filters, record_attnums_to_values)
 
     Health.put_event(consumer, %Event{slug: :messages_filtered, status: :success})
 
     table_matches? and column_filters_match?
   end
 
-  def matches_record?(
-        %SinkConsumer{schema_filter: %SchemaFilter{}} = consumer,
-        _table_oid,
-        _record_attnums_to_values
-      ) do
+  def matches_record?(%SinkConsumer{schema_filter: %SchemaFilter{}} = consumer, _table_oid, _record_attnums_to_values) do
     Health.put_event(consumer, %Event{slug: :messages_filtered, status: :success})
 
     true
@@ -1349,13 +1307,7 @@ defmodule Sequin.Consumers do
   defp check_filter_return(e, consumer) do
     val = e |> inspect() |> String.slice(0, 128)
     msg = "Filter functions must return true or false, got: #{val}"
-
-    Health.put_event(consumer, %Event{
-      slug: :messages_filtered,
-      status: :fail,
-      error: Error.invariant(message: msg)
-    })
-
+    Health.put_event(consumer, %Event{slug: :messages_filtered, status: :fail, error: Error.invariant(message: msg)})
     raise "filter function failed to return boolean"
   end
 
@@ -1369,9 +1321,7 @@ defmodule Sequin.Consumers do
     Enum.all?(column_filters, fn filter ->
       fields = if message.action == :delete, do: message.old_fields, else: message.fields
       field = Enum.find(fields, &(&1.column_attnum == filter.column_attnum))
-
-      field &&
-        apply_filter(filter.operator, coerce_field_value(field.value, filter), filter.value)
+      field && apply_filter(filter.operator, coerce_field_value(field.value, filter), filter.value)
     end)
   end
 
@@ -1392,9 +1342,7 @@ defmodule Sequin.Consumers do
     String.downcase(value)
   end
 
-  defp coerce_field_value(value, %ColumnFilter{jsonb_path: jsonb_path})
-       when jsonb_path in [nil, ""],
-       do: value
+  defp coerce_field_value(value, %ColumnFilter{jsonb_path: jsonb_path}) when jsonb_path in [nil, ""], do: value
 
   defp coerce_field_value(value, %ColumnFilter{jsonb_path: jsonb_path}) when is_map(value) do
     path = String.split(jsonb_path, ".")
@@ -1452,9 +1400,8 @@ defmodule Sequin.Consumers do
     not is_nil(field_value)
   end
 
-  defp apply_filter(op, field_value, %{value: filter_value})
-       when op in [:==, :!=, :>, :<, :>=, :<=],
-       do: apply(Kernel, op, [field_value, filter_value])
+  defp apply_filter(op, field_value, %{value: filter_value}) when op in [:==, :!=, :>, :<, :>=, :<=],
+    do: apply(Kernel, op, [field_value, filter_value])
 
   defp apply_filter(:is_null, field_value, _), do: is_nil(field_value)
   defp apply_filter(:not_null, field_value, _), do: not is_nil(field_value)
@@ -1643,11 +1590,7 @@ defmodule Sequin.Consumers do
   end
 
   def safe_evaluate_code(code) do
-    MiniElixir.run_interpreted(
-      %Function{function: %TransformFunction{code: code}},
-      synthetic_message().data
-    )
-
+    MiniElixir.run_interpreted(%Function{function: %TransformFunction{code: code}}, synthetic_message().data)
     :ok
   rescue
     error ->

--- a/lib/sequin/posthog.ex
+++ b/lib/sequin/posthog.ex
@@ -70,7 +70,7 @@ defmodule Sequin.Posthog do
     %{
       event: to_string(event),
       properties: merged_properties,
-      timestamp: DateTime.from_unix!(timestamp, :millisecond) |> DateTime.to_iso8601()
+      timestamp: timestamp |> DateTime.from_unix!(:millisecond) |> DateTime.to_iso8601()
     }
   end
 
@@ -92,26 +92,10 @@ defmodule Sequin.Posthog do
 
   defp async_post(body, opts) do
     unless disabled?(opts) do
-      Logger.info("[PostHog] Sending #{length(body.batch)} events to PostHog")
-
       Task.Supervisor.start_child(Sequin.TaskSupervisor, fn ->
-        result =
-          body
-          |> base_req(opts)
-          |> Req.run()
-
-        case result do
-          {_request, %{status: 200}} ->
-            Logger.info("[PostHog] Successfully sent events to PostHog")
-
-          {_request, %{status: status}} ->
-            Logger.warning("[PostHog] PostHog responded with status #{status}")
-
-          {:error, error} ->
-            Logger.error("[PostHog] Failed to send events: #{inspect(error)}")
-        end
-
-        result
+        body
+        |> base_req(opts)
+        |> Req.run()
       end)
     end
   end

--- a/lib/sequin/telemetry/posthog_reporter.ex
+++ b/lib/sequin/telemetry/posthog_reporter.ex
@@ -4,7 +4,7 @@ defmodule Sequin.Telemetry.PosthogReporter do
 
   require Logger
 
-  @default_publish_interval :timer.seconds(10)
+  @default_publish_interval :timer.minutes(1)
 
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
@@ -135,7 +135,8 @@ defmodule Sequin.Telemetry.PosthogReporter do
           message_count: total_count,
           bytes_processed: total_bytes,
           message_kind: base_metadata.properties.message_kind,
-          "$groups": base_metadata.properties[:"$groups"]
+          "$groups": base_metadata.properties[:"$groups"],
+          "$process_person_profile": base_metadata.properties[:"$process_person_profile"]
         }
       },
       timestamp

--- a/test/sequin/posthog_reporter_test.exs
+++ b/test/sequin/posthog_reporter_test.exs
@@ -101,7 +101,7 @@ defmodule Sequin.Telemetry.PosthogReporterTest do
 
     [event] = events
     assert event["event"] == "final_event"
-    assert event["distinct_id"] == "user_final"
+    assert event["properties"]["distinct_id"] == "user_final"
     assert event["properties"]["key"] == "value_final"
   end
 


### PR DESCRIPTION
1. Fix how we send `consumer_ack` events to PostHog
2. Batch `consumer_ack` events every minute (instead of every 10 seconds)