### PR TITLE
🌒 Prioritize CDC messages over backfill messages when possible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
   },
   "prettier.requireConfig": true,
   "prettier.configPath": "assets/.prettierrc",
-  "svelte.enable-ts-plugin": true
+  "svelte.enable-ts-plugin": true,
+  "[elixir]": {
+    "editor.defaultFormatter": "elixir-lsp.elixir-ls"
+  }
 }


### PR DESCRIPTION
## Overview
This PR implements delivery prioritization of CDC messages over backfill messages in some scenarios.

The purpose of this prioritization is to ensure low latency CDC delivery during backfills.

## Issue

Without this PR, CDC messages may be delayed by backfills. Consider a sink with a steady state of ~10 msgs/sec from Postgres changes. These are delivered downstream to the sink destination with low latency during this steady state.

Now, a user initiates a backfill. The backfill process may inject ~50k messages at a time into the delivery queue. Any CDC messages that occur after these backfill pages are enqueued after the backfill messages. This can cause the end to end latency of CDC message delivery to spike.

## Implementation

This PR implements a simple version of prioritization. We still must ensure that messages are delivered in strict order within groups. So this PR will prioritize CDC messages so long as there are **zero group conflicts**. As soon as a single group conflict is detected, we switch to strictly ordered mode.

To implement a more nuanced version of prioritization, we have to:
1) Iterate through CDC messages, accumulating which groups have a conflict and emitting only messages without conflicts
1) Iterate through the backfill messages
1) Re-iterate through CDC messages, producing those messages that were initially blocked