### PR TITLE
feat: allow users to configure postgres pool size

### DIFF
--- a/assets/svelte/databases/Form.svelte
+++ b/assets/svelte/databases/Form.svelte
@@ -55,6 +55,7 @@
     username: string;
     password: string;
     ssl: boolean;
+    pool_size: number;
     publication_name: string;
     slot_name: string;
     useLocalTunnel: boolean;
@@ -312,6 +313,7 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
       username: "",
       password: "",
       ssl: true,
+      pool_size: 10,
       publication_name: database.publication_name,
       slot_name: database.slot_name,
       useLocalTunnel: false,
@@ -493,6 +495,40 @@ sequin tunnel --ports=[your-local-port]:${form.name}`;
           </div>
           {#if databaseErrors.password}
             <p class="text-destructive text-sm">{databaseErrors.password}</p>
+          {/if}
+        </div>
+
+        <div class="space-y-2">
+          <Label for="pool_size" class="flex items-center">
+            Pool Size
+            <Tooltip.Root openDelay={200}>
+              <Tooltip.Trigger>
+                <HelpCircle
+                  class="inline-block h-4 w-4 text-gray-400 ml-1 cursor-help"
+                />
+              </Tooltip.Trigger>
+              <Tooltip.Content class="max-w-xs">
+                <p class="text-xs text-gray-500">
+                  <b>Pool Size</b>
+                  <br />
+                  The maximum number of concurrent connections that Sequin will maintain
+                  to your PostgreSQL database, aside from the replication slot connection.
+                  Higher values allow for better throughput but consume more database
+                  resources.
+                </p>
+              </Tooltip.Content>
+            </Tooltip.Root>
+          </Label>
+          <Input
+            type="number"
+            id="pool_size"
+            bind:value={form.pool_size}
+            placeholder="10"
+          />
+          {#if databaseErrors.pool_size}
+            <p class="text-destructive text-sm">
+              {databaseErrors.pool_size}
+            </p>
           {/if}
         </div>
 

--- a/lib/sequin/databases/postgres_database.ex
+++ b/lib/sequin/databases/postgres_database.ex
@@ -90,6 +90,7 @@ defmodule Sequin.Databases.PostgresDatabase do
     ])
     |> validate_required([:hostname, :database, :username, :password, :name])
     |> validate_number(:port, greater_than_or_equal_to: 0, less_than_or_equal_to: 65_535)
+    |> validate_number(:pool_size, greater_than_or_equal_to: 1)
     |> validate_not_supabase_pooled()
     |> cast_embed(:tables, with: &PostgresDatabaseTable.changeset/2, required: false)
     |> cast_embed(:primary, with: &PostgresDatabasePrimary.changeset/2, required: false)

--- a/lib/sequin/runtime/database_lifecycle_event_worker.ex
+++ b/lib/sequin/runtime/database_lifecycle_event_worker.ex
@@ -49,6 +49,7 @@ defmodule Sequin.Runtime.DatabaseLifecycleEventWorker do
 
       "update" ->
         with {:ok, %PostgresDatabase{} = db} <- Databases.get_db(id) do
+          Databases.ConnectionCache.invalidate_connection(db)
           db = Repo.preload(db, [:replication_slot])
           Runtime.Supervisor.restart_replication(db.replication_slot)
         end

--- a/lib/sequin_web/live/databases/form.ex
+++ b/lib/sequin_web/live/databases/form.ex
@@ -407,6 +407,7 @@ defmodule SequinWeb.DatabasesLive.Form do
       "username" => database.username || "postgres",
       "password" => database.password,
       "ssl" => ssl,
+      "pool_size" => database.pool_size || 10,
       "publication_name" => database.replication_slot.publication_name || "sequin_pub",
       "slot_name" => database.replication_slot.slot_name || "sequin_slot",
       "useLocalTunnel" => database.use_local_tunnel || false,
@@ -449,6 +450,14 @@ defmodule SequinWeb.DatabasesLive.Form do
         port when is_integer(port) -> port
       end
 
+    pool_size =
+      case form["pool_size"] do
+        nil -> nil
+        "" -> nil
+        pool_size when is_binary(pool_size) -> String.to_integer(pool_size)
+        pool_size when is_integer(pool_size) -> pool_size
+      end
+
     ssl = if form["useLocalTunnel"], do: false, else: form["ssl"]
     hostname = if form["useLocalTunnel"], do: Application.get_env(:sequin, :portal_hostname), else: form["hostname"]
 
@@ -463,6 +472,7 @@ defmodule SequinWeb.DatabasesLive.Form do
         "username" => maybe_trim(form["username"]),
         "password" => form["password"],
         "ssl" => ssl,
+        "pool_size" => pool_size,
         "use_local_tunnel" => form["useLocalTunnel"],
         "primary" => primary
       },


### PR DESCRIPTION
Allow users to specify pool size for Postgres Database connections

A user reported this behavior on [Slack](https://sequin-community.slack.com/archives/C0912LR0Y9F/p1749795449953879):

> Currently I'm using 12 databases to track on Sequin but the RDS connection count went more than 100 filtered by the sequin user. How do I debug this? Does Sequin re-use postgres connections or drop older connections? Because 100 connections for 12 databases seems huge.

Currently we have a fixed pool size of 10 for all connections, so these changes allow users to provide a number to fit their needs. Changing this number at runtime seems to work fine, and old pools get cleared out.

An additional change I made is to make sure that the Connection cache is cleared after the database configuration is updated, to make sure the old stale pool + replication slot connection is cleaned up

These changes do not apply for Replica mode, which we would need to handle separately.

---

<img width="884" alt="image" src="https://github.com/user-attachments/assets/b156a85d-b658-43d1-94a5-3cdff82a8ee8" />
