### PR TITLE
✨ GCP PubSub batch by messages and bytes

### DIFF
--- a/lib/sequin/runtime/gcp_pubsub_pipeline.ex
+++ b/lib/sequin/runtime/gcp_pubsub_pipeline.ex
@@ -17,12 +17,16 @@ defmodule Sequin.Runtime.GcpPubsubPipeline do
     Map.put(context, :pubsub_client, GcpPubsubSink.pubsub_client(sink))
   end
 
+  @max_bytes Sequin.Size.mb(10)
+
   @impl SinkPipeline
   def batchers_config(consumer) do
     [
       default: [
         concurrency: 400,
-        batch_size: consumer.batch_size,
+        max_demand: consumer.batch_size,
+        # Use 90% of max bytes for buffer
+        batch_size: SinkPipeline.batcher(consumer.batch_size, @max_bytes * 0.9),
         batch_timeout: 1
       ]
     ]
@@ -38,22 +42,31 @@ defmodule Sequin.Runtime.GcpPubsubPipeline do
     group_id = message.data.group_id
     ordering_key = {topic_id, group_id}
 
-    message = Broadway.Message.put_batch_key(message, ordering_key)
+    encoded_data = build_pubsub_message(context.consumer, message.data)
+    encoded_data_size_bytes = pubsub_message_byte_size(encoded_data)
+
+    consumer_message = %{
+      message.data
+      | encoded_data: encoded_data,
+        encoded_data_size_bytes: encoded_data_size_bytes
+    }
+
+    message =
+      message
+      |> Broadway.Message.put_data(consumer_message)
+      |> Broadway.Message.put_batch_key(ordering_key)
 
     {:ok, message, context}
   end
 
   @impl SinkPipeline
   def handle_batch(:default, messages, batch_info, context) do
-    %{consumer: consumer, pubsub_client: pubsub_client, test_pid: test_pid} = context
+    %{pubsub_client: pubsub_client, test_pid: test_pid} = context
     {topic_id, _group_id} = batch_info.batch_key
 
     setup_allowances(test_pid)
 
-    pubsub_messages =
-      Enum.map(messages, fn %{data: data} ->
-        build_pubsub_message(consumer, data)
-      end)
+    pubsub_messages = Enum.map(messages, fn %{data: data} -> data.encoded_data end)
 
     case PubSub.publish_messages(pubsub_client, topic_id, pubsub_messages) do
       :ok ->
