### PR TITLE
⚡️ Add outbound gzip compression for GCP Pubsub and Elasticsearch sinks

### DIFF
--- a/lib/sequin/runtime/elasticsearch_pipeline.ex
+++ b/lib/sequin/runtime/elasticsearch_pipeline.ex
@@ -13,8 +13,9 @@ defmodule Sequin.Runtime.ElasticsearchPipeline do
   require Logger
 
   @impl SinkPipeline
-  def init(context, _opts) do
-    context
+  def init(context, opts) do
+    req_opts = Keyword.get(opts, :req_opts, [])
+    Map.put(context, :req_opts, req_opts)
   end
 
   @impl SinkPipeline
@@ -45,7 +46,7 @@ defmodule Sequin.Runtime.ElasticsearchPipeline do
 
   @impl SinkPipeline
   def handle_batch(:default, messages, batch_info, context) do
-    %{consumer: consumer, test_pid: test_pid} = context
+    %{consumer: consumer, test_pid: test_pid, req_opts: req_opts} = context
     index_name = batch_info.batch_key
     sink = consumer.sink
 
@@ -69,7 +70,7 @@ defmodule Sequin.Runtime.ElasticsearchPipeline do
         end
       end)
 
-    case Client.import_documents(sink, index_name, ndjson) do
+    case Client.import_documents(sink, index_name, ndjson, req_opts) do
       {:ok, results} ->
         messages =
           messages

--- a/lib/sequin/sinks/gcp/pubsub.ex
+++ b/lib/sequin/sinks/gcp/pubsub.ex
@@ -248,7 +248,8 @@ defmodule Sequin.Sinks.Gcp.PubSub do
         [
           method: method,
           url: "#{base_url}/v1/#{path}",
-          headers: headers
+          headers: headers,
+          compress_body: true
         ]
         |> Req.new()
         |> Req.merge(client.req_opts)

--- a/test/sequin/elasticsearch_pipeline_test.exs
+++ b/test/sequin/elasticsearch_pipeline_test.exs
@@ -1,0 +1,174 @@
+defmodule Sequin.Runtime.ElasticsearchPipelineTest do
+  use Sequin.DataCase, async: true
+
+  alias Sequin.Factory.AccountsFactory
+  alias Sequin.Factory.ConsumersFactory
+  alias Sequin.Factory.FunctionsFactory
+  alias Sequin.Functions.MiniElixir
+  alias Sequin.Runtime.SinkPipeline
+
+  describe "elasticsearch pipeline" do
+    setup do
+      account = AccountsFactory.insert_account!()
+
+      transform =
+        FunctionsFactory.insert_function!(
+          account_id: account.id,
+          function_type: :transform,
+          function_attrs: %{body: "record"}
+        )
+
+      MiniElixir.create(transform.id, transform.function.code)
+
+      consumer =
+        ConsumersFactory.insert_sink_consumer!(
+          account_id: account.id,
+          type: :elasticsearch,
+          message_kind: :event,
+          transform_id: transform.id
+        )
+
+      {:ok, %{consumer: consumer}}
+    end
+
+    test "requests use compression", %{consumer: consumer} do
+      test_pid = self()
+
+      message =
+        ConsumersFactory.consumer_message(
+          consumer_id: consumer.id,
+          message_kind: consumer.message_kind,
+          data:
+            ConsumersFactory.consumer_message_data(
+              message_kind: consumer.message_kind,
+              action: :insert,
+              record: %{"name" => "test-name"}
+            )
+        )
+
+      adapter = fn request ->
+        send(test_pid, {:elasticsearch_request, request})
+
+        # Verify body is compressed by attempting to decompress it
+        body = :zlib.gunzip(request.body)
+        assert String.contains?(body, "test-name")
+
+        {request,
+         Req.Response.new(
+           status: 200,
+           body: %{"items" => [%{"index" => %{"_id" => "1", "status" => 201}}]}
+         )}
+      end
+
+      start_pipeline!(consumer, adapter)
+
+      send_test_batch(consumer, [message])
+
+      assert_receive {:elasticsearch_request, request}, 3000
+      assert request.method == :post
+      assert String.contains?(to_string(request.url), "/_bulk")
+
+      assert_receive {:ack, _ref, [success], []}, 3000
+      assert success.data == message
+    end
+
+    test "one message is published", %{consumer: consumer} do
+      test_pid = self()
+
+      message =
+        ConsumersFactory.consumer_message(
+          consumer_id: consumer.id,
+          message_kind: consumer.message_kind,
+          data:
+            ConsumersFactory.consumer_message_data(
+              message_kind: consumer.message_kind,
+              action: :insert
+            )
+        )
+
+      adapter = fn request ->
+        send(test_pid, {:elasticsearch_request, request})
+
+        assert request.method == :post
+        assert String.contains?(to_string(request.url), "/_bulk")
+
+        {request,
+         Req.Response.new(
+           status: 200,
+           body: %{"items" => [%{"index" => %{"_id" => "1", "status" => 201}}]}
+         )}
+      end
+
+      start_pipeline!(consumer, adapter)
+
+      send_test_batch(consumer, [message])
+
+      assert_receive {:elasticsearch_request, _request}, 3000
+
+      assert_receive {:ack, _ref, [success], []}, 3000
+      assert success.data == message
+    end
+
+    test "multiple messages are batched", %{consumer: consumer} do
+      test_pid = self()
+
+      messages =
+        for _ <- 1..3 do
+          ConsumersFactory.insert_consumer_message!(
+            consumer_id: consumer.id,
+            message_kind: consumer.message_kind,
+            data:
+              ConsumersFactory.consumer_message_data(
+                message_kind: consumer.message_kind,
+                action: :insert
+              )
+          )
+        end
+
+      adapter = fn request ->
+        send(test_pid, {:elasticsearch_request, request})
+
+        {request,
+         Req.Response.new(
+           status: 200,
+           body: %{
+             "items" => [
+               %{"index" => %{"_id" => "1", "status" => 201}},
+               %{"index" => %{"_id" => "2", "status" => 201}},
+               %{"index" => %{"_id" => "3", "status" => 201}}
+             ]
+           }
+         )}
+      end
+
+      start_pipeline!(consumer, adapter)
+
+      send_test_batch(consumer, messages)
+
+      assert_receive {:elasticsearch_request, _request}, 3000
+
+      assert_receive {:ack, _ref, successful, []}, 3000
+      assert length(successful) == 3
+    end
+  end
+
+  defp start_pipeline!(consumer, req_adapter) do
+    start_supervised!(
+      {SinkPipeline,
+       [
+         consumer_id: consumer.id,
+         producer: Broadway.DummyProducer,
+         test_pid: self(),
+         req_opts: [adapter: req_adapter]
+       ]}
+    )
+  end
+
+  defp send_test_batch(consumer, events) do
+    Broadway.test_batch(broadway(consumer), events)
+  end
+
+  defp broadway(consumer) do
+    SinkPipeline.via_tuple(consumer.id)
+  end
+end

