### PR TITLE
Upgrade EBS volume type from gp2 to gp3 in EC2 launch templates

### DIFF
--- a/deployment/terraform-ecs-ec2-sqs/infra/ec2.tf
+++ b/deployment/terraform-ecs-ec2-sqs/infra/ec2.tf
@@ -60,9 +60,8 @@ resource "aws_launch_template" "sequin-main" {
     ebs {
       delete_on_termination = "true"
       encrypted             = "false"
-      iops                  = "0"
       volume_size           = "100"
-      volume_type           = "gp2"
+      volume_type           = "gp3"
     }
   }
 

--- a/deployment/terraform-ecs-ec2/infra/ec2.tf
+++ b/deployment/terraform-ecs-ec2/infra/ec2.tf
@@ -60,9 +60,8 @@ resource "aws_launch_template" "sequin-main" {
     ebs {
       delete_on_termination = "true"
       encrypted             = "false"
-      iops                  = "0"
       volume_size           = "100"
-      volume_type           = "gp2"
+      volume_type           = "gp3"
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the default EBS volume type from `gp2` to `gp3` in the EC2 launch templates for both `terraform-ecs-ec2` and `terraform-ecs-ec2-sqs` deployment setups.

### Why is this change necessary?
As discussed with Carter on the Sequin Community Slack, upgrading to `gp3` provides immediate benefits for anyone self-hosting Sequin on AWS:
1. **Cost Reduction:** `gp3` volumes are up to 20% cheaper per GB compared to `gp2`.
2. **Performance:** `gp3` provides a baseline of 3,000 IOPS and 125 MB/s throughput regardless of volume size, eliminating the burst-credit limitations inherent to `gp2`.

Additionally, I removed the `iops = "0"` parameter, as `gp3` volumes require either a minimum of `3000` IOPS or the parameter can be omitted entirely (AWS defaults it to `3000` for `gp3`). Setting `iops = 0` with `gp3` will cause a Terraform validation error.

*(Note: The diff shows `iops = "0"` being removed, which is the correct approach when migrating to `gp3` without explicitly defining custom IOPS).*

### How was this identified?
This opportunity was identified while running a static infrastructure analysis on the `deployment/` directory using **InfraScan** (an open-source FinOps/SecOps tool by SolDevelo). 

You can view the full report that highlighted this here:
[View InfraScan Report for Sequin](https://infrascan.soldevelo.com/?scan_id=6a0d9360-1594-4e29-8392-17ec89a9de5a)

### Testing
- Validated Terraform syntax.
- Confirmed AWS provider documentation supports implicit IOPS for `gp3`.