### PR TITLE
auto assign on commenting take

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,32 @@
+name: Assign the issue via a `take` comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_assign:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Check if comment is "take"
+        if: github.event.comment.body == 'take'
+        run: echo "Comment is 'take'"
+
+      - name: Assign issue to commenter
+        if: github.event.comment.body == 'take'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              assignees: [commenter],
+            });


### PR DESCRIPTION
Simplify the process of assigning the issue to the contributor, user's can self assign the issue. 
An additional GitHub workflow that would run in response to work take submitted as a comment