### PR TITLE
:zap: Improve default performance

### DIFF
--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -587,31 +587,6 @@
               <AccordionContent>
                 <div class="space-y-4 pt-4">
                   <div class="space-y-2">
-                    <Label for="max-memory">Memory limit</Label>
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <Input
-                          id="max-memory"
-                          type="number"
-                          min="128"
-                          bind:value={form.maxMemoryMb}
-                          class="w-32"
-                        />
-                        <span class="text-sm text-muted-foreground">MB</span>
-                      </div>
-                      <p class="text-xs font-light">
-                        The soft memory limit for this specific sink. Defaults
-                        to 128MB, which is a good starting point.
-                      </p>
-                    </div>
-                    {#if errors.consumer.max_memory_mb}
-                      <p class="text-destructive text-sm">
-                        {errors.consumer.max_memory_mb}
-                      </p>
-                    {/if}
-                  </div>
-
-                  <div class="space-y-2">
                     <Label for="timestamp-format">Timestamp format</Label>
                     <Select
                       selected={{

--- a/docs/reference/sinks/overview.mdx
+++ b/docs/reference/sinks/overview.mdx
@@ -58,11 +58,6 @@ You can click into any failed message to view the delivery logs and error detail
 
 ## Advanced configuration
 
-### Max memory usage
-When sink destinations can't keep up with incoming messages, Sequin continues to advance the Postgres replication slot and buffer messages in memory.
-
-By default, each sink is set to a max memory usage of 128MB. You can configure the max memory usage for a sink by setting the `max_memory_mb` parameter in the sink configuration.
-
 ### Load shedding policy
 If a sink's in-memory buffer fills up, the `load_shedding_policy` will be triggered. There are two available load shedding policies:
 

--- a/lib/sequin/runtime/kafka_pipeline.ex
+++ b/lib/sequin/runtime/kafka_pipeline.ex
@@ -16,17 +16,6 @@ defmodule Sequin.Runtime.KafkaPipeline do
   end
 
   @impl SinkPipeline
-  def processors_config(%SinkConsumer{}) do
-    [
-      default: [
-        concurrency: System.schedulers_online() * 2,
-        max_demand: 10,
-        min_demand: 5
-      ]
-    ]
-  end
-
-  @impl SinkPipeline
   def batchers_config(%SinkConsumer{batch_size: batch_size}) do
     [
       default: [

--- a/lib/sequin/runtime/message_handler.ex
+++ b/lib/sequin/runtime/message_handler.ex
@@ -345,8 +345,8 @@ defmodule Sequin.Runtime.MessageHandler do
     end
   end
 
-  @max_backoff_ms :timer.seconds(1)
-  @max_attempts 5
+  @max_backoff_ms 100
+  @max_attempts 15
   @decorate track_metrics("put_messages")
   defp put_messages(consumer, messages_to_ingest) do
     do_put_messages(consumer, messages_to_ingest)
@@ -359,7 +359,7 @@ defmodule Sequin.Runtime.MessageHandler do
         :ok
 
       {:error, %InvariantError{code: :payload_size_limit_exceeded}} when attempt <= @max_attempts ->
-        backoff = Sequin.Time.exponential_backoff(50, attempt, @max_backoff_ms)
+        backoff = Sequin.Time.exponential_backoff(5, attempt, @max_backoff_ms)
 
         Logger.debug(
           "[MessageHandler] Slot message store for consumer #{consumer.id} is full. " <>

--- a/lib/sequin/runtime/sink_pipeline.ex
+++ b/lib/sequin/runtime/sink_pipeline.ex
@@ -315,9 +315,9 @@ defmodule Sequin.Runtime.SinkPipeline do
   defp processors_config(pipeline_mod, consumer) do
     default = [
       default: [
-        concurrency: System.schedulers_online(),
-        max_demand: 10,
-        min_demand: 5
+        concurrency: System.schedulers_online() * 2,
+        max_demand: 150,
+        min_demand: 50
       ]
     ]
 

--- a/lib/sequin/runtime/slot_message_store_state.ex
+++ b/lib/sequin/runtime/slot_message_store_state.ex
@@ -15,7 +15,7 @@ defmodule Sequin.Runtime.SlotMessageStore.State do
   @type message :: ConsumerRecord.t() | ConsumerEvent.t()
   @type cursor_tuple :: {commit_lsn :: non_neg_integer(), commit_idx :: non_neg_integer()}
 
-  @default_setting_max_messages 500_000
+  @default_setting_max_messages 50_000
 
   typedstruct do
     field :consumer, SinkConsumer.t()
@@ -135,7 +135,7 @@ defmodule Sequin.Runtime.SlotMessageStore.State do
     unpersisted_cursor_tuples_for_table_reader_batches =
       Multiset.union(state.unpersisted_cursor_tuples_for_table_reader_batches, batch_id, MapSet.new(cursor_tuples))
 
-    case put_messages(state, messages) do
+    case put_messages(state, messages, skip_limit_check?: true) do
       {:ok, %State{} = state} ->
         {:ok,
          %{

--- a/lib/sequin/runtime/slot_processor_server.ex
+++ b/lib/sequin/runtime/slot_processor_server.ex
@@ -50,7 +50,7 @@ defmodule Sequin.Runtime.SlotProcessorServer do
 
   # 100 MB
   @max_accumulated_bytes 100 * 1024 * 1024
-  @max_accumulated_messages 100_000
+  @max_accumulated_messages 2500
   @backfill_batch_high_watermark Constants.backfill_batch_high_watermark()
 
   @config_schema Application.compile_env(:sequin, [Sequin.Repo, :config_schema_prefix])


### PR DESCRIPTION
- Use smaller, partitioned SlotMessageStores by default
- Tuned buffer sizes to optimal setting
- Increase demand settings for process_message (big impact)