### PR TITLE
Make Typesense to be default fast

### DIFF
--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -410,6 +410,20 @@
             </p>
           {/if}
 
+          {#if consumer.type === "typesense" && !form.messageGrouping}
+            <Alert.Root variant="destructive" class="mt-4">
+              <CircleAlert class="h-4 w-4" />
+              <Alert.Title>Message grouping disabled for Typesense</Alert.Title>
+              <Alert.Description>
+                <p class="mb-2">
+                  Message grouping ensures that changes are processed in the
+                  correct order - keeping Typesense in sync with your database.
+                  Don't disable it!
+                </p>
+              </Alert.Description>
+            </Alert.Root>
+          {/if}
+
           <p class="text-sm text-muted-foreground">
             When enabled, messages within groups are <a
               href="https://sequinstream.com/docs/reference/sinks/overview#message-grouping-and-ordering"
@@ -471,6 +485,43 @@
       </svelte:fragment>
 
       <svelte:fragment slot="content">
+        {#if consumer.type === "typesense" && form.transform === "none"}
+          <Alert.Root variant="info" class="mb-4">
+            <Alert.Title>Typesense transform requirements</Alert.Title>
+            <Alert.Description>
+              <p class="mb-2">
+                For Typesense, your <a
+                  class="underline font-medium"
+                  href="https://sequinstream.com/docs/reference/transforms"
+                  target="_blank">transform</a
+                >
+                must return a document matching the schema of the
+                <a
+                  class="underline font-medium"
+                  href="https://typesense.org/docs/28.0/api/collections.html#create-a-collection"
+                  target="_blank">Typesense collection</a
+                >.
+              </p>
+              <p class="mb-2">
+                Your message must include an <code>id</code> field, as a string.
+              </p>
+              <div class="mb-2">
+                Sequin uses Typesense's <code>emplace</code> import action,
+                which means:
+                <ul class="ml-6 list-disc">
+                  <li>
+                    Typesense will create a new document or update an existing
+                    one based on the <code>id</code>
+                  </li>
+                  <li>
+                    Your transform can supply either a complete document or a
+                    partial document for update
+                  </li>
+                </ul>
+              </div>
+            </Alert.Description>
+          </Alert.Root>
+        {/if}
         <FunctionPicker
           {functions}
           selectedFunctionId={form.transform}

--- a/assets/svelte/consumers/SinkConsumerForm.svelte
+++ b/assets/svelte/consumers/SinkConsumerForm.svelte
@@ -416,9 +416,9 @@
               <Alert.Title>Message grouping disabled for Typesense</Alert.Title>
               <Alert.Description>
                 <p class="mb-2">
-                  Message grouping ensures that changes are processed in the
-                  correct order - keeping Typesense in sync with your database.
-                  Don't disable it!
+                  With message grouping disabled, inserts, updates, and deletes
+                  in your database might be delivered to Typesense out of order.
+                  This can cause inconsistent search results.
                 </p>
               </Alert.Description>
             </Alert.Root>
@@ -762,8 +762,53 @@
               <AccordionTrigger>Advanced configuration</AccordionTrigger>
               <AccordionContent>
                 <div class="space-y-4 pt-4">
+                  {#if consumer.type !== "http_push"}
+                    <div class="space-y-2">
+                      <Label for="batch-size">Batch size</Label>
+                      <Tooltip.Root openDelay={200}>
+                        <Tooltip.Trigger>
+                          <Info class="h-4 w-4 text-gray-400 cursor-help" />
+                        </Tooltip.Trigger>
+                        <Tooltip.Content class="p-4 max-w-xs">
+                          <div
+                            class="text-sm text-muted-foreground font-normal"
+                          >
+                            The number of messages to batch together in a single
+                            request.
+                          </div>
+                        </Tooltip.Content>
+                      </Tooltip.Root>
+
+                      <div class="flex items-center space-x-2">
+                        <Input
+                          id="batch-size"
+                          type="number"
+                          bind:value={form.sink.batch_size}
+                          min="1"
+                          placeholder="40"
+                        />
+                      </div>
+                      {#if errors.consumer?.batch_size}
+                        <p class="text-destructive text-sm">
+                          {errors.consumer.batch_size}
+                        </p>
+                      {/if}
+                    </div>
+                  {/if}
+
                   <div class="space-y-2">
                     <Label for="timestamp-format">Timestamp format</Label>
+                    <Tooltip.Root openDelay={200}>
+                      <Tooltip.Trigger>
+                        <Info class="h-4 w-4 text-gray-400 cursor-help" />
+                      </Tooltip.Trigger>
+                      <Tooltip.Content class="p-4 max-w-xs">
+                        <div class="text-sm text-muted-foreground font-normal">
+                          Choose how timestamps should be formatted in messages
+                          sent to your sink.
+                        </div>
+                      </Tooltip.Content>
+                    </Tooltip.Root>
                     <Select
                       selected={{
                         value: form.timestampFormat,
@@ -788,10 +833,6 @@
                         >
                       </SelectContent>
                     </Select>
-                    <p class="text-xs font-light">
-                      Choose how timestamps should be formatted in messages sent
-                      to your sink.
-                    </p>
                     {#if errors.consumer.timestamp_format}
                       <p class="text-destructive text-sm">
                         {errors.consumer.timestamp_format}

--- a/assets/svelte/sinks/elasticsearch/ElasticsearchSinkForm.svelte
+++ b/assets/svelte/sinks/elasticsearch/ElasticsearchSinkForm.svelte
@@ -160,22 +160,6 @@
         {/if}
       </p>
     </div>
-
-    <div class="space-y-2">
-      <Label for="batch_size">Batch Size</Label>
-      <Input
-        id="batch_size"
-        type="number"
-        bind:value={form.sink.batch_size}
-        placeholder="500"
-      />
-      {#if errors.sink?.batch_size}
-        <p class="text-destructive text-sm">{errors.sink.batch_size}</p>
-      {/if}
-      <p class="text-sm text-muted-foreground">
-        Number of documents to send in each batch (default: 100)
-      </p>
-    </div>
   </CardContent>
 </Card>
 

--- a/assets/svelte/sinks/meilisearch/MeilisearchSinkForm.svelte
+++ b/assets/svelte/sinks/meilisearch/MeilisearchSinkForm.svelte
@@ -121,22 +121,6 @@
         <p class="text-destructive text-sm">{errors.sink.api_key}</p>
       {/if}
     </div>
-
-    <div class="space-y-2">
-      <Label for="batch_size">Batch Size</Label>
-      <Input
-        id="batch_size"
-        type="number"
-        bind:value={form.sink.batch_size}
-        placeholder="500"
-      />
-      {#if errors.sink?.batch_size}
-        <p class="text-destructive text-sm">{errors.sink.batch_size}</p>
-      {/if}
-      <p class="text-sm text-muted-foreground">
-        Number of documents to send in each batch (default: 100)
-      </p>
-    </div>
   </CardContent>
 </Card>
 

--- a/assets/svelte/sinks/typesense/TypesenseSinkForm.svelte
+++ b/assets/svelte/sinks/typesense/TypesenseSinkForm.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Input } from "$lib/components/ui/input";
-  import * as Alert from "$lib/components/ui/alert";
   import {
     Card,
     CardContent,
@@ -12,6 +11,12 @@
   import { Eye, EyeOff, Info } from "lucide-svelte";
   import DynamicRoutingForm from "$lib/consumers/DynamicRoutingForm.svelte";
   import * as Tooltip from "$lib/components/ui/tooltip";
+  import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+  } from "$lib/components/ui/accordion";
 
   export let form: TypesenseConsumer;
   export let errors: any = {};
@@ -34,42 +39,6 @@
     <CardTitle>Typesense configuration</CardTitle>
   </CardHeader>
   <CardContent class="space-y-4">
-    <Alert.Root variant="info">
-      <Alert.Title>Transform requirements</Alert.Title>
-      <Alert.Description>
-        <p class="mb-2">
-          Your <a
-            class="underline font-medium"
-            href="https://sequinstream.com/docs/reference/transforms"
-            target="_blank">transform</a
-          >
-          must return a document matching the schema of the
-          <a
-            class="underline font-medium"
-            href="https://typesense.org/docs/28.0/api/collections.html#create-a-collection"
-            >Typesense collection</a
-          >.
-        </p>
-        <p class="mb-2">
-          This includes an <code>id</code> field which is mandatory.
-        </p>
-        <div class="mb-2">
-          Sequin uses Typesense's <code>emplace</code> import action, which
-          means:
-          <ul class="ml-6 list-disc">
-            <li>
-              Typesense will create a new document or update an existing one
-              based on the <code>id</code>
-            </li>
-            <li>
-              Your transform can supply either a complete document or a partial
-              document for update
-            </li>
-          </ul>
-        </div>
-      </Alert.Description>
-    </Alert.Root>
-
     <div class="space-y-2">
       <Label for="endpoint_url">Endpoint URL</Label>
       <Input
@@ -113,37 +82,86 @@
       {/if}
     </div>
 
-    <div class="space-y-2">
-      <div class="flex items-center space-x-2">
-        <Label for="timeout_seconds">Timeout (seconds)</Label>
-        <Tooltip.Root openDelay={200}>
-          <Tooltip.Trigger>
-            <Info class="h-4 w-4 text-gray-400 cursor-help" />
-          </Tooltip.Trigger>
-          <Tooltip.Content class="p-4 max-w-xs">
-            <div class="text-sm text-muted-foreground font-normal">
-              The timeout for requests to the Typesense server. You may want to
-              increase this if:
-              <ul class="list-disc pl-4 mt-2">
-                <li>You have a slow network connection</li>
-                <li>You are indexing a large number of documents per batch</li>
-                <li>You have auto-embedding enabled in Typesense</li>
-              </ul>
+    <Accordion>
+      <AccordionItem value="advanced">
+        <AccordionTrigger>Advanced Typsense Sink settings</AccordionTrigger>
+        <AccordionContent>
+          <div class="space-y-4 pt-4">
+            <div class="space-y-2">
+              <div class="flex items-center space-x-2">
+                <Label for="batch-size">Batch size</Label>
+                <Tooltip.Root openDelay={200}>
+                  <Tooltip.Trigger>
+                    <Info class="h-4 w-4 text-gray-400 cursor-help" />
+                  </Tooltip.Trigger>
+                  <Tooltip.Content class="p-4 max-w-xs">
+                    <div class="text-sm text-muted-foreground font-normal">
+                      The number of messages to batch together in a single
+                      request. By default, Typesense processes
+                      <a
+                        href="https://typesense.org/docs/29.0/api/documents.html#index-multiple-documents"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="underline font-medium">40 documents</a
+                      >
+                      at a time.
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              </div>
+              <div class="flex items-center space-x-2">
+                <Input
+                  id="batch-size"
+                  type="number"
+                  bind:value={form.sink.batch_size}
+                  min="1"
+                  placeholder="40"
+                />
+              </div>
+              {#if errors.sink?.batch_size}
+                <p class="text-destructive text-sm">{errors.sink.batch_size}</p>
+              {/if}
             </div>
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </div>
-      <Input
-        id="timeout_seconds"
-        bind:value={form.sink.timeout_seconds}
-        placeholder="5"
-        type="number"
-        min="1"
-      />
-      {#if errors.sink?.timeout_seconds}
-        <p class="text-destructive text-sm">{errors.sink.timeout_seconds}</p>
-      {/if}
-    </div>
+
+            <div class="space-y-2">
+              <div class="flex items-center space-x-2">
+                <Label for="timeout_seconds">Timeout (seconds)</Label>
+                <Tooltip.Root openDelay={200}>
+                  <Tooltip.Trigger>
+                    <Info class="h-4 w-4 text-gray-400 cursor-help" />
+                  </Tooltip.Trigger>
+                  <Tooltip.Content class="p-4 max-w-xs">
+                    <div class="text-sm text-muted-foreground font-normal">
+                      The timeout for requests to the Typesense server. You may
+                      want to increase this if:
+                      <ul class="list-disc pl-4 mt-2">
+                        <li>You have a slow network connection</li>
+                        <li>
+                          You are indexing a large number of documents per batch
+                        </li>
+                        <li>You have auto-embedding enabled in Typesense</li>
+                      </ul>
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              </div>
+              <Input
+                id="timeout_seconds"
+                bind:value={form.sink.timeout_seconds}
+                placeholder="10"
+                type="number"
+                min="1"
+              />
+              {#if errors.sink?.timeout_seconds}
+                <p class="text-destructive text-sm">
+                  {errors.sink.timeout_seconds}
+                </p>
+              {/if}
+            </div>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   </CardContent>
 </Card>
 

--- a/assets/svelte/sinks/typesense/TypesenseSinkForm.svelte
+++ b/assets/svelte/sinks/typesense/TypesenseSinkForm.svelte
@@ -89,43 +89,7 @@
           <div class="space-y-4 pt-4">
             <div class="space-y-2">
               <div class="flex items-center space-x-2">
-                <Label for="batch-size">Batch size</Label>
-                <Tooltip.Root openDelay={200}>
-                  <Tooltip.Trigger>
-                    <Info class="h-4 w-4 text-gray-400 cursor-help" />
-                  </Tooltip.Trigger>
-                  <Tooltip.Content class="p-4 max-w-xs">
-                    <div class="text-sm text-muted-foreground font-normal">
-                      The number of messages to batch together in a single
-                      request. By default, Typesense processes
-                      <a
-                        href="https://typesense.org/docs/29.0/api/documents.html#index-multiple-documents"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="underline font-medium">40 documents</a
-                      >
-                      at a time.
-                    </div>
-                  </Tooltip.Content>
-                </Tooltip.Root>
-              </div>
-              <div class="flex items-center space-x-2">
-                <Input
-                  id="batch-size"
-                  type="number"
-                  bind:value={form.sink.batch_size}
-                  min="1"
-                  placeholder="40"
-                />
-              </div>
-              {#if errors.sink?.batch_size}
-                <p class="text-destructive text-sm">{errors.sink.batch_size}</p>
-              {/if}
-            </div>
-
-            <div class="space-y-2">
-              <div class="flex items-center space-x-2">
-                <Label for="timeout_seconds">Timeout (seconds)</Label>
+                <Label for="timeout_seconds">Request timeout (seconds)</Label>
                 <Tooltip.Root openDelay={200}>
                   <Tooltip.Trigger>
                     <Info class="h-4 w-4 text-gray-400 cursor-help" />

--- a/lib/sequin/consumers/typesense_sink.ex
+++ b/lib/sequin/consumers/typesense_sink.ex
@@ -14,8 +14,8 @@ defmodule Sequin.Consumers.TypesenseSink do
     field :endpoint_url, :string
     field :collection_name, :string
     field :api_key, Sequin.Encrypted.Binary
-    field :batch_size, :integer, default: 100
-    field :timeout_seconds, :integer, default: 5
+    field :batch_size, :integer, default: 40
+    field :timeout_seconds, :integer, default: 10
     field :routing_mode, Ecto.Enum, values: [:dynamic, :static]
   end
 

--- a/lib/sequin/runtime/typesense_pipeline.ex
+++ b/lib/sequin/runtime/typesense_pipeline.ex
@@ -30,12 +30,12 @@ defmodule Sequin.Runtime.TypesensePipeline do
       default: [
         concurrency: concurrency,
         batch_size: consumer.sink.batch_size,
-        batch_timeout: 10
+        batch_timeout: 1
       ],
       delete: [
         concurrency: concurrency,
         batch_size: 1,
-        batch_timeout: 10
+        batch_timeout: 1
       ]
     ]
   end


### PR DESCRIPTION
1. Configure Typesense to be default fast
2. Add batching to console for Typesense
3. Add alerts to console for Typesense to (a) warn users if they turn off grouping (b) provide in context information about transforms 👇 

<img width="1616" height="1086" alt="CleanShot 2025-07-15 at 15 55 35@2x" src="https://github.com/user-attachments/assets/c8ff67e3-f7b4-48ce-adc0-07db8a239817" />
<img width="1596" height="642" alt="CleanShot 2025-07-15 at 15 55 56@2x" src="https://github.com/user-attachments/assets/1de6d1b8-5195-44e3-9eb5-996c8098b81f" />


---
## EntelligenceAI PR Summary 
 This PR enhances Typesense sink consumer configuration and defaults:
- Added Typesense-specific alert messages in SinkConsumerForm.svelte
- Refactored TypesenseSinkForm.svelte to group advanced settings and improve input guidance
- Updated default batch_size and timeout_seconds in typesense_sink.ex
- Lowered batch_timeout in typesense_pipeline.ex for faster batch processing 

