### PR TITLE
docs: typesense

### DIFF
--- a/docs/quickstart/typesense.mdx
+++ b/docs/quickstart/typesense.mdx
@@ -37,7 +37,7 @@ By the end, you'll have hands-on experience setting up Postgres change data capt
         -p 8108:8108 \
         -v ./typesense-data:/data \
         --restart on-failure \
-        typesense/typesense:28.0 \
+        typesense/typesense:29.0 \
         --data-dir /data \
         --api-key=my-api-key \
         --enable-cors


### PR DESCRIPTION
## Changes Summary

I was just getting started with Sequin and TypeSense, so I was following this guide: https://sequinstream.com/docs/quickstart/typesense and noticed a couple improvements that could be made:
- Typesense could be bumped to `(0).29.0` (there's even `typesense/typesense:30.0.rca32`, which I used and it worked for the `products` example, but I assume docs want to point to non-RC version),
- For me `http://host.docker.internal:8108` wasn't working, but I had success with specifying Typesense container name directly (added it as alternative Host in the docs),
- The default transform function doesn't work and results in an Error:

```elixir
def transform(action, record, changes, metadata) do
  Map.take(record, ["id", "name", "price"])
end
```

> Error: [sink_pipeline]: Document's id field should be a string.

After updating it to:

```elixir
def transform(action, record, changes, metadata) do
  record
  |> Map.take(["id", "name", "price"])
  |> Map.update("id", nil, fn id ->
    cond do
      is_binary(id) -> id
      is_integer(id) -> Integer.to_string(id)
      true -> to_string(id)
    end
  end)
end
```

it worked as expected. Mind you that I'm no Elixir guy, so the above was generated with GPT using the prompt that was in the settings.

There's one more thing that I didn't edit: in "Step 6. Configure Typesense" it mentions Collection. Seems this field was moved to "Routing". While it's quite intuitive after a minute, it would be good to note this change in the future.