### PR TITLE
fix(yaml_loader): refresh stale table cache on miss during config apply

### DIFF
--- a/lib/sequin/yaml_loader.ex
+++ b/lib/sequin/yaml_loader.ex
@@ -727,6 +727,8 @@ defmodule Sequin.YamlLoader do
        ) do
     with {:ok, source_database} <- fetch_database(databases, source_db_name, :source_database),
          {:ok, destination_database} <- fetch_database(databases, dest_db_name, :destination_database),
+         {:ok, destination_database} <- ensure_table_cached(destination_database, dest_schema, dest_table),
+         {:ok, source_database} <- ensure_table_cached(source_database, source_schema, source_table),
          {:ok, destination_table} <-
            fetch_table(destination_database.tables, dest_schema, dest_table, :destination_table),
          {:ok, source_table_struct} <-
@@ -791,6 +793,22 @@ defmodule Sequin.YamlLoader do
     case Enum.find(tables, &(&1.schema == schema && &1.name == table_name)) do
       nil -> {:error, Error.not_found(entity: :table, params: %{schema: schema, name: table_name})}
       table -> {:ok, table}
+    end
+  end
+
+  # The cached `tables` can be stale during config apply (only refreshed on create
+  # and by a 6-hourly cron), so on a miss refresh once from the live database.
+  defp ensure_table_cached(%PostgresDatabase{} = database, schema, table_name) do
+    if Enum.any?(database.tables, &(&1.schema == schema && &1.name == table_name)) do
+      {:ok, database}
+    else
+      case Databases.update_tables(database) do
+        {:ok, refreshed} ->
+          {:ok, %{database | tables: refreshed.tables, tables_refreshed_at: refreshed.tables_refreshed_at}}
+
+        {:error, error} ->
+          {:error, error}
+      end
     end
   end
 

--- a/test/sequin/yaml_loader_test.exs
+++ b/test/sequin/yaml_loader_test.exs
@@ -188,6 +188,53 @@ defmodule Sequin.YamlLoaderTest do
     end
   end
 
+  describe "change_retentions" do
+    test "refreshes a stale table cache on miss during config apply" do
+      # First apply creates the database; create_db refreshes its table cache.
+      assert :ok = YamlLoader.apply_from_yml!(playground_yml())
+
+      [%PostgresDatabase{} = db] = Repo.all(PostgresDatabase)
+
+      # Simulate a stale cache (as if the tables were created after the last
+      # refresh): clear the cached table list on the existing database record.
+      {:ok, _} = db |> PostgresDatabase.changeset(%{tables: []}) |> Repo.update()
+
+      # Applying a change_retention whose tables are absent from the stale cache
+      # must still succeed: the loader refreshes tables from the live database on a
+      # miss instead of failing the apply.
+      assert :ok =
+               YamlLoader.apply_from_yml!("""
+               account:
+                 name: "Playground"
+
+               users:
+                 - email: "admin@sequinstream.com"
+                   password: "sequinpassword!"
+
+               databases:
+                 - name: "test-db"
+                   username: "postgres"
+                   password: "postgres"
+                   hostname: "localhost"
+                   database: "sequin_test"
+                   slot_name: "#{replication_slot()}"
+                   publication_name: "#{@publication}"
+
+               change_retentions:
+                 - name: "test-pipeline"
+                   source_database: "test-db"
+                   source_table_schema: "public"
+                   source_table_name: "Characters"
+                   destination_database: "test-db"
+                   destination_table_schema: "public"
+                   destination_table_name: "sequin_events"
+               """)
+
+      assert [%WalPipeline{} = pipeline] = Repo.all(WalPipeline)
+      assert pipeline.name == "test-pipeline"
+    end
+  end
+
   describe "databases" do
     test "creates a database" do
       assert :ok =


### PR DESCRIPTION
## Problem

Fixes #2150.

When applying declarative YAML config, `change_retentions` resolve their source/destination tables against the `tables` list cached on the `postgres_databases` record. That cache is only refreshed when a database is **created** and by the 6-hourly `EnqueueDatabaseUpdateWorker` cron — the config-apply update path (`update_db/2`) never refreshes it. So if a table is created after the last refresh, `apply_config` fails with:

```
No `table` found matching params: `name=..., schema=public`
```

Because config apply runs at container start (before `start_application`), this fails the boot and crash-loops the container, which in turn prevents the 6-hourly cron from ever running — so the deployment can't self-heal. (Full analysis in #2150.)

## Fix

Refresh the referenced database's tables from the live database on a cache miss while parsing `change_retention` attrs, then retry the lookup (option 1 from the issue). A new `ensure_table_cached/3` helper:

- returns the database unchanged on a cache **hit** (existing in-memory fast path — no extra round-trip);
- on a **miss**, calls `Databases.update_tables/1` once to refresh from the live DB, preserving the `replication_slot` preload;
- still returns `not_found` if the table is genuinely absent after refreshing (no behavior change for real misses).

A round-trip is only added when a referenced table is missing from the cache, so applies that don't reference new tables are unchanged.

## Test

Adds a `change_retentions` test that creates a database, clears its cached `tables` to simulate a stale cache, then applies a config whose `change_retention` references those tables and asserts the apply succeeds and the pipeline is created.