### PR TITLE
Docs Update - Remove `clustering` reference

### DIFF
--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -238,9 +238,6 @@ Requirements for multi-node deployment:
   - The same Postgres database
   - The same Redis instance
   - Identical configuration
-- Nodes must be able to communicate directly with each other
-- Network latency between nodes should be minimal
-- Configuration enviroment variables must be properly set
 
 Sequin uses Redis for distributed locking and leader election.
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -240,7 +240,7 @@ Requirements for multi-node deployment:
   - Identical configuration
 - Nodes must be able to communicate directly with each other
 - Network latency between nodes should be minimal
-- Environment variables for [Clustering configuration](#clustering-configuration) must be properly set
+- Configuration enviroment variables must be properly set
 
 Sequin uses Redis for distributed locking and leader election.
 


### PR DESCRIPTION
While looking into HA/Production config for Sequin - I noticed this issue - https://github.com/sequinstream/sequin/issues/1899

Based on the reply to the issue, clustering isn't currently supported by Sequin

Further scrolling of docs show a reference to a missing heading for `Clustering configuration` on the `configuration` page is still present - I'm not entirely certain if this bullet point should reference specific config on this page - perhaps the postgres and/or redis vars? or alternatively - this line _could_ be seen as redundant - but I refer to maintainers! 

Thanks team! 
