### PR TITLE
🐛 Fix NATS routing details in NatsSinkCard

### DIFF
--- a/assets/svelte/sinks/nats/NatsSinkCard.svelte
+++ b/assets/svelte/sinks/nats/NatsSinkCard.svelte
@@ -91,15 +91,12 @@
                 class="underline">router</a
               >
               <ExternalLink class="h-4 w-4 inline" />
-            {:else if consumer.sequence.table_name}
-              {#if consumer.message_kind === "event"}
-                sequin.changes.{consumer.postgres_database.name}.{consumer
-                  .sequence.table_schema}.{consumer.sequence
-                  .table_name}.{"{action}"}
-              {:else}
-                sequin.rows.{consumer.postgres_database.name}.{consumer.sequence
-                  .table_schema}.{consumer.sequence.table_name}
-              {/if}
+            {:else if consumer.message_kind === "event"}
+              sequin.changes.{consumer.database
+                .name}.&lt;table_schema&gt;.&lt;table_name&gt;.&lt;action&gt;
+            {:else}
+              sequin.rows.{consumer.database
+                .name}.&lt;table_schema&gt;.&lt;table_name&gt;
             {/if}
           </span>
         </div>


### PR DESCRIPTION
Currently the UI crashes if you try loading a NATS sink without a routing function with the following error. This is a quick fix to get the views loading with some details, we can work on showing as many _dynamic_ details as possible (such as table_name or schema_name) later on

```
Uncaught TypeError: Cannot read properties of undefined (reading 'table_name')
    at select_block_type (NatsSinkCard.svelte:94:41)
    at Array.create_default_slot_188 (NatsSinkCard.svelte:94:51)
    at create_slot (utils.js:165:22)
    at create_fragment288 (index.ts:1:1)
    at init3 (Component.js:148:34)
    at new Card_content (card-content.svelte:11:55)
    at Array.create_default_slot170 (NatsSinkCard.svelte:109:26)
    at create_slot (utils.js:165:22)
    at create_fragment293 (card-title.svelte:16:12)
```