### PR TITLE
🌒 Compare backfill cursor tuple to cdc cursor tuple

### DIFF
--- a/lib/sequin/multiset.ex
+++ b/lib/sequin/multiset.ex
@@ -88,6 +88,14 @@ defmodule Sequin.Multiset do
     |> List.flatten()
   end
 
+  @spec values(t(), key()) :: [value()]
+  def values(multiset, key) do
+    case Map.get(multiset, key) do
+      nil -> []
+      set -> MapSet.to_list(set)
+    end
+  end
+
   @doc """
   Checks if a key exists in the multiset.
 


### PR DESCRIPTION
This allows us to proceed in cdc priortize mode in more cases