@@ -66,21 +79,21 @@ defmodule Sequin.Runtime.GcpPubsubPipeline do
 
   defp build_pubsub_message(consumer, %Sequin.Consumers.ConsumerRecord{} = record) do
     msg = %{
-      data: Message.to_external(consumer, record),
-      attributes: %{
+      "data" => Base.encode64(Jason.encode!(Message.to_external(consumer, record))),
+      "attributes" => %{
         "trace_id" => record.replication_message_trace_id,
         "type" => "record",
         "table_name" => record.data.metadata.table_name
       }
     }
 
-    Sequin.Map.put_if_present(msg, :ordering_key, record.group_id)
+    Sequin.Map.put_if_present(msg, "orderingKey", record.group_id)
   end
 
   defp build_pubsub_message(consumer, %Sequin.Consumers.ConsumerEvent{} = event) do
     msg = %{
-      data: Message.to_external(consumer, event),
-      attributes: %{
+      "data" => Base.encode64(Jason.encode!(Message.to_external(consumer, event))),
+      "attributes" => %{
         "trace_id" => event.replication_message_trace_id,
         "type" => "event",
         "table_name" => event.data.metadata.table_name,
@@ -88,13 +101,19 @@ defmodule Sequin.Runtime.GcpPubsubPipeline do
       }
     }
 
-    Sequin.Map.put_if_present(msg, :ordering_key, event.group_id)
+    Sequin.Map.put_if_present(msg, "orderingKey", event.group_id)
+  end
+
+  defp pubsub_message_byte_size(%{"data" => data, "attributes" => attributes}) do
+    data_size = byte_size(data)
+    attributes_size = :erlang.external_size(attributes)
+    data_size + attributes_size
   end
 
   defp setup_allowances(nil), do: :ok
 
   defp setup_allowances(test_pid) do
-    Req.Test.allow(Sequin.Sinks.Gcp.HttpClient, test_pid, self())
+    Req.Test.allow(PubSub, test_pid, self())
     Mox.allow(Sequin.TestSupport.DateTimeMock, test_pid, self())
   end
 end

--- a/lib/sequin/sinks/gcp/pubsub.ex
+++ b/lib/sequin/sinks/gcp/pubsub.ex
@@ -89,17 +89,8 @@ defmodule Sequin.Sinks.Gcp.PubSub do
   def publish_messages(%Client{} = client, topic_id, messages) when is_list(messages) do
     path = "#{topic_path(client.project_id, topic_id)}:publish"
 
-    encoded_messages =
-      Enum.map(messages, fn msg ->
-        %{
-          "data" => Base.encode64(Jason.encode!(msg.data)),
-          "attributes" => msg[:attributes] || %{},
-          "orderingKey" => msg[:ordering_key]
-        }
-      end)
-
     payload = %{
-      "messages" => encoded_messages
+      "messages" => messages
     }
 
     case authenticated_request(client, :post, path, json: payload) do

--- a/test/sequin/gcp_pubsub_pipeline_test.exs
+++ b/test/sequin/gcp_pubsub_pipeline_test.exs
@@ -1,0 +1,154 @@
+defmodule Sequin.Runtime.GcpPubsubPipelineTest do
+  use Sequin.DataCase, async: true
+
+  alias Sequin.Consumers
+  alias Sequin.Factory.ConsumersFactory
+  alias Sequin.Factory.FunctionsFactory
+  alias Sequin.Functions.MiniElixir
+  alias Sequin.Runtime.SinkPipeline
+  alias Sequin.Sinks.Gcp.PubSub
+
+  describe "events are sent to GCP PubSub" do
+    setup do
+      consumer = ConsumersFactory.insert_sink_consumer!(type: :gcp_pubsub, batch_size: 10)
+
+      # Setup auth token expectation for all tests
+      Req.Test.expect(PubSub, fn conn ->
+        if conn.host == "oauth2.googleapis.com" do
+          Req.Test.json(conn, %{"access_token" => "test_token"})
+        end
+      end)
+
+      {:ok, %{consumer: consumer}}
+    end
+
+    test "events are sent to PubSub", %{consumer: consumer} do
+      message = ConsumersFactory.consumer_message(message_kind: consumer.message_kind)
+
+      # Mock PubSub publish
+      Req.Test.expect(PubSub, fn conn ->
+        assert conn.method == "POST"
+        assert conn.host == "pubsub.googleapis.com"
+        assert String.contains?(conn.request_path, ":publish")
+
+        {:ok, body, _} = Plug.Conn.read_body(conn)
+        body = body |> :zlib.gunzip() |> Jason.decode!()
+
+        data = get_in(body, ["messages", Access.at(0), "data"])
+        data = data |> Base.decode64!() |> Jason.decode!()
+        assert Map.has_key?(data, "record")
+        assert Map.has_key?(data, "metadata")
+
+        Req.Test.json(conn, %{})
+      end)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_event(consumer, message)
+      assert_receive {:ack, ^ref, [_successful], []}, 1_000
+    end
+
+    test "batched messages are processed together", %{consumer: consumer} do
+      group_id = UUID.uuid4()
+      message1 = ConsumersFactory.consumer_message(group_id: group_id)
+      message2 = ConsumersFactory.consumer_message(group_id: group_id)
+
+      # Mock PubSub publish and verify batch
+      Req.Test.expect(PubSub, fn conn ->
+        assert conn.method == "POST"
+        assert conn.host == "pubsub.googleapis.com"
+
+        {:ok, body, _} = Plug.Conn.read_body(conn)
+        body = body |> :zlib.gunzip() |> Jason.decode!()
+        assert length(body["messages"]) == 2
+
+        Req.Test.json(conn, %{})
+      end)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_batch(consumer, [message1, message2])
+      assert_receive {:ack, ^ref, [_message1, _message2], []}, 1_000
+    end
+
+    @tag capture_log: true
+    test "failed PubSub publish results in failed events", %{consumer: consumer} do
+      # Mock failed PubSub publish
+      Req.Test.expect(PubSub, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => "Failed to publish to PubSub"})
+      end)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_event(consumer)
+      assert_receive {:ack, ^ref, [], [_failed]}, 2_000
+    end
+
+    test "PubSub routing can assign topic", %{consumer: consumer} do
+      router =
+        FunctionsFactory.insert_routing_function!(
+          account_id: consumer.account_id,
+          function_attrs: [
+            sink_type: :gcp_pubsub,
+            body: """
+            %{topic_id: "my_topic"}
+            """
+          ]
+        )
+
+      MiniElixir.create(router.id, router.function.code)
+
+      {:ok, consumer} = Consumers.update_sink_consumer(consumer, %{routing_id: router.id, routing_mode: "dynamic"})
+
+      message = ConsumersFactory.consumer_message(message_kind: consumer.message_kind)
+
+      # Mock PubSub publish and verify topic
+      Req.Test.expect(PubSub, fn conn ->
+        assert conn.method == "POST"
+        assert conn.host == "pubsub.googleapis.com"
+        assert String.contains?(conn.request_path, "/my_topic:publish")
+
+        Req.Test.json(conn, %{})
+      end)
+
+      start_pipeline!(consumer)
+
+      ref = send_test_event(consumer, message)
+      assert_receive {:ack, ^ref, [_successful], []}, 1_000
+    end
+  end
+
+  defp start_pipeline!(consumer, opts \\ []) do
+    {dummy_producer, _opts} = Keyword.pop(opts, :dummy_producer, true)
+
+    opts = [
+      consumer_id: consumer.id,
+      test_pid: self()
+    ]
+
+    opts =
+      if dummy_producer do
+        Keyword.put(opts, :producer, Broadway.DummyProducer)
+      else
+        opts
+      end
+
+    start_supervised!({SinkPipeline, opts})
+  end
+
+  defp send_test_event(consumer, message \\ nil) do
+    message = message || ConsumersFactory.consumer_message()
+
+    Broadway.test_message(broadway(consumer), message)
+  end
+
+  defp send_test_batch(consumer, messages) do
+    Broadway.test_batch(broadway(consumer), messages)
+  end
+
+  defp broadway(consumer) do
+    SinkPipeline.via_tuple(consumer.id)
+  end
+end

