### PR TITLE
🤫 do not tcp connect for endpoint health checks

### DIFF
--- a/assets/svelte/http_endpoints/Show.svelte
+++ b/assets/svelte/http_endpoints/Show.svelte
@@ -152,7 +152,7 @@
   </header>
 
   <div class="container mx-auto px-4 py-8">
-    <div class="grid gap-6 md:grid-cols-3 mb-8">
+    <div class="grid gap-6 md:grid-cols-2 mb-8">
       <HealthSummary health={http_endpoint.health} {pushEvent} />
       <Card>
         <CardContent class="p-6">
@@ -161,22 +161,6 @@
             <Activity class="h-5 w-5 text-blue-500" />
           </div>
           <span class="text-2xl font-bold">{metrics.throughput} req/min</span>
-        </CardContent>
-      </Card>
-      <Card>
-        <CardContent class="p-6">
-          <div class="flex justify-between items-center mb-4">
-            <span class="text-sm font-medium text-gray-500">Avg. Latency</span>
-            <Clock class="h-5 w-5 text-green-500" />
-          </div>
-          {#if metrics.avg_latency}
-            <span class="text-2xl font-bold">{metrics.avg_latency} ms</span>
-          {:else}
-            <div class="flex items-center">
-              <Loader2 class="h-6 w-6 text-gray-500 animate-spin mr-2" />
-              <span class="text-2xl font-bold text-gray-500">ms</span>
-            </div>
-          {/if}
         </CardContent>
       </Card>
     </div>

--- a/lib/sequin/metrics/metrics.ex
+++ b/lib/sequin/metrics/metrics.ex
@@ -91,15 +91,6 @@ defmodule Sequin.Metrics do
     Store.get_throughput("http_endpoint_throughput:#{id}")
   end
 
-  # HTTP Endpoint Average Latency
-  def measure_http_endpoint_avg_latency(%HttpEndpoint{id: id}, latency) do
-    Store.measure_latency("http_endpoint_avg_latency:#{id}", latency)
-  end
-
-  def get_http_endpoint_avg_latency(%HttpEndpoint{id: id}) do
-    Store.get_latency("http_endpoint_avg_latency:#{id}")
-  end
-
   def measure_postgres_replication_slot_lag(%PostgresReplicationSlot{id: id}, lag_bytes) do
     Store.measure_gauge("postgres_replication_slot_lag:#{id}", lag_bytes)
   end

--- a/lib/sequin_web/live/http_endpoints/show.ex
+++ b/lib/sequin_web/live/http_endpoints/show.ex
@@ -101,16 +101,8 @@ defmodule SequinWeb.HttpEndpointsLive.Show do
 
     {:ok, throughput} = Metrics.get_http_endpoint_throughput(http_endpoint)
 
-    avg_latency =
-      case Metrics.get_http_endpoint_avg_latency(http_endpoint) do
-        {:ok, nil} -> nil
-        {:ok, avg_latency} -> round(avg_latency)
-        {:error, _} -> nil
-      end
-
     metrics = %{
-      throughput: Float.round(throughput * 60, 1),
-      avg_latency: avg_latency
+      throughput: Float.round(throughput * 60, 1)
     }
 
     assign(socket, :metrics, metrics)


### PR DESCRIPTION
This prevents errors such as 415s from downstream http endpoints.

However, this significantly reduces the thoroughness of HTTP Endpoint health checks. The check now passes so long as the hostname is resolvable. Additionally, the avg. latency is now reported as just the time it takes to translate the hostname to an IP address. This often hits local DNS servers, which are typically very fast, rather than the actual HTTP endpoint
