### PR TITLE
Add routing for RabbitMQ sink

### DIFF
--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -575,7 +575,13 @@
         bind:functionRefreshState
       />
     {:else if consumer.type === "rabbitmq"}
-      <RabbitMqSinkForm errors={errors.consumer} bind:form />
+      <RabbitMqSinkForm
+        errors={errors.consumer}
+        bind:form
+        {functions}
+        {refreshFunctions}
+        bind:functionRefreshState
+      />
     {:else if consumer.type === "azure_event_hub"}
       <AzureEventHubSinkForm errors={errors.consumer} bind:form />
     {:else if consumer.type === "typesense"}

--- a/assets/svelte/consumers/dynamicRoutingDocs.ts
+++ b/assets/svelte/consumers/dynamicRoutingDocs.ts
@@ -167,4 +167,27 @@ export const routedSinkDocs: Record<RoutedSinkType, RoutedSinkDocs> = {
       },
     },
   },
+  rabbitmq: {
+    fields: {
+      exchange: {
+        description: "RabbitMQ exchange to publish to",
+        staticValue: "<empty>",
+        staticFormField: "exchange",
+        dynamicDefault: "<empty>",
+      },
+      routing_key: {
+        description: "RabbitMQ routing key to publish to",
+        staticValue:
+          "sequin.<database_name>.<table_schema>.<table_name>.<action>",
+        dynamicDefault:
+          "sequin.<database_name>.<table_schema>.<table_name>.<action>",
+      },
+      headers: {
+        description: "Map of header key value pairs",
+        staticValue: "%{}",
+        staticFormField: "headers",
+        dynamicDefault: "%{}",
+      },
+    },
+  },
 };

