### PR TITLE
✨ Add sink-level `message_grouping` attribute

### DIFF
--- a/docs/concepts/consistency-model.mdx
+++ b/docs/concepts/consistency-model.mdx
@@ -80,7 +80,16 @@ However, while Sequin reads from the replication slot in serial, it delivers to 
 
 To achieve high throughput with strict ordering, Sequin partitions messages into **message groups**. Messages that belong to the same group are delivered to the sink in order. By default, the primary key value(s) of the source row are used to group messages. So, a create, update, and delete affecting the same row will be grouped together. And, therefore, delivered in order to the sink.
 
-You can specify how to group messages when setting up a sink. You can, for example, decide to group messages by a single column (e.g. "deliver all messages pertaining to this `account_id` in order").
+### Configuring message grouping
+
+You can control message grouping behavior using the `message_grouping` configuration option when setting up a sink:
+
+- `message_grouping: true` (default): Enable message grouping for ordered delivery within groups
+- `message_grouping: false`: Disable message grouping for maximum throughput without ordering guarantees
+
+When message grouping is enabled, by default the primary keys of each table are used to group messages (e.g. "deliver all messages pertaining to row with `id=1` in order"). You can also specify custom grouping columns at the table level. For example, you can group messages by a single column like `account_id` to ensure all messages pertaining to the same account are delivered in order.
+
+When message grouping is disabled, messages are delivered without considering groups. This may permit higher throughput for some sinks.
 
 <Note>
   Choosing too course-grained of a group can slow throughput, as Sequin will be able to deliver fewer messages in parallel.
@@ -150,6 +159,6 @@ Sequin's backfill worker avoids those traps:
 
 If a message fails to process or deliver to the sink, Debezium will halt the entire pipeline until the issue is cleared.
 
-By contrast, Sequin uses a dead letter queue concept to persist the message to an internal buffer and retry delivery. 
+By contrast, Sequin uses a dead letter queue concept to persist the message to an internal buffer and retry delivery.
 
 This means Sequin is more resilient to outlier and temporary issues, giving your team more time to respond to issues.

--- a/docs/how-to/stream-postgres-to-gcp-pubsub.mdx
+++ b/docs/how-to/stream-postgres-to-gcp-pubsub.mdx
@@ -83,10 +83,15 @@ In Sequin, navigate to the "Sinks" tab, click "Create Sink", and select "Pub/Sub
     You can backfill at any time. If you don't want to backfill, toggle "Backfill" off.
   </Step>
 
-  <Step title="Specify message grouping">
-    Under "Message grouping", you'll most likely want to leave the default option selected to ensure events for the same row are sent to Pub/Sub in order.
+  <Step title="Configure message grouping">
+    Under "Message grouping", you can control how messages are grouped for ordering:
 
