### PR TITLE
Fix aws-ecs secret generation docs & Add terraform variable validations

### DIFF
--- a/deploy/aws-ecs/README.md
+++ b/deploy/aws-ecs/README.md
@@ -4,12 +4,16 @@ These templates assume you need to create a VPC, ECS cluster, and security group
 
 ### Secrets
 
-`secret_key_base` should be a random string of at least 32 characters.
+`secret_key_base` should be a random string of **exactly** 64 characters.
 
 `vault_key` should be a random base64 encoded string of **exactly** 32 characters.
 
 You can generate these secrets with `openssl` like so:
 
 ```bash
+# Generate SECRET_KEY_BASE
+openssl rand -base64 64
+
+# Generate VAULT_KEY
 openssl rand -base64 32
 ```

--- a/deploy/aws-ecs/variables.tf
+++ b/deploy/aws-ecs/variables.tf
@@ -35,12 +35,22 @@ variable "secret_key_base" {
   description = "The secret key base for Sequin (will be stored in SSM Parameter Store)"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(var.secret_key_base) == 64
+    error_message = "secret_key_base must be exactly 64 characters long."
+  }
 }
 
 variable "vault_key" {
   description = "The vault key for Sequin (will be stored in SSM Parameter Store)"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(var.vault_key) == 32
+    error_message = "vault_key must be exactly 32 characters long."
+  }
 }
 
 data "aws_availability_zones" "available" {}


### PR DESCRIPTION
This PullRequests changes the aws-ecs readme to correctly reflect the needed key length according to the Sequin [Documentation](https://sequinstream.com/docs/reference/configuration#secret-generation).

Additionally validations are added to the Terraform variables for `secret_key_base` and `vault_key`