### PR TITLE
🔧 Include :aws_credentials in included_applications to be included in release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule Sequin.MixProject do
   def application do
     [
       mod: {Sequin.Application, []},
-      extra_applications: [:logger, :runtime_tools] ++ extra_applications(Mix.env())
+      extra_applications: [:logger, :runtime_tools] ++ extra_applications(Mix.env()),
+      included_applications: [:aws_credentials]
     ]
   end
 


### PR DESCRIPTION
Running the release version of Sequin seems to not include the `:aws_credentials` app because we added `runtime: false` to the dependency declaration.

With this change, we are now including the library while keeping the auto-start disabled.

Problem:
```elixir
iex(sequin@abedc7026e12)9> Application.ensure_all_started(:aws_credentials)
{:error,
 {:aws_credentials, {~c"no such file or directory", ~c"aws_credentials.app"}}}
 ```
 
Source:
 
https://elixirforum.com/t/how-to-exclude-a-dependencys-application-from-running-but-still-include-it-in-the-release/55863