### PR TITLE
⚙️  Set low timeout on filtered messages batcher

### DIFF
--- a/lib/sequin/runtime/sink_pipeline.ex
+++ b/lib/sequin/runtime/sink_pipeline.ex
@@ -349,7 +349,8 @@ defmodule Sequin.Runtime.SinkPipeline do
       ],
       filtered_messages: [
         concurrency: 10,
-        batch_size: 100
+        batch_size: 100,
+        batch_timeout: 10
       ]
     ]
 


### PR DESCRIPTION
This ensures we will move through group_ids with all filtered messages
more quickly. The default for this is 1000ms, so this is a 100x speed
up.