### PR TITLE
🎨 Adjust sink type icon grid to make room for more sinks

### DIFF
--- a/assets/svelte/consumers/SinkIndex.svelte
+++ b/assets/svelte/consumers/SinkIndex.svelte
@@ -458,14 +458,17 @@
       </DialogDescription>
     </DialogHeader>
     <div class="flex-1 overflow-y-auto">
-      <div class="grid grid-cols-3 gap-4 py-4">
+      <div class="grid grid-cols-4 gap-4 py-4">
         {#each sinks as dest}
           <LinkPatchNavigate href={`/sinks/new?kind=${dest.id}`}>
             <Label
               for={dest.id}
               class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground text-center leading-tight cursor-pointer"
             >
-              <svelte:component this={dest.icon} class="mb-3 h-12 w-12" />
+              <svelte:component
+                this={dest.icon}
+                class="mb-4 h-10 w-10 flex items-center justify-center"
+              />
               {dest.name}
             </Label>
           </LinkPatchNavigate>

--- a/assets/svelte/sinks/redis_shared/RedisIcon.svelte
+++ b/assets/svelte/sinks/redis_shared/RedisIcon.svelte
@@ -1,5 +1,5 @@
 <svg
-  viewBox="-18 -18 292 292"
+  viewBox="0 0 256 185"
   xmlns="http://www.w3.org/2000/svg"
   class={$$props.class}
 >


### PR DESCRIPTION
Adjust Sink Type icon select grid from 3 to 4 columns to make room for more sinks, such as the meilisearch one that is almost ready.

Also slightly improve the redis icon to have less whitespace around the inner box

### Before
<img width="1800" alt="Before Icons" src="https://github.com/user-attachments/assets/7382c7d0-ab2e-4791-8884-90e42afc35fd" />

### After
<img width="1800" alt="After Icons" src="https://github.com/user-attachments/assets/89f61f8d-ff75-40f2-a991-ce2677e76db2" />