-    That way, if you're using a Pub/Sub subscription with "message ordering" enabled, your system will receive events for a row in the [same order they occurred in Postgres](reference/sinks/gcp-pubsub#grouping-and-ordering).
+    - **Enable message grouping** (default): Messages are grouped by primary key to ensure ordered delivery within each group. This is recommended if you plan to use Pub/Sub subscriptions with "message ordering" enabled.
+    - **Disable message grouping**: Messages are not grouped, allowing for higher throughput but without ordering guarantees.
+
+    If you enable message grouping, you can also specify custom grouping columns at the table level to group by fields other than the primary key (e.g., group orders by `customer_id`).
+
+    When message grouping is enabled and you use a Pub/Sub subscription with "message ordering" enabled, your system will receive events for each group in the [same order they occurred in Postgres](/reference/sinks/gcp-pubsub#grouping-and-ordering).
   </Step>
 </Steps>
 

--- a/docs/management-api/sink-consumers/create.mdx
+++ b/docs/management-api/sink-consumers/create.mdx
@@ -270,6 +270,12 @@ Creates a new sink consumer.
   Column names used for grouping records
 </ParamField>
 
+<ParamField body="message_grouping" type="boolean">
+  Whether to enable message grouping for ordering purposes. When `true` (default), messages are grouped by primary key or custom grouping columns. When `false`, grouping is disabled for higher throughput batching.
+  
+  Cannot be used with `group_column_names` when set to `false`.
+</ParamField>
+
 <ParamField body="max_retry_count" type="integer">
   The maximum number of times a message will be retried if delivery fails. Once this limit is reached, the message will be discarded.
 

--- a/docs/management-api/sink-consumers/update.mdx
+++ b/docs/management-api/sink-consumers/update.mdx
@@ -46,6 +46,12 @@ The request body can include any of the following fields:
   Possible values include `insert`, `update`, `delete`.
 </ParamField>
 
+<ParamField body="message_grouping" type="boolean">
+  Whether to enable [message grouping](/reference/sinks/overview#message-grouping-and-ordering) for ordering purposes. When `true` (default), messages are grouped by primary key or custom grouping columns. When `false`, grouping is disabled for higher throughput batching.
+
+  Cannot be used with `group_column_names` when set to `false`.
+</ParamField>
+
 <ParamField body="max_retry_count" type="integer">
   The maximum number of times a message will be retried if delivery fails. Once this limit is reached, the message will be discarded.
 
@@ -270,6 +276,6 @@ The request body can include any of the following fields:
       "batch_size": 50
     }'
   ```
-</RequestExample> 
+</RequestExample>
 
 <SinkConsumerResponseExample />

--- a/docs/reference/sequin-yaml.mdx
+++ b/docs/reference/sequin-yaml.mdx
@@ -174,6 +174,7 @@ sinks:
       - insert
       - update
       - delete
+    message_grouping: true         # Optional, enable message grouping, default: true
     tables:                        # Optional, table specific configuration
       - name: "public.users"
         group_column_names:        # Optional, custom group column names
@@ -200,6 +201,28 @@ You can also specify schemas and tables to include or exclude from the stream.
 #### Sink actions
 
 Additionally, you can specify `actions` to stream. By default, all actions (`insert`, `update`, `delete`) are included.  `read` events are emitted during backfills and are always included.
+
+#### Message grouping
+
+The `message_grouping` field controls whether messages are grouped for ordering purposes. When enabled (default), messages are grouped by primary key or custom grouping columns, ensuring ordered delivery within each group. When disabled, messages are not grouped, which may allow for higher throughput for some sinks.
+
+- `true` (default): Enable message grouping. Messages are grouped by primary key unless overridden by table-level `group_column_names`
+- `false`: Disable message grouping. Cannot be used with table-level `group_column_names`
+
+```yaml
+sinks:
+  - name: "ordered-sink"
+    message_grouping: true  # Default, enables ordering
+    tables:
+      - name: "public.users"
+        group_column_names: ["account_id"]  # Custom grouping
+
+  - name: "high-throughput-sink"
+    message_grouping: false
+    tables:
+      - name: "public.events"
+        # group_column_names not allowed when message_grouping is false
+```
 
 #### Sink functions
 

--- a/docs/reference/sinks/gcp-pubsub.mdx
+++ b/docs/reference/sinks/gcp-pubsub.mdx
@@ -77,7 +77,7 @@ By default, Sequin publishes messages to Pub/Sub one at a time (`batch_size=1`).
 
 If you don't need message ordering in Pub/Sub, you can significantly improve throughput by:
 
-1. **Disabling message grouping** - Set `group_column_names` to an empty array in your configuration
+1. **Disabling message grouping** - Set `message_grouping: false` at the sink level
 2. **Increasing batch size** - Set `batch_size` to a higher value (e.g., 100-1000)
 
 Here's an example configuration for high throughput:
@@ -85,16 +85,17 @@ Here's an example configuration for high throughput:
 ```yaml
 sinks:
   - name: my_pubsub_sink
+    message_grouping: false  # Disables message grouping and ordering key
     batch_size: 300
     tables:
       - name: public.my_table
-        group_column_names: []  # Disables ordering key
+        # group_column_names not allowed when message_grouping is false
 ```
 
-When grouping is disabled, Sequin will not set an `ordering_key` on the published messages, allowing Pub/Sub to process them in parallel for maximum throughput.
+When `message_grouping` is disabled, Sequin will not set an `ordering_key` on the published messages, allowing Pub/Sub to process them in parallel for maximum throughput.
 
 <Note>
-  Editing these settings in the Sequin web console is coming soon (July 2025). For now, you can configure batching and grouping using YAML configuration or the Sequin API.
+  Editing message grouping settings in the Sequin web console is coming soon (July 2025). For now, you can configure message grouping using YAML configuration or the Sequin API.
 </Note>
 
 ## Debugging

--- a/docs/reference/sinks/overview.mdx
+++ b/docs/reference/sinks/overview.mdx
@@ -30,11 +30,35 @@ By default, Sequin retries messages indefinitely. You can configure a maximum nu
 
 Sequin has the ability to group messages by one or more fields. Changes for rows in the same group are guaranteed to arrive in the order they occurred (i.e. the order they were committed in Postgres) to your sink.
 
-By default, Sequin groups messages by the primary key value(s) of the source row. This means that if a row is updated multiple times, each update event will arrive in order to your sink.
+### Enabling/disabling message grouping
 
-You can specify message grouping behavior when configuring a sink. You can group rows by a single field or multiple fields.
+You can control message grouping behavior using the `message_grouping` configuration option:
 
-So, for example, instead of grouping by primary key, you could instead group `orders` by `account_id`. This means that all changes for a given `account_id` will be sent to your sink in the order they were committed in Postgres.
+- `message_grouping: true` (default): Enable message grouping for ordered delivery
+- `message_grouping: false`: Disable message grouping for maximum throughput
+
+When `message_grouping` is enabled, Sequin groups messages by the primary key value(s) of the source row by default. This means that if a row is updated multiple times, each update event will arrive in order to your sink.
+
+When `message_grouping` is disabled, messages are not grouped, allowing for higher throughput batching but without ordering guarantees.
+
+### Custom grouping columns
+
+When message grouping is enabled, you can specify custom grouping behavior by configuring `group_column_names` at the table level. You can group rows by a single field or multiple fields.
+
+For example, instead of grouping by primary key, you could group `orders` by `account_id`. This means that all changes for a given `account_id` will be sent to your sink in the order they were committed in Postgres.
+
+```yaml
+sinks:
+  - name: "ordered-sink"
+    message_grouping: true  # Enable grouping
+    tables:
+      - name: "public.orders"
+        group_column_names: ["account_id"]  # Custom grouping
+
+  - name: "high-throughput-sink"
+    message_grouping: false  # Disable grouping for max throughput
+    batch_size: 300
+```
 
 All this applies to how Sequin _delivers_ messages to your sink. Whether your sink supports ordered/FIFO processing depends on the sink. See the reference page for your sink for details.
 

--- a/docs/reference/sinks/sqs.mdx
+++ b/docs/reference/sinks/sqs.mdx
@@ -69,11 +69,36 @@ If SQS rejects a message, Sequin will cancel the message's delivery.
 
 ## Grouping and ordering
 
-When you configure an SQS sink, you can specify message grouping behavior. This will be used to set the `MessageGroupId` on the SQS message if you're using a FIFO queue.
+You can control message grouping behavior using the `message_grouping` configuration option:
 
-The default message group for a message is the source row's primary key(s). You can override this by specifying one or more columns to use for message grouping.
+- `message_grouping: true` (default): Enable message grouping for ordered delivery
+- `message_grouping: false`: Disable message grouping for maximum throughput
+
+When `message_grouping` is enabled, Sequin will set the `MessageGroupId` on SQS messages if you're using a FIFO queue. The default message group for a message is the source row's primary key(s). You can override this by specifying one or more columns to use for message grouping at the table level.
+
+When `message_grouping` is disabled, no `MessageGroupId` is set, allowing for higher throughput but without ordering guarantees.
 
 Sequin will order the delivery of messages with the same group according to their commit timestamp.
+
+```yaml
+sinks:
+  - name: "sqs-ordered"
+    message_grouping: true  # Enable grouping
+    batch_size: 10
+    tables:
+      - name: "public.orders"
+        group_column_names: ["customer_id"]  # Group by customer instead of PK
+    destination:
+      type: "sqs"
+      queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/orders.fifo"
+
+  - name: "sqs-high-throughput"
+    message_grouping: false  # Disable grouping for max throughput
+    batch_size: 10
+    destination:
+      type: "sqs"
+      queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/events"
+```
 
 ### FIFO vs standard queues
 

--- a/docs/snippets/sink-consumer-response-snippet.mdx
+++ b/docs/snippets/sink-consumer-response-snippet.mdx
@@ -293,3 +293,6 @@
 <ResponseField name="group_column_names" type="array" >
     Column names used for grouping records
 </ResponseField>
+<ResponseField name="message_grouping" type="boolean" >
+    Whether [message grouping](/reference/sinks/overview#message-grouping-and-ordering) is enabled for ordering purposes. When `true` (default), messages are grouped by primary key or custom grouping columns. When `false`, grouping is disabled for higher throughput batching.
+</ResponseField>

--- a/priv/repo/migrations/20250625183900_add_message_grouping_to_sink_consumers.exs
+++ b/priv/repo/migrations/20250625183900_add_message_grouping_to_sink_consumers.exs
@@ -1,0 +1,11 @@
+defmodule Sequin.Repo.Migrations.AddMessageGroupingToSinkConsumers do
+  use Ecto.Migration
+
+  @config_schema Application.compile_env(:sequin, [Sequin.Repo, :config_schema_prefix])
+
+  def change do
+    alter table(:sink_consumers, prefix: @config_schema) do
+      add :message_grouping, :boolean, default: true, null: false
+    end
+  end
+end

--- a/test/sequin/yaml_loader_test.exs
+++ b/test/sequin/yaml_loader_test.exs
@@ -1114,6 +1114,42 @@ defmodule Sequin.YamlLoaderTest do
       assert [%ConsumersSourceTable{group_column_attnums: [1]}] = consumer.source_tables
     end
 
+    test "sets message_grouping field" do
+      YamlLoader.apply_from_yml!("""
+      #{account_and_db_yml()}
+
+      sinks:
+        - name: "message-grouping-consumer"
+          database: "test-db"
+          message_grouping: false
+          tables:
+            - name: "Characters"
+          destination:
+            type: "sequin_stream"
+      """)
+
+      assert [consumer] = Repo.all(SinkConsumer)
+      assert consumer.message_grouping == false
+    end
+
+    test "fails when message_grouping is false but group_column_names are specified" do
+      assert_raise RuntimeError, ~r/Cannot specify group columns when message_grouping is disabled/, fn ->
+        YamlLoader.apply_from_yml!("""
+        #{account_and_db_yml()}
+
+        sinks:
+          - name: "invalid-grouping-consumer"
+            database: "test-db"
+            message_grouping: false
+            tables:
+              - name: "Characters"
+                group_column_names: ["id"]
+            destination:
+              type: "sequin_stream"
+        """)
+      end
+    end
+
     test "fails when group_column_names contains non-existent column" do
       assert_raise RuntimeError, ~r/Failed to parse tables.*No `postgres column` found.*non_existent_column/, fn ->
         YamlLoader.apply_from_yml!("""


### PR DESCRIPTION
Allows for setting whether a sink should order messages or not.