### PR TITLE
🔧 Fix flaky connection_cache_tests

### DIFF
--- a/test/sequin/connection_cache_test.exs
+++ b/test/sequin/connection_cache_test.exs
@@ -67,7 +67,7 @@ defmodule Sequin.Databases.ConnectionCacheTest do
 
       {:ok, pid} = ConnectionCache.connection(cache, db)
 
-      updated_db = %{db | database: Factory.postgres_object()}
+      updated_db = %{db | database: Factory.postgres_object() <> "_changed"}
 
       {:ok, new_pid} = ConnectionCache.connection(cache, updated_db)
 
@@ -149,6 +149,8 @@ defmodule Sequin.Databases.ConnectionCacheTest do
       task1 = Task.async(fn -> ConnectionCache.connection(cache, db) end)
       assert_receive {:started, pid}
       task2 = Task.async(fn -> ConnectionCache.connection(cache, db) end)
+
+      Process.sleep(1)
       :erlang.yield()
 
       send(pid, :go)


### PR DESCRIPTION
Fix some of the tests that often fail during signoff.

1. Appending `_changed` to the database name factory results forces the config to be different, rather than relying on non-deterministic randomness
2. Adding a 1ms sleep addresses a race condition - I couldn't find the root cause but this seems to fix it for now.

Validated running the test file many times - without these changes the tests often fail at the 10th or so attempt

`mix test test/sequin/connection_cache_test.exs --repeat-until-failure 1000`