### PR TITLE
🔧 Fix esbuild-svelte warning

### DIFF
--- a/assets/svelte/components/FilterForm.svelte
+++ b/assets/svelte/components/FilterForm.svelte
@@ -8,7 +8,6 @@
     actions: string[];
     filterId: string;
   };
-  export let errors: any;
   export let showTitle: boolean = true;
   export let functions: Array<{
     id: string;

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -373,7 +373,6 @@
           messageKind={form.messageKind}
           {selectedDatabase}
           bind:form
-          {errors}
           {refreshFunctions}
           {functionRefreshState}
           showTitle={false}

--- a/assets/svelte/wal_pipelines/Form.svelte
+++ b/assets/svelte/wal_pipelines/Form.svelte
@@ -160,7 +160,6 @@
               messageKind="event"
               selectedTable={selectedSourceTable}
               bind:form
-              {errors}
               onFilterChange={(filters) => (form.sourceTableFilters = filters)}
             />
           {/if}


### PR DESCRIPTION
Fix this esbuild-svelte warning showing up when starting the app:

Seems like since commit [ce5e6b7](https://github.com/sequinstream/sequin/commit/ce5e6b7af00bf65154779c91f4372e46d0e21704) we no longer are displaying errors in the `FilterForm` component, so it seems safe to remove the `export` and the corresponding prop being passed from parent components.

```
▲ [WARNING] [plugin esbuild-svelte] FilterForm has unused export property 'errors'. If it is for external
reference only, please consider using `export const errors`

    svelte/components/FilterForm.svelte:6:11:
      6 │ export let errors;
        ╵            ~~~~~~

  The plugin "esbuild-svelte" was triggered by this import

    import-glob:../svelte/**/*.svelte:2:757:
      2 │ ...dule11 from '../svelte/components/FilterForm.svelte';import * as...
        ╵                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```