--- a/test/sequin/gcp_pubsub_test.exs
+++ b/test/sequin/gcp_pubsub_test.exs
@@ -99,13 +99,8 @@ defmodule Sequin.Sinks.Gcp.PubSubTest do
         {:ok, body, _} = Plug.Conn.read_body(conn)
         body = body |> :zlib.gunzip() |> Jason.decode!()
 
-        decoded_data =
-          body
-          |> get_in(["messages", Access.at(0), "data"])
-          |> Base.decode64!()
-          |> Jason.decode!()
-
-        assert decoded_data == %{"key" => "value"}
+        data = get_in(body, ["messages", Access.at(0), "data"])
+        assert data == %{"key" => "value"}
         assert get_in(body, ["messages", Access.at(0), "attributes"]) == %{"type" => "test"}
 
         Req.Test.json(conn, %{})


### PR DESCRIPTION
Unfortunately the Broadway batcher will [include the current message in the batch when the batcher responds with `:emit`](https://github.com/dashbitco/broadway/blob/136bea6786ae1526721a98a93ca9d752543c3a7d/lib/broadway/topology/batcher_stage.ex#L159). This makes it hard to enforce a hard byte size ceiling.

I use the `incoming_bytes` as a buffer as a partial workaround -- but this is not perfect.

Considering a PR upstream to move the `event` to `remaining` instead of `acc` -- curious yalls thoughts!