### PR TITLE
⚡️ Add outbound gzip compression for http_push via `content-encoding: gzip` header

### DIFF
--- a/docs/reference/sinks/webhooks.mdx
+++ b/docs/reference/sinks/webhooks.mdx
@@ -178,6 +178,22 @@ Example (when batching is enabled):
 }
 ```
 
+## Payload compression
+
+Sequin supports gzip compression for webhook payloads to reduce bandwidth usage and improve performance for large messages or high-throughput scenarios.
+
+To enable gzip compression, add a `content-encoding: gzip` header to your webhook sink configuration. This can be configured either as a header in the HTTP endpoint or via a routing function.
+
+<Note>
+  Most modern web frameworks, and HTTP proxies or libraries automatically handle gzip decompression when the `content-encoding: gzip` header is present. However, make sure to check your framework's documentation for specific implementation details.
+</Note>
+
+<Tip>
+  Compression is most beneficial when:
+  - Your messages contain large payloads (e.g., JSON with many fields or large text values)
+  - You're using batching with multiple messages per request
+  - You're processing high volumes of messages and want to reduce network overhead
+</Tip>
 
 ## Response format
 


### PR DESCRIPTION
Add outbound payload compression by analyzing the [`content-encoding` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding), which may be specified at the HTTP Endpoint level, or at the Routing level via `headers:` key.

Currently only `gzip` is supported, but in the future we could handle multiple compression mechanisms, and even sequential ones, such as `gzip, deflate`

This addition should be backwards compatible for _most_ cases, except for cases where users have explicitly set `content-encoding: gzip` before, which it was not really doing anything, so we would now be fulfilling their expectations.

Sister PR: #1932 
Incrementally fixing: #1800 