### PR TITLE
Increase Meilisearch's validation max_retries to 10

### DIFF
--- a/lib/sequin/sinks/meilisearch/client.ex
+++ b/lib/sequin/sinks/meilisearch/client.ex
@@ -27,7 +27,7 @@ defmodule Sequin.Sinks.Meilisearch.Client do
         url: "/tasks/#{task_id}",
         # We need to disable this if we use a custom retry that emits delays
         retry_delay: nil,
-        max_retries: 5,
+        max_retries: 10,
         retry: fn request, response_or_exception ->
           should_retry =
             case response_or_exception do

--- a/test/sequin/meilisearch_client_test.exs
+++ b/test/sequin/meilisearch_client_test.exs
@@ -339,12 +339,12 @@ defmodule Sequin.Sinks.Meilisearch.ClientTest do
       assert error.details.task_id == 456
       assert error.details.last_status == "processing"
 
-      # Verify we made all 6 attempts (1 initial + 5 retries)
-      for i <- 0..5 do
+      # Verify we made all 11 attempts (1 initial + 10 retries)
+      for i <- 0..10 do
         assert_receive {:task_check, ^i}, 3_000
       end
 
-      refute_receive {:task_check, 6}, 100
+      refute_receive {:task_check, 11}, 100
     end
 
     test "wait_for_task handles task failure" do


### PR DESCRIPTION
This is small PR to quickly fix an issue with Meilisearch's sink. It increases the validation timeout from around 3,2 to 52,6 seconds. 

See Issue #2138 for more details.