### PR TITLE
fix: only ignore esc keypress for the function code editor

### DIFF
--- a/assets/svelte/components/FullPageForm.svelte
+++ b/assets/svelte/components/FullPageForm.svelte
@@ -6,14 +6,13 @@
   export let title: string = "";
   let showConfirmDialog = false;
   export let showConfirmOnExit = true;
-  export let enableEscapeClose = true;
 
   const dispatch = createEventDispatcher();
 
   let listening = false;
 
   function handleEscapeKey(event: KeyboardEvent) {
-    if (event.key === "Escape" && !showConfirmDialog && enableEscapeClose) {
+    if (event.key === "Escape" && !showConfirmDialog) {
       event.preventDefault();
       if (showConfirmOnExit) {
         showConfirmDialog = true;

--- a/assets/svelte/functions/Edit.svelte
+++ b/assets/svelte/functions/Edit.svelte
@@ -492,6 +492,12 @@
     }
   }
 
+  function ignoreEscKeypress(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+    }
+  }
+
   onMount(() => {
     // Handle URL parameters for new functions
     if (!isEditing) {
@@ -656,7 +662,6 @@ Please help me create or modify the Elixir function transform to achieve the des
 <FullPageForm
   title={isEditing ? "Edit Function" : "New Function"}
   showConfirmOnExit={isDirty}
-  enableEscapeClose={false}
   on:close={handleClose}
 >
   <form on:submit={handleSubmit} class="space-y-4">
@@ -970,6 +975,7 @@ Please help me create or modify the Elixir function transform to achieve the des
                   <div
                     bind:this={functionEditorElement}
                     class="w-full max-w-3xl max-h-full bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-800 rounded-md overflow-hidden relative"
+                    on:keydown={ignoreEscKeypress}
                   >
                     <div
                       class="absolute bottom-2 right-2 flex items-center gap-2 z-10"


### PR DESCRIPTION
Fixes #1781 specifically for the function code editor, and not for the whole FullPageForm component as done by https://github.com/sequinstream/sequin/pull/1783