### PR TITLE
🛠️ Remove `test/support` from being compiled in :dev mode

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Sequin.MixProject do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(:dev), do: ["lib", "test/support", "bench"]
+  defp elixirc_paths(:dev), do: ["lib", "bench"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.


### PR DESCRIPTION
After the changes [we made recently on grouping the verify_on_exit calls](https://github.com/sequinstream/sequin/commit/a3dba292da7ce10cc72296fbe7120a219d798d1f
) we started getting a warning in dev mode:


```
│                                                                                                                                                                                                                              │
│       warning: Hammox.verify_on_exit!/0 is undefined (module Hammox is not available or is yet to be defined). Make sure the module name is correct and has been specified in full (or that an alias has been defined)       │
│       │                                                                                                                                                                                                                      │
│    51 │     Hammox.verify_on_exit!()                                                                                                                                                                                         │
│       │            ~                                                                                                                                                                                                         │
│       │                                                                                                                                                                                                                      │
│       └─ test/support/case.ex:51:12: Sequin.Case.verify_stubs/1                                                                                                                                                              │
│
```

So this PR proposes to remove `test/support` from being included in the compilation process of `:dev` mode.