--- a/assets/svelte/consumers/types.ts
+++ b/assets/svelte/consumers/types.ts
@@ -154,7 +154,8 @@ export type RabbitMqConsumer = BaseConsumer & {
     type: "rabbitmq";
     host: string;
     port: number;
-    exchange: string;
+    exchange: string | null;
+    headers: Record<string, string> | null;
     topic: string;
     username: string;
     password?: string;
@@ -292,6 +293,7 @@ export const RoutedSinkTypeValues = [
   "typesense",
   "meilisearch",
   "elasticsearch",
+  "rabbitmq",
   "sqs",
   "sns",
 ] as const;

--- a/assets/svelte/functions/Edit.svelte
+++ b/assets/svelte/functions/Edit.svelte
@@ -105,6 +105,7 @@
     kafka: "Kafka",
     meilisearch: "Meilisearch",
     nats: "NATS",
+    rabbitmq: "RabbitMQ",
     redis_stream: "Redis Stream",
     redis_string: "Redis String",
     typesense: "Typesense",

--- a/assets/svelte/sinks/rabbitmq/RabbitMqSinkCard.svelte
+++ b/assets/svelte/sinks/rabbitmq/RabbitMqSinkCard.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { Card, CardContent } from "$lib/components/ui/card";
+  import {
+    Card,
+    CardHeader,
+    CardTitle,
+    CardContent,
+  } from "$lib/components/ui/card";
   import type { RabbitMqConsumer } from "../../consumers/types";
 
   export let consumer: RabbitMqConsumer;
@@ -8,7 +13,7 @@
 <Card>
   <CardContent class="p-6">
     <div class="flex justify-between items-center mb-4">
-      <h2 class="text-lg font-semibold">RabbitMQ configuration</h2>
+      <h2 class="text-lg font-semibold">RabbitMQ Configuration</h2>
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -17,7 +22,7 @@
         <div class="mt-2">
           <div class="overflow-x-auto">
             <span
-              class="font-mono bg-slate-50 pl-1 pr-4 py-1 border border-slate-100 rounded-md inline-block whitespace-nowrap"
+              class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md inline-block whitespace-nowrap"
               >{consumer.sink.host}</span
             >
           </div>
@@ -28,7 +33,7 @@
         <span class="text-sm text-gray-500">Port</span>
         <div class="mt-2">
           <span
-            class="font-mono bg-slate-50 pl-1 pr-4 py-1 border border-slate-100 rounded-md whitespace-nowrap"
+            class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md whitespace-nowrap"
             >{consumer.sink.port}</span
           >
         </div>
@@ -38,7 +43,7 @@
         <span class="text-sm text-gray-500">Virtual Host</span>
         <div class="mt-2">
           <span
-            class="font-mono bg-slate-50 pl-1 pr-4 py-1 border border-slate-100 rounded-md whitespace-nowrap"
+            class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md whitespace-nowrap"
             >{consumer.sink.virtual_host}</span
           >
         </div>
@@ -48,33 +53,76 @@
         <span class="text-sm text-gray-500">Username</span>
         <div class="mt-2">
           <span
-            class="font-mono bg-slate-50 pl-1 pr-4 py-1 border border-slate-100 rounded-md whitespace-nowrap"
+            class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md whitespace-nowrap"
             >{consumer.sink.username || "-"}</span
           >
         </div>
       </div>
-
+    </div>
+  </CardContent>
+</Card>
+<Card>
+  <CardHeader>
+    <CardTitle>Routing</CardTitle>
+  </CardHeader>
+  <CardContent>
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div>
         <span class="text-sm text-gray-500">Exchange</span>
         <div class="mt-2">
           <span
-            class="font-mono bg-slate-50 pl-1 pr-4 py-1 border border-slate-100 rounded-md whitespace-nowrap"
-            >{consumer.sink.exchange}</span
+            class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md whitespace-nowrap"
           >
+            {#if consumer.routing_id}
+              determined-by-router
+            {:else}
+              {consumer.sink.exchange}
+            {/if}
+          </span>
         </div>
       </div>
 
       <div>
-        <span class="text-sm text-gray-500">Topic</span>
+        <span class="text-sm text-gray-500">Headers</span>
         <div class="mt-2">
-          <div class="overflow-x-auto">
-            <span
-              class="font-mono bg-slate-50 pl-1 pr-4 py-1 border border-slate-100 rounded-md inline-block whitespace-nowrap"
-              >{consumer.sink.topic}</span
-            >
-          </div>
+          <span
+            class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md break-all w-fit whitespace-nowrap"
+          >
+            {#if consumer.routing_id}
+              determined-by-router
+            {:else}
+              {JSON.stringify(consumer.sink.headers || {})}
+            {/if}
+          </span>
+        </div>
+      </div>
+
+      <div>
+        <span class="text-sm text-gray-500">Routing Key</span>
+        <div class="mt-2">
+          <span
+            class="font-mono bg-slate-50 px-2 py-1 border border-slate-100 rounded-md whitespace-nowrap"
+          >
+            {#if consumer.routing_id}
+              determined-by-router
+            {:else}
+              sequin.database_name.table_schema.table_name.action
+            {/if}
+          </span>
         </div>
       </div>
     </div>
+
+    {#if consumer.routing}
+      <div class="mt-4">
+        <span class="text-sm text-gray-500">Router</span>
+        <div class="mt-2">
+          <pre
+            class="font-mono bg-slate-50 p-2 border border-slate-100 rounded-md text-sm overflow-x-auto"><code
+              >{consumer.routing.function.code}</code
+            ></pre>
+        </div>
+      </div>
+    {/if}
   </CardContent>
 </Card>

--- a/config/test.exs
+++ b/config/test.exs
@@ -110,6 +110,7 @@ config :sequin,
   redis_module: Sequin.Sinks.RedisMock,
   kafka_module: Sequin.Sinks.KafkaMock,
   nats_module: Sequin.Sinks.NatsMock,
+  rabbitmq_module: Sequin.Sinks.RabbitMqMock,
   # Arbitrarily high memory limit for testing
   max_memory_bytes: 100 * 1024 * 1024 * 1024,
   slot_message_store: [flush_batch_size: 8],

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
 
   rabbitmq:
     profiles: [rabbitmq]
-    image: rabbitmq:3.12-management-alpine
+    image: rabbitmq:3.13-management-alpine
     ports:
       - "127.0.0.1:5672:5672"  # AMQP protocol port
       - "127.0.0.1:15672:15672"  # Management UI port

--- a/docs/quickstart/rabbitmq.mdx
+++ b/docs/quickstart/rabbitmq.mdx
@@ -86,11 +86,11 @@ By the end, you'll have hands-on experience setting up Postgres change data capt
       2. Find the "Bindings" section and expand it if needed
       3. In "Add binding to this queue", enter:
          - From exchange: sequin
-         - Routing key: `sequin.changes.sequin-playground.public.products.*`
+         - Routing key: `sequin.sequin_playground.public.products.*`
       4. Click "Bind"
 
       This routing key pattern will match all changes to the products table. The format is:
-      `sequin.changes.<database>.<schema>.<table>.<action>`
+      `sequin.<database_name>.<table_schema>.<table_name>.<action>`
 
       <Frame>
         <img style={{ maxWidth: '700px' }} src="/images/quickstart/rabbitmq/add-binding.png" alt="Adding a binding in RabbitMQ" />

--- a/docs/reference/routing.mdx
+++ b/docs/reference/routing.mdx
@@ -42,6 +42,7 @@ The following sinks support dynamic routing:
 - Meilisearch
 - Elasticsearch
 - AWS SQS
+- RabbitMQ
 
 Each sink type has different fields that can be routed:
 
@@ -135,6 +136,16 @@ For [AWS SQS](/reference/sinks/sqs), your routing function must return a map wit
 | Key | Type | Description | Example |
 |-----|------|-------------|---------|
 | `queue_url` | String | The queue URL to publish to | `"https://sqs.us-east-1.amazonaws.com/123456789012/users"` |
+
+### RabbitMQ sink
+
+For [RabbitMQ](/reference/sinks/rabbitmq), your routing function must return a map with these keys:
+
+| Key | Type | Description | Example |
+|-----|------|-------------|---------|
+| `exchange` | String | The exchange to publish to | `"sequin"` |
+| `routing_key` | String | The routing key to publish to | `"sequin.users.insert"` |
+| `headers` | Map | AMQP headers to include | `%{"x-key" => "value"}` |
 
 ## Common routing patterns
 

--- a/docs/reference/sinks/rabbitmq.mdx
+++ b/docs/reference/sinks/rabbitmq.mdx
@@ -46,23 +46,17 @@ Sequin sends messages to RabbitMQ as JSON. You can find the shape of the message
 
 ## Routing keys
 
-Messages are published with routing keys using the following patterns:
+Messages are published with routing keys using the following pattern:
 
-For change events:
 ```
-sequin.changes.<database_name>.<schema_name>.<table_name>.<action>
-```
-
-For record events:
-```
-sequin.rows.<database_name>.<schema_name>.<table_name>
+sequin.<database_name>.<schema_name>.<table_name>.<action>
 ```
 
-For example, if you're streaming changes from a table called `products` in the `public` schema of a database called `shop`, you would see routing keys like:
+For example, if you're streaming changes from a table called `products` in the `public` schema of a database called `shop_prod`, you would see routing keys like:
 
-- `sequin.changes.shop_prod.public.products.insert`
-- `sequin.changes.shop_prod.public.products.update`
-- `sequin.changes.shop_prod.public.products.delete`
+- `sequin.shop_prod.public.products.insert`
+- `sequin.shop_prod.public.products.update`
+- `sequin.shop_prod.public.products.delete`
 
 ## Message properties
 
@@ -107,6 +101,24 @@ rabbitmqadmin declare binding \
   destination=my-queue \
   routing_key="sequin.changes.mydb.public.mytable.*"
 ```
+
+## Routing
+
+The RabbitMQ sink supports dynamic routing of the `exchange`, `routing_key`, and message `headers` with [routing functions](/reference/routing).
+
+Example routing function:
+
+```elixir
+def route(action, record, changes, metadata) do
+  %{
+    exchange: "sequin_" <> metadata.table_schema,
+    routing_key: "#{metadata.database_name}.#{metadata.table_schema}.#{metadata.table_name}.#{action}",
+    headers: %{"Idempotency-Key" => metadata.idempotency_key}
+  }
+end
+```
+
+When not using a routing function, messages will be published to the statically configured exchange with any headers specified in the sink configuration.
 
 ## Debugging
 

--- a/lib/sequin/consumers/rabbitmq_sink.ex
+++ b/lib/sequin/consumers/rabbitmq_sink.ex
@@ -7,7 +7,7 @@ defmodule Sequin.Consumers.RabbitMqSink do
 
   alias Sequin.Encrypted.Binary, as: EncryptedBinary
 
-  @derive {Jason.Encoder, only: [:host, :port, :exchange]}
+  @derive {Jason.Encoder, only: [:host, :port, :exchange, :headers]}
   @derive {Inspect, except: [:password]}
   @primary_key false
   typed_embedded_schema do
@@ -19,6 +19,8 @@ defmodule Sequin.Consumers.RabbitMqSink do
     field :virtual_host, :string, default: "/"
     field :tls, :boolean, default: false
     field :exchange, :string
+    field :headers, :map, default: %{}
+    field :routing_mode, Ecto.Enum, values: [:dynamic, :static]
     field :connection_id, :string
   end
 
@@ -31,13 +33,33 @@ defmodule Sequin.Consumers.RabbitMqSink do
       :password,
       :virtual_host,
       :tls,
-      :exchange
+      :exchange,
+      :headers,
+      :routing_mode
     ])
-    |> validate_required([:host, :port, :exchange])
+    |> validate_required([:host, :port])
+    |> validate_routing()
     |> validate_number(:port, greater_than: 0, less_than: 65_536)
     |> validate_length(:exchange, max: 255)
     |> validate_length(:virtual_host, max: 255)
     |> put_connection_id()
+  end
+
+  defp validate_routing(changeset) do
+    routing_mode = get_field(changeset, :routing_mode)
+
+    cond do
+      routing_mode == :dynamic ->
+        changeset
+        |> put_change(:exchange, nil)
+        |> put_change(:headers, nil)
+
+      routing_mode == :static ->
+        validate_required(changeset, [:exchange])
+
+      true ->
+        add_error(changeset, :routing_mode, "is required")
+    end
   end
 
   defp put_connection_id(changeset) do

--- a/lib/sequin/consumers/routing_function.ex
+++ b/lib/sequin/consumers/routing_function.ex
@@ -25,6 +25,7 @@ defmodule Sequin.Consumers.RoutingFunction do
         :typesense,
         :meilisearch,
         :elasticsearch,
+        :rabbitmq,
         :sqs
       ]
 

--- a/lib/sequin/runtime/rabbitmq_pipeline.ex
+++ b/lib/sequin/runtime/rabbitmq_pipeline.ex
@@ -3,6 +3,7 @@ defmodule Sequin.Runtime.RabbitMqPipeline do
   @behaviour Sequin.Runtime.SinkPipeline
 
   alias Sequin.Error
+  alias Sequin.Runtime.Routing
   alias Sequin.Runtime.SinkPipeline
   alias Sequin.Sinks.RabbitMq
 
@@ -31,9 +32,9 @@ defmodule Sequin.Runtime.RabbitMqPipeline do
     %{consumer: consumer, test_pid: test_pid} = context
     setup_allowances(test_pid)
 
-    consumer_messages = Enum.map(messages, & &1.data)
+    routed_messages = Routing.route_and_transform_messages(consumer, Enum.map(messages, & &1.data))
 
-    case RabbitMq.send_messages(consumer, consumer_messages) do
+    case RabbitMq.send_messages(consumer, routed_messages) do
       :ok ->
         {:ok, messages, context}
 

--- a/lib/sequin/runtime/routing/consumers/rabbitmq.ex
+++ b/lib/sequin/runtime/routing/consumers/rabbitmq.ex
@@ -1,0 +1,38 @@
+defmodule Sequin.Runtime.Routing.Consumers.Rabbitmq do
+  @moduledoc false
+  use Sequin.Runtime.Routing.RoutedConsumer
+
+  @primary_key false
+  @derive {Jason.Encoder, only: [:exchange, :headers]}
+  typed_embedded_schema do
+    field :exchange, :string
+    field :routing_key, :string
+    field :message_id, :string
+    field :headers, :map
+  end
+
+  def changeset(struct, params) do
+    allowed_keys = [:exchange, :headers, :routing_key, :message_id]
+
+    struct
+    |> cast(params, allowed_keys, empty_values: [])
+    |> Routing.Helpers.validate_no_extra_keys(params, allowed_keys)
+    |> validate_required([:exchange])
+    |> validate_length(:exchange, max: 255)
+  end
+
+  def route(action, _record, _changes, metadata) do
+    routing_key = "sequin.#{metadata.database_name}.#{metadata.table_schema}.#{metadata.table_name}.#{action}"
+
+    %{
+      exchange: nil,
+      headers: %{},
+      routing_key: routing_key,
+      message_id: metadata.idempotency_key
+    }
+  end
+
+  def route_consumer(%Sequin.Consumers.SinkConsumer{sink: sink}) do
+    %{exchange: sink.exchange, headers: sink.headers || %{}}
+  end
+end

--- a/lib/sequin/runtime/routing/routing.ex
+++ b/lib/sequin/runtime/routing/routing.ex
@@ -93,6 +93,7 @@ defmodule Sequin.Runtime.Routing do
       :typesense -> Sequin.Runtime.Routing.Consumers.Typesense
       :meilisearch -> Sequin.Runtime.Routing.Consumers.Meilisearch
       :elasticsearch -> Sequin.Runtime.Routing.Consumers.Elasticsearch
+      :rabbitmq -> Sequin.Runtime.Routing.Consumers.Rabbitmq
       :sqs -> Sequin.Runtime.Routing.Consumers.Sqs
       _ -> nil
     end

--- a/lib/sequin/sinks/rabbitmq/rabbitmq.ex
+++ b/lib/sequin/sinks/rabbitmq/rabbitmq.ex
@@ -5,8 +5,9 @@ defmodule Sequin.Sinks.RabbitMq do
   alias Sequin.Consumers.RabbitMqSink
   alias Sequin.Consumers.SinkConsumer
   alias Sequin.Error
+  alias Sequin.Runtime.Routing.Consumers.Rabbitmq, as: RabbitmqRouting
 
-  @callback send_messages(SinkConsumer.t(), [ConsumerRecord.t() | ConsumerEvent.t()]) ::
+  @callback send_messages(SinkConsumer.t(), [{ConsumerRecord.t() | ConsumerEvent.t(), RabbitmqRouting.t()}]) ::
               :ok | {:error, Error.t()}
   @callback test_connection(RabbitMqSink.t()) :: :ok | {:error, Error.t()}
 

--- a/lib/sequin_web/live/components/consumer_form.ex
+++ b/lib/sequin_web/live/components/consumer_form.ex
@@ -810,7 +810,8 @@ defmodule SequinWeb.Components.ConsumerForm do
       "username" => sink["username"],
       "password" => sink["password"],
       "virtual_host" => sink["virtual_host"],
-      "tls" => sink["tls"]
+      "tls" => sink["tls"],
+      "headers" => sink["headers"]
     }
   end
 
@@ -1065,7 +1066,8 @@ defmodule SequinWeb.Components.ConsumerForm do
       "exchange" => sink.exchange,
       "username" => sink.username,
       "password" => sink.password,
-      "virtual_host" => sink.virtual_host
+      "virtual_host" => sink.virtual_host,
+      "headers" => sink.headers
     }
   end
 

--- a/lib/sequin_web/live/functions/edit.ex
+++ b/lib/sequin_web/live/functions/edit.ex
@@ -150,6 +150,16 @@ defmodule SequinWeb.FunctionsLive.Edit do
   end
   """
 
+  @initial_route_rabbitmq """
+  def route(action, record, changes, _metadata) do
+    %{
+      exchange: "amq.fanout",
+      routing_key: "\#{metadata.database_name}.\#{metadata.table_schema}.\#{metadata.table_name}.\#{action}",
+      headers: %{"Idempotency-Key" => metadata.idempotency_key}
+    }
+  end
+  """
+
   @initial_filter """
   def filter(action, record, changes, metadata) do
     # Must return true or false!
@@ -172,7 +182,8 @@ defmodule SequinWeb.FunctionsLive.Edit do
     "routing_redis_stream" => @initial_route_redis_stream,
     "routing_elasticsearch" => @initial_route_elasticsearch,
     "routing_sns" => @initial_route_sns,
-    "routing_sqs" => @initial_route_sqs
+    "routing_sqs" => @initial_route_sqs,
+    "routing_rabbitmq" => @initial_route_rabbitmq
   }
 
   # We generate the function completions at compile time because

--- a/lib/sequin_web/live/sink_consumers/show.ex
+++ b/lib/sequin_web/live/sink_consumers/show.ex
@@ -900,7 +900,8 @@ defmodule SequinWeb.SinkConsumersLive.Show do
       username: sink.username,
       virtual_host: sink.virtual_host,
       tls: sink.tls,
-      topic: topic
+      topic: topic,
+      headers: sink.headers
     }
   end
 

--- a/test/sequin/rabbitmq_pipeline_test.exs
+++ b/test/sequin/rabbitmq_pipeline_test.exs
@@ -1,0 +1,225 @@
+defmodule Sequin.Runtime.RabbitMqPipelineTest do
+  use Sequin.DataCase, async: true
+
+  alias Sequin.Factory.AccountsFactory
+  alias Sequin.Factory.ConsumersFactory
+  alias Sequin.Factory.FunctionsFactory
+  alias Sequin.Functions.MiniElixir
+  alias Sequin.Runtime.Routing.RoutedMessage
+  alias Sequin.Runtime.SinkPipeline
+  alias Sequin.Sinks.RabbitMqMock
+
+  describe "rabbitmq pipeline" do
+    setup do
+      account = AccountsFactory.insert_account!()
+
+      transform =
+        FunctionsFactory.insert_function!(
+          account_id: account.id,
+          function_type: :transform,
+          function_attrs: %{body: "record"}
+        )
+
+      MiniElixir.create(transform.id, transform.function.code)
+
+      consumer =
+        ConsumersFactory.insert_sink_consumer!(
+          account_id: account.id,
+          type: :rabbitmq,
+          message_kind: :event,
+          transform_id: transform.id
+        )
+
+      {:ok, %{consumer: consumer}}
+    end
+
+    test "one message is published", %{consumer: consumer} do
+      message =
+        ConsumersFactory.consumer_message(
+          consumer_id: consumer.id,
+          message_kind: consumer.message_kind,
+          data:
+            ConsumersFactory.consumer_message_data(
+              message_kind: consumer.message_kind,
+              action: :insert
+            )
+        )
+
+      Mox.expect(RabbitMqMock, :send_messages, fn _consumer, routed_messages ->
+        assert length(routed_messages) == 1
+        %RoutedMessage{routing_info: routing_info} = List.first(routed_messages)
+        assert routing_info.exchange == consumer.sink.exchange
+        :ok
+      end)
+
+      start_pipeline!(consumer)
+      send_test_batch(consumer, [message])
+
+      assert_receive {:ack, _ref, [success], []}, 3000
+      assert success.data == message
+    end
+
+    test "multiple messages are batched", %{consumer: consumer} do
+      messages =
+        for _ <- 1..3 do
+          ConsumersFactory.insert_consumer_message!(
+            consumer_id: consumer.id,
+            message_kind: consumer.message_kind,
+            data:
+              ConsumersFactory.consumer_message_data(
+                message_kind: consumer.message_kind,
+                action: Enum.random([:insert, :update])
+              )
+          )
+        end
+
+      Mox.expect(RabbitMqMock, :send_messages, fn _consumer, routed_messages ->
+        assert length(routed_messages) == 3
+        :ok
+      end)
+
+      start_pipeline!(consumer)
+      send_test_batch(consumer, messages)
+
+      assert_receive {:ack, _ref, successful, []}, 3000
+      assert length(successful) == 3
+    end
+  end
+
+  describe "rabbitmq routing" do
+    setup do
+      account = AccountsFactory.insert_account!()
+
+      transform =
+        FunctionsFactory.insert_function!(
+          account_id: account.id,
+          function_type: :transform,
+          function_attrs: %{body: "record"}
+        )
+
+      routing =
+        FunctionsFactory.insert_function!(
+          account_id: account.id,
+          function_type: :routing,
+          function_attrs: %{
+            body: """
+            %{
+              exchange: "amq.fanout",
+              routing_key: "\#{metadata.database_name}.\#{metadata.table_schema}.\#{metadata.table_name}.\#{action}",
+              headers: %{"Idempotency-Key" => metadata.idempotency_key}
+            }
+            """
+          }
+        )
+
+      MiniElixir.create(transform.id, transform.function.code)
+      MiniElixir.create(routing.id, routing.function.code)
+
+      consumer =
+        ConsumersFactory.insert_sink_consumer!(
+          account_id: account.id,
+          type: :rabbitmq,
+          message_kind: :event,
+          transform_id: transform.id,
+          routing_mode: "dynamic",
+          routing_id: routing.id
+        )
+
+      {:ok, %{consumer: consumer}}
+    end
+
+    test "routing can override exchange and add headers", %{consumer: consumer} do
+      message =
+        ConsumersFactory.consumer_message(
+          consumer_id: consumer.id,
+          message_kind: consumer.message_kind,
+          data:
+            ConsumersFactory.consumer_message_data(
+              message_kind: consumer.message_kind,
+              action: :insert
+            )
+        )
+
+      Mox.expect(RabbitMqMock, :send_messages, fn _consumer, routed_messages ->
+        assert length(routed_messages) == 1
+
+        %RoutedMessage{transformed_message: transformed_message, routing_info: routing_info} =
+          List.first(routed_messages)
+
+        assert transformed_message == message.data.record
+
+        metadata = message.data.metadata
+        assert routing_info.exchange == "amq.fanout"
+
+        assert routing_info.routing_key ==
+                 "#{metadata.database_name}.#{metadata.table_schema}.#{metadata.table_name}.insert"
+
+        assert routing_info.headers == %{"Idempotency-Key" => metadata.idempotency_key}
+        :ok
+      end)
+
+      start_pipeline!(consumer)
+      send_test_batch(consumer, [message])
+
+      assert_receive {:ack, _ref, [success], []}, 3000
+      assert success.data == message
+    end
+
+    test "routing can change exchange based on deleted_at field", %{consumer: consumer} do
+      message =
+        ConsumersFactory.consumer_message(
+          consumer_id: consumer.id,
+          message_kind: consumer.message_kind,
+          data:
+            ConsumersFactory.consumer_message_data(
+              message_kind: consumer.message_kind,
+              action: :insert,
+              record: %{"id" => 123, "deleted_at" => "2024-01-01T00:00:00Z"}
+            )
+        )
+
+      Mox.expect(RabbitMqMock, :send_messages, fn _consumer, routed_messages ->
+        assert length(routed_messages) == 1
+
+        %RoutedMessage{transformed_message: transformed_message, routing_info: routing_info} =
+          List.first(routed_messages)
+
+        assert transformed_message == message.data.record
+
+        metadata = message.data.metadata
+        assert routing_info.exchange == "amq.fanout"
+
+        assert routing_info.routing_key ==
+                 "#{metadata.database_name}.#{metadata.table_schema}.#{metadata.table_name}.insert"
+
+        assert routing_info.headers == %{"Idempotency-Key" => metadata.idempotency_key}
+        :ok
+      end)
+
+      start_pipeline!(consumer)
+      send_test_batch(consumer, [message])
+
+      assert_receive {:ack, _ref, [success], []}, 3000
+      assert success.data == message
+    end
+  end
+
+  defp start_pipeline!(consumer) do
+    start_supervised!(
+      {SinkPipeline,
+       [
+         consumer_id: consumer.id,
+         producer: Broadway.DummyProducer,
+         test_pid: self()
+       ]}
+    )
+  end
+
+  defp send_test_batch(consumer, events) do
+    Broadway.test_batch(broadway(consumer), events)
+  end
+
+  defp broadway(consumer) do
+    SinkPipeline.via_tuple(consumer.id)
+  end
+end

--- a/test/sequin/rabbitmq_sink_test.exs
+++ b/test/sequin/rabbitmq_sink_test.exs
@@ -1,0 +1,31 @@
+defmodule Sequin.Consumers.RabbitMqSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Sequin.Consumers.RabbitMqSink
+
+  describe "changeset/2" do
+    test "requires exchange when routing_mode is static" do
+      params = %{
+        host: "localhost",
+        port: 5672,
+        exchange: "sequin",
+        routing_mode: :static
+      }
+
+      changeset = RabbitMqSink.changeset(%RabbitMqSink{}, params)
+      assert changeset.valid?
+    end
+
+    test "clears exchange when routing_mode is dynamic" do
+      params = %{
+        host: "localhost",
+        port: 5672,
+        exchange: "sequin",
+        routing_mode: :dynamic
+      }
+
+      changeset = RabbitMqSink.changeset(%RabbitMqSink{}, params)
+      refute Map.has_key?(changeset.changes, :exchange)
+    end
+  end
+end

--- a/test/support/factory/consumers_factory.ex
+++ b/test/support/factory/consumers_factory.ex
@@ -278,7 +278,9 @@ defmodule Sequin.Factory.ConsumersFactory do
         type: :rabbitmq,
         host: "localhost",
         port: 5672,
-        exchange: "test-exchange"
+        exchange: "test-exchange",
+        headers: %{},
+        routing_mode: "static"
       },
       attrs
     )

--- a/test/support/factory/functions_factory.ex
+++ b/test/support/factory/functions_factory.ex
@@ -159,7 +159,8 @@ defmodule Sequin.Factory.FunctionsFactory do
           :meilisearch,
           :elasticsearch,
           :sqs,
-          :sns
+          :sns,
+          :rabbitmq
         ])
       end)
 
@@ -235,6 +236,13 @@ defmodule Sequin.Factory.FunctionsFactory do
             """
             %{
               index_name: metadata.table_name
+            }
+            """
+
+          :rabbitmq ->
+            """
+            %{
+              exchange_name: metadata.table_name
             }
             """
         end


### PR DESCRIPTION
## Summary
- add RabbitMQ routing schema and pipeline updates
- update sink config and factories
- support rabbitmq routing in frontend forms and docs
- document routing options for RabbitMQ

------
https://chatgpt.com/codex/tasks/task_e_6864906ebf28832cb60d8470932f52b3