### PR TITLE
Investigate issues with mock expectations

### DIFF
--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -18,10 +18,6 @@ defmodule Sequin.Case do
       setup :verify_stubs
       setup :default_stubs
       setup :setup_self_hosted_tag
-      # For Hammox
-      # Note: You may be tempted to move this to Hammox.verify_on_exit!() in
-      # verify_stubs/1, but that doesn't seem to have an effect.
-      setup :verify_on_exit!
     end
   end
 
@@ -49,7 +45,10 @@ defmodule Sequin.Case do
   end
 
   def verify_stubs(_context) do
+    # TODO Update Req to the latest version once this is released:
+    # https://github.com/wojtekmach/req/commit/dcb7ddf6a449dfd2cc2a99c6354d050b65e5191a
     Req.Test.verify_on_exit!()
+    Hammox.verify_on_exit!()
     :ok
   end
 


### PR DESCRIPTION
When running these tests, we should see 3 failures

    mix test test/sequin/mock_verification_test.exs

During the Test.Case setup:

- If we call `Req.Test.verify_on_exit!` last, we see only 1 failure as the Mox/Hammox
verify_on_exit! gets overwritten

- If we call `Hammox.verify_on_exit!` last, we see only 2 failure as the Req
verify_on_exit! gets overwritten



This could be fixed by:

1. Fixing the root cause at either Req.Test, or Mox/Hammox by providing distinct `on_exit` hook identifiers (so they dont overlap)
    - See https://github.com/wojtekmach/req/issues/490

2. Monkey patching the `verify_on_exit!` method by Req.Test
    - See `Req.Test.verify_on_exit!` monkey patch in this branch: https://github.com/sequinstream/sequin/pull/1976/files#diff-c45579b686b8c68b0d9ef1b2fd3e2f25427e2d3b21acc6e5bda94e4ed3e33d75R654-R660

3. Perform a mutually exclusive `Hammox.verify_on_exit!` or `Req.Test.verify_on_exit!` by specifying it via the `using` macro like `use Sequin.Case, mock: Req`


-------

Fixes #1799 