--- a/test/sequin/gcp_pubsub_test.exs
+++ b/test/sequin/gcp_pubsub_test.exs
@@ -97,7 +97,7 @@ defmodule Sequin.Sinks.Gcp.PubSubTest do
         assert conn.request_path == "/v1/projects/#{@project_id}/topics/#{@topic_id}:publish"
 
         {:ok, body, _} = Plug.Conn.read_body(conn)
-        body = Jason.decode!(body)
+        body = body |> :zlib.gunzip() |> Jason.decode!()
 
         decoded_data =
           body


### PR DESCRIPTION
  ### Add outbound gzip compression for GCP Pubsub and Elasticsearch sinks

  
  **Currently Enabled (2 sinks)**

  | Sink        | Library | Compression Status | Implementation                      |
  |-------------|---------|--------------------|-------------------------------------|
  | S2          | Req     | ✅ Enabled          | compress_body: true in base_request |
  | Meilisearch | Req     | ✅ Enabled          | compress_body: true in base_request |

  **Enabled in this PR (2 sinks)**

  | Sink            | Library | Compression Status | Implementation Path                              |
  |-----------------|---------|--------------------|--------------------------------------------------|
  | GCP Pub/Sub     | Req     | 🟢 Ready           | Add compress_body: true |
  | Elasticsearch   | Req     | 🟢 Ready           | Add compress_body: true |

  **Enabled in this PR (2 sinks)**
  | Sink            | Library | Compression Status | Implementation Path                              |
  |-----------------|---------|--------------------|--------------------------------------------------|
  | HTTP Push       | Req     | 🟡 WIP           |  See #1934 |
  | Kafka          | :brod   | 🟡 WIP           | Set the right `:brod` options configuration|

  
   **Discovered these services do not support transparent compression (5 sinks)**

  | Sink            | Compression Status | Reference              |
  |-----------------|--------------------|------------------------|
  | Azure Event Hub | 🟠 Needs custom consumers   |  |
  | NATS            | 🟠 Needs custom consumers   |  |
  | Redis String    | 🟠 Needs custom consumers   |  |
  | Redis Stream   | 🟠 Needs custom consumers   |  |
  | Kinesis         | 🟠 Needs custom consumers   |                        |
  | SNS             | 🟠 Needs custom consumers   |                        |
  | SQS             | 🟠 Needs custom consumers   |                        |
  | Typesense       | 🔴 Not supported yet  | https://github.com/typesense/typesense/issues/580                        |

This PR improves the situation for #1800 but doesn't close the issue until we figure out what to do with the pending sinks

### Additional thoughts
  - [x] We need to confirm that all the receiving ends support gzip compressed payloads, but I would be surprised if any of them did not supported them
  - [ ] In the future we could consider supporting other compression mechanisms, which may be better suited than gzip, such as: snappy, brotli, lz4, zstd. But we would need to check compatibility with the receiving end
  - [ ] We could also consider in the future having a compression algorithm attribute in the routing struct, or a setting sink consumers, so users can pick their compression mechanism


---


History log (before service review where we discarded incompatible services)

0e5f476b88a782c71f2dc9998fa13d2efa8db79e