### PR TITLE
Feat: Enable automatic AWS credential discovery via provider chain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing to Sequin! This document provides gu
 - GitHub CLI (`gh`)
 - Node.js (for frontend assets)
 - Go (only necessary for CLI development)
+- [CMake](https://cmake.org/download/)
 
 ### Getting started
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -63,13 +63,21 @@ end
 # Configure SQS integration for HTTP Push sinks
 sqs_config =
   if System.get_env("HTTP_PUSH_VIA_SQS_QUEUE_URL") do
-    %{
+    base_config = %{
       main_queue_url: System.fetch_env!("HTTP_PUSH_VIA_SQS_QUEUE_URL"),
       dlq_url: System.fetch_env!("HTTP_PUSH_VIA_SQS_DLQ_URL"),
-      region: System.fetch_env!("HTTP_PUSH_VIA_SQS_REGION"),
-      access_key_id: System.fetch_env!("HTTP_PUSH_VIA_SQS_ACCESS_KEY_ID"),
-      secret_access_key: System.fetch_env!("HTTP_PUSH_VIA_SQS_SECRET_ACCESS_KEY")
+      region: System.fetch_env!("HTTP_PUSH_VIA_SQS_REGION")
     }
+
+    # Support both explicit credentials and task role
+    if System.get_env("HTTP_PUSH_VIA_SQS_USE_TASK_ROLE") == "true" do
+      Map.put(base_config, :use_task_role, true)
+    else
+      Map.merge(base_config, %{
+        access_key_id: System.fetch_env!("HTTP_PUSH_VIA_SQS_ACCESS_KEY_ID"),
+        secret_access_key: System.fetch_env!("HTTP_PUSH_VIA_SQS_SECRET_ACCESS_KEY")
+      })
+    end
   end
 
 # Enable via_sqs_for_new_sinks? flag for HttpPushSink

--- a/lib/sequin/consumers/kinesis_sink.ex
+++ b/lib/sequin/consumers/kinesis_sink.ex
@@ -134,5 +134,4 @@ defmodule Sequin.Consumers.KinesisSink do
         {:error, reason}
     end
   end
-
 end

--- a/lib/sequin/consumers/kinesis_sink.ex
+++ b/lib/sequin/consumers/kinesis_sink.ex
@@ -29,7 +29,6 @@ defmodule Sequin.Consumers.KinesisSink do
     |> validate_credentials()
     |> validate_stream_arn()
     |> validate_routing()
-    |> validate_cloud_mode_restrictions()
   end
 
   defp validate_credentials(changeset) do
@@ -136,18 +135,4 @@ defmodule Sequin.Consumers.KinesisSink do
     end
   end
 
-  defp validate_cloud_mode_restrictions(changeset) do
-    self_hosted? = Sequin.Config.self_hosted?()
-    use_task_role? = get_field(changeset, :use_task_role)
-
-    if not self_hosted? and use_task_role? do
-      add_error(
-        changeset,
-        :use_task_role,
-        "Task role credentials are not supported in Sequin Cloud. Please use explicit credentials instead."
-      )
-    else
-      changeset
-    end
-  end
 end

--- a/lib/sequin/consumers/sns_sink.ex
+++ b/lib/sequin/consumers/sns_sink.ex
@@ -42,7 +42,6 @@ defmodule Sequin.Consumers.SnsSink do
     |> validate_routing()
     |> put_is_fifo()
     |> validate_emulator_base_url()
-    |> validate_cloud_mode_restrictions()
   end
 
   defp validate_credentials(changeset) do
@@ -171,18 +170,4 @@ defmodule Sequin.Consumers.SnsSink do
     ~r/^arn:aws:sns:(?<region>[a-z0-9-]+):(?<account_id>\d{12}):(?<topic_name>[a-zA-Z0-9_.-]+)$/
   end
 
-  defp validate_cloud_mode_restrictions(changeset) do
-    self_hosted? = Sequin.Config.self_hosted?()
-    use_task_role? = get_field(changeset, :use_task_role)
-
-    if not self_hosted? and use_task_role? do
-      add_error(
-        changeset,
-        :use_task_role,
-        "Task role credentials are not supported in Sequin Cloud. Please use explicit credentials instead."
-      )
-    else
-      changeset
-    end
-  end
 end

--- a/lib/sequin/consumers/sns_sink.ex
+++ b/lib/sequin/consumers/sns_sink.ex
@@ -169,5 +169,4 @@ defmodule Sequin.Consumers.SnsSink do
   def sns_arn_regex do
     ~r/^arn:aws:sns:(?<region>[a-z0-9-]+):(?<account_id>\d{12}):(?<topic_name>[a-zA-Z0-9_.-]+)$/
   end
-
 end

--- a/lib/sequin/consumers/sqs_sink.ex
+++ b/lib/sequin/consumers/sqs_sink.ex
@@ -43,7 +43,6 @@ defmodule Sequin.Consumers.SqsSink do
     |> put_is_fifo()
     |> validate_emulator_base_url()
     |> validate_routing()
-    |> validate_cloud_mode_restrictions()
   end
 
   defp validate_credentials(changeset) do
@@ -171,18 +170,4 @@ defmodule Sequin.Consumers.SqsSink do
     ~r/^https?:\/\/sqs\.(?<region>[a-z0-9-]+)\.([a-zA-Z0-9.-]+)(?::\d+)?\/\d{12}\/[a-zA-Z0-9_-]+(?:\.fifo)?$/
   end
 
-  defp validate_cloud_mode_restrictions(changeset) do
-    self_hosted? = Sequin.Config.self_hosted?()
-    use_task_role? = get_field(changeset, :use_task_role)
-
-    if not self_hosted? and use_task_role? do
-      add_error(
-        changeset,
-        :use_task_role,
-        "Task role credentials are not supported in Sequin Cloud. Please use explicit credentials instead."
-      )
-    else
-      changeset
-    end
-  end
 end

--- a/lib/sequin/consumers/sqs_sink.ex
+++ b/lib/sequin/consumers/sqs_sink.ex
@@ -169,5 +169,4 @@ defmodule Sequin.Consumers.SqsSink do
   def sqs_url_regex do
     ~r/^https?:\/\/sqs\.(?<region>[a-z0-9-]+)\.([a-zA-Z0-9.-]+)(?::\d+)?\/\d{12}\/[a-zA-Z0-9_-]+(?:\.fifo)?$/
   end
-
 end

--- a/lib/sequin/runtime/http_push_sqs_pipeline.ex
+++ b/lib/sequin/runtime/http_push_sqs_pipeline.ex
@@ -137,12 +137,7 @@ defmodule Sequin.Runtime.HttpPushSqsPipeline do
           producer_mod,
           queue_url: queue_url,
           config:
-            [
-              access_key_id: access_key_id,
-              secret_access_key: secret_access_key,
-              region: region
-            ]
-            |> maybe_put_token(token),
+            maybe_put_token([access_key_id: access_key_id, secret_access_key: secret_access_key, region: region], token),
           attribute_names: [:sent_timestamp, :approximate_receive_count, :approximate_first_receive_timestamp],
           receive_interval: 1_000,
           max_number_of_messages: 10,

--- a/lib/sequin/sinks/kafka/aws_msk_iam/auth.ex
+++ b/lib/sequin/sinks/kafka/aws_msk_iam/auth.ex
@@ -12,14 +12,7 @@ defmodule Sequin.Sinks.Kafka.AwsMskIam.Auth do
   @handshake_version 1
 
   # Handle task role credentials
-  def auth(
-        host,
-        sock,
-        mod,
-        client_id,
-        timeout,
-        {:AWS_MSK_IAM = mechanism, :task_role, aws_region} = _sasl_opts
-      ) do
+  def auth(host, sock, mod, client_id, timeout, {:AWS_MSK_IAM = mechanism, :task_role, aws_region} = _sasl_opts) do
     case :aws_credentials.get_credentials() do
       :undefined ->
         {:error,

--- a/mix.exs
+++ b/mix.exs
@@ -23,8 +23,7 @@ defmodule Sequin.MixProject do
   def application do
     [
       mod: {Sequin.Application, []},
-      extra_applications: [:logger, :runtime_tools] ++ extra_applications(Mix.env()),
-      included_applications: [:aws_credentials]
+      extra_applications: [:logger, :runtime_tools] ++ extra_applications(Mix.env())
     ]
   end
 
@@ -70,7 +69,7 @@ defmodule Sequin.MixProject do
 
       # AWS and Cloud Services
       {:aws, "~> 1.0"},
-      {:aws_credentials, "~> 1.0.0", runtime: false},
+      {:aws_credentials, "~> 1.0.0"},
       {:aws_rds_castore, "~> 1.2.0"},
       {:aws_signature, "~> 0.3.2"},
 

--- a/test/sequin/consumers/sns_sink_test.exs
+++ b/test/sequin/consumers/sns_sink_test.exs
@@ -87,7 +87,6 @@ defmodule Sequin.Consumers.SnsSinkTest do
     end
   end
 
-
   describe "aws_client/1" do
     test "creates client with explicit credentials when use_task_role is false" do
       sink = %SnsSink{

--- a/test/sequin/consumers/sns_sink_test.exs
+++ b/test/sequin/consumers/sns_sink_test.exs
@@ -87,56 +87,6 @@ defmodule Sequin.Consumers.SnsSinkTest do
     end
   end
 
-  describe "changeset/2 cloud mode restrictions" do
-    @tag self_hosted: false
-    test "validates that use_task_role is false when not self_hosted" do
-      params = %{
-        topic_arn: "arn:aws:sns:us-east-1:123456789012:test-topic",
-        region: "us-east-1",
-        use_task_role: true,
-        routing_mode: :static
-      }
-
-      changeset = SnsSink.changeset(%SnsSink{}, params)
-
-      refute changeset.valid?
-
-      assert changeset.errors[:use_task_role] ==
-               {"Task role credentials are not supported in Sequin Cloud. Please use explicit credentials instead.", []}
-    end
-
-    @tag self_hosted: true
-    test "allows use_task_role when self_hosted" do
-      params = %{
-        topic_arn: "arn:aws:sns:us-east-1:123456789012:test-topic",
-        region: "us-east-1",
-        use_task_role: true,
-        routing_mode: :static
-      }
-
-      changeset = SnsSink.changeset(%SnsSink{}, params)
-
-      assert changeset.valid?
-      refute changeset.errors[:use_task_role]
-    end
-
-    @tag self_hosted: false
-    test "allows use_task_role=false in cloud mode" do
-      params = %{
-        topic_arn: "arn:aws:sns:us-east-1:123456789012:test-topic",
-        region: "us-east-1",
-        use_task_role: false,
-        access_key_id: "test_key",
-        secret_access_key: "test_secret",
-        routing_mode: :static
-      }
-
-      changeset = SnsSink.changeset(%SnsSink{}, params)
-
-      assert changeset.valid?
-      refute changeset.errors[:use_task_role]
-    end
-  end
 
   describe "aws_client/1" do
     test "creates client with explicit credentials when use_task_role is false" do

--- a/test/sequin/kinesis_sink_test.exs
+++ b/test/sequin/kinesis_sink_test.exs
@@ -124,7 +124,6 @@ defmodule Sequin.Consumers.KinesisSinkTest do
     end
   end
 
-
   describe "region_from_arn/1" do
     test "extracts region from valid ARN" do
       arn = "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"

--- a/test/sequin/kinesis_sink_test.exs
+++ b/test/sequin/kinesis_sink_test.exs
@@ -124,56 +124,6 @@ defmodule Sequin.Consumers.KinesisSinkTest do
     end
   end
 
-  describe "changeset/2 cloud mode restrictions" do
-    @tag self_hosted: false
-    test "validates that use_task_role is false when not self_hosted" do
-      params = %{
-        stream_arn: "arn:aws:kinesis:us-east-1:123456789012:stream/test-stream",
-        region: "us-east-1",
-        use_task_role: true,
-        routing_mode: :static
-      }
-
-      changeset = KinesisSink.changeset(%KinesisSink{}, params)
-
-      refute changeset.valid?
-
-      assert changeset.errors[:use_task_role] ==
-               {"Task role credentials are not supported in Sequin Cloud. Please use explicit credentials instead.", []}
-    end
-
-    @tag self_hosted: true
-    test "allows use_task_role when self_hosted" do
-      params = %{
-        stream_arn: "arn:aws:kinesis:us-east-1:123456789012:stream/test-stream",
-        region: "us-east-1",
-        use_task_role: true,
-        routing_mode: :static
-      }
-
-      changeset = KinesisSink.changeset(%KinesisSink{}, params)
-
-      assert changeset.valid?
-      refute changeset.errors[:use_task_role]
-    end
-
-    @tag self_hosted: false
-    test "allows use_task_role=false in cloud mode" do
-      params = %{
-        stream_arn: "arn:aws:kinesis:us-east-1:123456789012:stream/test-stream",
-        region: "us-east-1",
-        use_task_role: false,
-        access_key_id: "test_key",
-        secret_access_key: "test_secret",
-        routing_mode: :static
-      }
-
-      changeset = KinesisSink.changeset(%KinesisSink{}, params)
-
-      assert changeset.valid?
-      refute changeset.errors[:use_task_role]
-    end
-  end
 
   describe "region_from_arn/1" do
     test "extracts region from valid ARN" do

--- a/test/sequin/sqs_sink_test.exs
+++ b/test/sequin/sqs_sink_test.exs
@@ -70,7 +70,6 @@ defmodule Sequin.Consumers.SqsSinkTest do
     end
   end
 
-
   describe "aws_client/1" do
     test "creates client with explicit credentials when use_task_role is false" do
       sink = %SqsSink{

--- a/test/sequin/sqs_sink_test.exs
+++ b/test/sequin/sqs_sink_test.exs
@@ -70,56 +70,6 @@ defmodule Sequin.Consumers.SqsSinkTest do
     end
   end
 
-  describe "changeset/2 cloud mode restrictions" do
-    @tag self_hosted: false
-    test "validates that use_task_role is false when not self_hosted" do
-      params = %{
-        queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/test",
-        region: "us-east-1",
-        use_task_role: true,
-        routing_mode: :static
-      }
-
-      changeset = SqsSink.changeset(%SqsSink{}, params)
-
-      refute changeset.valid?
-
-      assert changeset.errors[:use_task_role] ==
-               {"Task role credentials are not supported in Sequin Cloud. Please use explicit credentials instead.", []}
-    end
-
-    @tag self_hosted: true
-    test "allows use_task_role when self_hosted" do
-      params = %{
-        queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/test",
-        region: "us-east-1",
-        use_task_role: true,
-        routing_mode: :static
-      }
-
-      changeset = SqsSink.changeset(%SqsSink{}, params)
-
-      assert changeset.valid?
-      refute changeset.errors[:use_task_role]
-    end
-
-    @tag self_hosted: false
-    test "allows use_task_role=false in cloud mode" do
-      params = %{
-        queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/test",
-        region: "us-east-1",
-        use_task_role: false,
-        access_key_id: "test_key",
-        secret_access_key: "test_secret",
-        routing_mode: :static
-      }
-
-      changeset = SqsSink.changeset(%SqsSink{}, params)
-
-      assert changeset.valid?
-      refute changeset.errors[:use_task_role]
-    end
-  end
 
   describe "aws_client/1" do
     test "creates client with explicit credentials when use_task_role is false" do


### PR DESCRIPTION
  Add support for AWS credential provider chain across all AWS integrations,
  eliminating the need for long-lived IAM access keys in production environments.

  Changes:
  - Enable aws_credentials library at runtime (remove runtime: false)
  - Remove self-hosted mode restriction for task role credentials
  - Add task role support to Kafka sinks with AWS MSK IAM authentication
  - Add task role support to HttpPushSqsPipeline (BroadwaySQS)
  - Update all AWS sink validations to support use_task_role flag

  This enables automatic credential discovery from:
  - Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
  - AWS credentials file (~/.aws/credentials)
  - IRSA/EKS Pod Identity (web identity tokens)
  - ECS task credentials
  - EC2 instance metadata

  Benefits:
  - Eliminates security risk of long-lived IAM keys
  - Supports modern Kubernetes auth patterns (IRSA, Pod Identity)
  - Automatic credential rotation for temporary credentials
  - Follows AWS security best practices
  - Fully backward compatible (use_task_role defaults to false)

  Affected services: SQS, SNS, Kinesis, Kafka (MSK IAM), HttpPushSQS