### PR TITLE
Add fallback condition on login screen to handle self signup disabled when self hosted

### DIFF
--- a/lib/sequin_web/live/user_login_live.ex
+++ b/lib/sequin_web/live/user_login_live.ex
@@ -116,6 +116,7 @@ defmodule SequinWeb.UserLoginLive do
                 Sign up
               </.button>
             </p>
+          <% true -> %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
A `CondClauseError` is raised when account self-signup is disabled and running in self hosted mode, as no condition is true.

This adds a fallback that does nothing to handle this case.